### PR TITLE
Scalus offline evaluator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 
 	implementation 'io.micrometer:micrometer-registry-prometheus:latest.release'
 
+	implementation 'org.scalus:scalus-bloxbean-cardano-client-lib_3:0.14.1'
+
 	implementation 'org.postgresql:postgresql:42.6.0'
 	testImplementation 'com.h2database:h2:2.1.214'
 

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/ScheduledTransactionService.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/ScheduledTransactionService.java
@@ -11,7 +11,7 @@ import com.bloxbean.cardano.client.quicktx.ScriptTx;
 import com.bloxbean.cardano.client.transaction.spec.TransactionInput;
 import com.bloxbean.cardano.yaci.store.utxo.storage.impl.model.AddressUtxoEntity;
 import scalus.bloxbean.ScalusTransactionEvaluator;
-import com.bloxbean.cardano.client.backend.api.DefaultUtxoSupplier;
+import scalus.bloxbean.ScriptServiceSupplier;
 import com.bloxbean.cardano.yaci.store.utxo.storage.impl.repository.UtxoRepository;
 import com.fluidtokens.aquarium.offchain.blueprint.types.datum.model.DatumTank;
 import com.fluidtokens.aquarium.offchain.blueprint.types.datum.model.converter.DatumTankConverter;
@@ -199,7 +199,8 @@ public class ScheduledTransactionService {
 
                 var protocolParams = bfBackendService.getEpochService().getProtocolParameters().getValue();
                 var utxoSupplier = new DefaultUtxoSupplier(bfBackendService.getUtxoService());
-                var evaluator = new ScalusTransactionEvaluator(protocolParams, utxoSupplier);
+                var scriptSupplier = new ScriptServiceSupplier(bfBackendService.getScriptService());
+                var evaluator = new ScalusTransactionEvaluator(protocolParams, utxoSupplier, scriptSupplier);
 
                 quickTxBuilder.compose(tx)
                         .withSigner(SignerProviders.signerFrom(account))


### PR DESCRIPTION
This PR adds and configures `ScalusTransactionEvaluator` to `ScheduledTransactionService`.

When evaluating transactions, it doesn't make a network call for script evaluation, instead using its own cek machine implementation.

I may have configured its dependencies, namely Protocol Parameters and the UTxO supplier, incorrectly, as I'm not Spring-savvy. If you know a better way and would like me to improve this patch -- please share.

The gist of it is pretty simple -- Scalus implements a bloxbean-compatible interface for tx evaluation, and this PR adds it.
Will be happy to help with improvements and further integration!