### PR TITLE
chore: always pull latest image

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -27,6 +27,7 @@ services:
   aquarium-node:
     container_name: aquarium
     image: "${AQUARIUM_DOCKER_IMAGE_NAME}:${AQUARIUM_DOCKER_IMAGE_VERSION}"
+    pull_policy: always
     restart: on-failure
     environment:
       - SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}


### PR DESCRIPTION
docker compose is setup to pull latest image, but it does not check if `latest` on docker hub has been overwritten.

two options are:
1. force docker compose to always pull latest (so that it's really always the latest)
2. set the actual version to use

This PR forces compose to always pull latest if specified