### PR TITLE
chore: added auto-unstake

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ and the additional following property:
 ## Aquarium configuration
 # Whether the bot should attempt to stake tokens if required.
 AQUARIUM_STAKING_AUTO=false
+AQUARIUM_UNSTAKING_AUTO=false
 ```
-
 is set to true.
 
 > [!NOTE]  

--- a/src/main/java/com/fluidtokens/aquarium/offchain/config/AppConfig.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/config/AppConfig.java
@@ -2,6 +2,7 @@ package com.fluidtokens.aquarium.offchain.config;
 
 import com.bloxbean.cardano.client.common.model.Networks;
 import com.bloxbean.cardano.client.transaction.spec.TransactionInput;
+import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.cardanofoundation.conversions.CardanoConverters;
@@ -42,6 +43,9 @@ public class AppConfig {
         @Value("${aquarium.staking.auto}")
         private Boolean autoStake;
 
+        @Value("${aquarium.unstaking.auto}")
+        private Boolean autoUnstake;
+
         @Value("${aquarium.staking.token.policy}")
         private String stakingTokenPolicy;
 
@@ -53,6 +57,15 @@ public class AppConfig {
 
         @Value("${aquarium.tank.ref-input.outputIndex}")
         private Integer tankRefInputOutputIndex;
+
+        @PostConstruct
+        public void init(){
+            log.info("INIT - Starting ...");
+            if (autoStake && autoUnstake) {
+                log.error("You can't start aquarium node with both auto stake and auto unstake set to true.");
+                throw new RuntimeException("You can't start aquarium node with both auto stake and auto unstake set to true.");
+            }
+        }
 
         public TransactionInput getTankRefInput() {
             return TransactionInput.builder().transactionId(tankRefInputTxHash).index(tankRefInputOutputIndex).build();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -23,6 +23,8 @@ aquarium:
     token:
       policy: 577f0b1342f8f8f4aed3388b80a8535812950c7a892495c0ecdf0f1e
       name: 0014df10464c4454
+  unstaking:
+    auto: true
   tank:
     ref-input:
       txHash: e016e3db3db27e167906df22b8a6c7879911c089bd2d9f3ec4be061e2690173b
@@ -62,6 +64,8 @@ aquarium:
     token:
       policy: 0b77d150c275bd0a600633e4be7d09f83c4b9f00981e22ac9c9d3f62
       name: 0014df1074464c4454
+  unstaking:
+    auto: true
   tank:
     ref-input:
       txHash: fc9579059f844d8e3b5eaf6e4db665b04866af3a16e05b14ed26c55c2a41c534


### PR DESCRIPTION
Added auto unstake before decommissioning the feature (and let pioneer operators to claw back their FLDT tokens)

it will be enough to deploy latest version, and set env vars:

```
AQUARIUM_STAKING_AUTO=false
AQUARIUM_UNSTAKING_AUTO=true
```

