### PR TITLE
Token principals: anticipate pays in the principal asset, and the economics can price any token

### DIFF
--- a/src/main/java/com/fluidtokens/aquarium/offchain/controller/LiquidationReadinessController.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/controller/LiquidationReadinessController.java
@@ -95,7 +95,11 @@ public class LiquidationReadinessController {
                       String feeUnknownReason,
                       String route,
                       String routeDetail,
-                      BigInteger advanceLovelace) {
+                      // F5 (round 2) — RENAMED from advanceLovelace: the figure is denominated in the
+                      // LOAN'S OWN PRINCIPAL asset (principalUnit, above), never lovelace — a USDM loan
+                      // reported here in a field named "…Lovelace" was 4.63x wrong in the wrong unit,
+                      // read literally as lovelace by an operator acting on it.
+                      BigInteger advancePrincipalAmount) {
 
         /** Sorting key: lower is closer to liquidation. Unknown health sorts last, never first. */
         public double sortKey() {
@@ -285,10 +289,17 @@ public class LiquidationReadinessController {
 
     /**
      * ⛔ The PRODUCTION figure — {@code convertedLoanCollateralToPrincipalAmount}, taken from the
-     * builder, never {@code remainingDebt}. Null when the collateral has no oracle entry, because
-     * the amount genuinely cannot be known then.
+     * builder, never {@code remainingDebt}. Null when the collateral (or, for a non-ada principal,
+     * the principal) has no oracle entry, because the amount genuinely cannot be known then.
+     * <p>
+     * F5 (round 2) — routed through the REAL {@code numbers()} overload with the loan's own principal
+     * oracle, never the deprecated 4-arg one that silently priced every principal as ada. That
+     * silent substitution was a 4.63x wrong number in a field an operator acts on directly.
      */
-    private BigInteger advanceAmount(Loan loan, LenderBond bond, long now) {
+    // Package-private (not private) so LiquidationReadinessControllerTest can prove F5's fix directly
+    // — that a real principalOracle actually reaches numbers(), not just that the deprecated 4-arg
+    // overload got deleted — without standing up the full readiness()/rows() Spring plumbing.
+    BigInteger advanceAmount(Loan loan, LenderBond bond, long now) {
         FluidOracleClient client = oracleClient.getIfAvailable();
         LoansContractRegistry reg = registry.getIfAvailable();
         if (client == null || reg == null) {
@@ -298,11 +309,25 @@ public class LiquidationReadinessController {
         if (oracle.isEmpty()) {
             return null;
         }
+        AssetType principalAsset = loan.datum().principalAsset();
+        OracleEntry principalOracle = null;
+        if (!principalAsset.isAda()) {
+            // Same lookup style already used for the collateral leg above — findEntry is keyed by the
+            // PRICED asset (byToken), never the oracle NFT (that is findEntryByOracleToken's job, for
+            // building a real transaction where the exact reference-input coordinate matters). A
+            // controller-only simplification unchanged by this fix; see the class javadoc on where a
+            // re-derivation is and is not tolerated here.
+            Optional<OracleEntry> principalEntry = client.findEntry(principalAsset);
+            if (principalEntry.isEmpty()) {
+                return null;
+            }
+            principalOracle = principalEntry.get();
+        }
         try {
             return new LiquidatePayInAdvanceTransactionBuilder(reg, network.getCardanoNetwork(),
                     (com.bloxbean.cardano.client.api.UtxoSupplier) null,
                     (com.bloxbean.cardano.client.api.ProtocolParamsSupplier) null)
-                    .numbers(loan, bond, oracle.get(), now)
+                    .numbers(loan, bond, oracle.get(), principalOracle, now)
                     .convertedLoanCollateralToPrincipalAmount();
         } catch (RuntimeException e) {
             log.debug("could not compute the advance amount for {}: {}", loan.utxoRef(), e.toString());

--- a/src/main/java/com/fluidtokens/aquarium/offchain/model/loans/CompoundAssessment.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/model/loans/CompoundAssessment.java
@@ -11,9 +11,15 @@ import java.math.BigInteger;
  * @param escrow        the principal sitting in the asset manager, in the pool's principal unit
  * @param feePerMille   {@code compoudingFeePerMille} read from the live {@code PoolManagerDatum} —
  *                      <b>set by the pool owner, not by us and not by the protocol</b>
- * @param expectedFee   {@code escrow * feePerMille / 1000}, the on-chain formula, integer division
+ * @param expectedFee   {@code escrow * feePerMille / 1000}, the on-chain formula, integer division —
+ *                      in the <b>principal's own unit</b>, exactly what the pool is entitled to
+ *                      withhold on chain
+ * @param expectedFeeLovelace {@link #expectedFee} priced into lovelace via
+ *                      {@code PricingService} — the identity for an ada principal, so this equals
+ *                      {@link #expectedFee} exactly whenever the principal is ada
  * @param txFee         the measured transaction fee this compound would pay
- * @param net           {@code expectedFee - txFee}; negative means the bot pays to do the work
+ * @param net           {@code expectedFeeLovelace - txFee}; negative means the bot pays to do the
+ *                      work
  * @param floor         {@code loans.compound.profit-margin-lovelace}, the operator's stated bound
  */
 public record CompoundAssessment(boolean approved,
@@ -21,12 +27,13 @@ public record CompoundAssessment(boolean approved,
                                  BigInteger escrow,
                                  long feePerMille,
                                  BigInteger expectedFee,
+                                 BigInteger expectedFeeLovelace,
                                  BigInteger txFee,
                                  BigInteger net,
                                  BigInteger floor) {
 
     public static CompoundAssessment refused(CompoundExclusion why) {
-        return new CompoundAssessment(false, why, null, 0L, null, null, null, null);
+        return new CompoundAssessment(false, why, null, 0L, null, null, null, null, null);
     }
 
     /** True when the pool owner has set no compounding fee, so this work pays nothing. */

--- a/src/main/java/com/fluidtokens/aquarium/offchain/model/loans/CompoundExclusion.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/model/loans/CompoundExclusion.java
@@ -27,15 +27,44 @@ public enum CompoundExclusion {
     POOL_NOT_LIVE,
 
     /**
-     * ⛔ The pool's principal is not ADA.
+     * ⛔ The pool's principal is not ADA — a <b>structural, build-capability</b> refusal, distinct
+     * from {@link #PRICE_UNAVAILABLE} below.
      *
-     * <p>The compounding fee is denominated in the <b>principal asset</b>, while the transaction fee
-     * that must be cleared is in <b>lovelace</b>. For a token-principal pool those are different
-     * units and the gate's subtraction would be meaningless — it would compare a token quantity to a
-     * lovelace cost and produce a number that looks like profit. Pricing the token needs an oracle
-     * this path does not have, so the honest answer is to refuse rather than to compare.
+     * <p>{@link com.fluidtokens.aquarium.offchain.service.loans.CompoundEconomics#assess} no longer
+     * refuses on this alone: it prices the fee slice through
+     * {@link com.fluidtokens.aquarium.offchain.service.loans.PricingService} regardless of the
+     * principal's asset, and only refuses with {@link #PRICE_UNAVAILABLE} when that pricing itself
+     * fails. This exclusion is emitted upstream instead, by
+     * {@code CompoundCandidateScanner#classify}, for two reasons that both still hold today:
+     *
+     * <ol>
+     *   <li>{@code CompoundTransactionBuilder} computes the pool's output and the bot's own net
+     *   position entirely in lovelace ({@code plusLovelace}/{@code lovelaceOf} applied directly to
+     *   {@code addedLiquidity} and the compounding fee) — sound only because the one principal that
+     *   has ever reached it is ada, where "the principal's own unit" and "lovelace" are the same
+     *   thing. It is not yet generalised to pay a token amount instead of a lovelace one, and until
+     *   it is, letting a non-ada candidate reach it would build an incorrect transaction.</li>
+     *   <li>Held on a product ruling from Giovanni (FAB-77, 2026-09-09): a token-principal compound
+     *   pays its fee in ADA and is rewarded in the principal token — i.e. the bot acquires a token —
+     *   the same class of decision as convert's "the bot buys collateral". Lifting this exclusion is
+     *   not only a build question.</li>
+     * </ol>
+     *
+     * <p>So a token-principal escrow is refused here structurally, <b>regardless of whether its
+     * price would in fact be available</b> — that is the "case that is still refused" the
+     * oracle-pricing slice's contract names.
      */
     PRINCIPAL_NOT_ADA,
+
+    /**
+     * ⛔ {@code PricingService} could not price the fee slice into lovelace: no oracle feed for the
+     * principal asset at all, a feed present but not usable at the instant asked (expired, or not
+     * yet valid), or a feed present and covering the instant but a {@code POOLED} variant —
+     * {@code get_token_amount_in_lovelace} is an outright {@code fail} on that variant on chain, so
+     * it cannot be priced off chain either (hazard: {@code OraclePriceFeed.price()} throws for it).
+     * Fail-closed: never a 1:1 fallback, never a last-known price.
+     */
+    PRICE_UNAVAILABLE,
 
     /**
      * ⛔ The escrow UTxO carries assets the validator will not accept.

--- a/src/main/java/com/fluidtokens/aquarium/offchain/model/loans/LiquidationDecision.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/model/loans/LiquidationDecision.java
@@ -172,6 +172,16 @@ public record LiquidationDecision(long decidedAt,
          * record is not a record of absence.</b> Confirmed 2026-08-25 by waiting out a real 30-minute
          * quarantine and observing the first decision land at the first cycle past expiry.
          */
-        QUARANTINED
+        QUARANTINED,
+        /**
+         * The economics gate could not price a leg of the candidate into lovelace — {@code
+         * PricingService.toLovelace} refused (no feed, a feed not usable at the instant asked, or a
+         * {@code POOLED} variant). Landed live for the pay-in-advance path's token outlay
+         * (token-principals slice, 2026-09-10): before this it was RESERVED here — see
+         * {@code CompoundExclusion.PRICE_UNAVAILABLE} for the sibling that has carried the compound
+         * path's equivalent refusal since the oracle-pricing slice. Not quarantined: a feed coming
+         * back into its validity window cures it without the bot's own state changing.
+         */
+        PRICE_UNAVAILABLE
     }
 }

--- a/src/main/java/com/fluidtokens/aquarium/offchain/model/loans/LiquidationDecision.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/model/loans/LiquidationDecision.java
@@ -18,8 +18,11 @@ import java.math.BigInteger;
  * @param decidedAt              epoch millis at which the decision was taken
  * @param loanUtxoRef            {@code txHash#index} of the loan UTxO
  * @param bondUtxoRef            {@code txHash#index} of the lender-bond UTxO
- * @param variant                which action this decision is about — {@link #VARIANT} or
- *                               {@link #VARIANT_CONVERT}. A field rather than an implicit fact so a
+ * @param variant                which action this decision is about — {@link #VARIANT},
+ *                               {@link #VARIANT_CONVERT} or {@link #VARIANT_CONVERT_MINSWAP}. All
+ *                               THREE are emitted in production: the third since 22573f9, when
+ *                               {@code variantOf} began consulting the market gate instead of the
+ *                               lender's bond flag alone. A field rather than an implicit fact so a
  *                               second action can be added without every stored decision becoming
  *                               ambiguous. ⚠ <b>It was hardcoded to the plain value for the whole
  *                               time the convert path was live</b>, so every convert decision would

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/CompoundCandidateScanner.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/CompoundCandidateScanner.java
@@ -149,11 +149,19 @@ public class CompoundCandidateScanner {
         long feePerMille = compoundingFeePerMille(pair.poolManager());
 
         if (!principalIsAda) {
+            // ⛔ Still refused, but no longer because CompoundEconomics "cannot compare" the fee —
+            // it can now price a token fee via PricingService. This is a structural gate: the
+            // compound TRANSACTION BUILDER assumes an ada principal throughout, and lifting the
+            // refusal is also held on a product ruling from Giovanni (FAB-77, 2026-09-09) about
+            // whether the bot should acquire a token this way at all. See
+            // CompoundExclusion.PRINCIPAL_NOT_ADA's javadoc for both reasons.
             return new CompoundCandidate(loanId, escrow, datum, addedLiquidity, bond, poolId,
                     pair.pool(), pair.poolManager(), feePerMille, false,
                     CompoundExclusion.PRINCIPAL_NOT_ADA,
                     "pool principal is " + bond.datum().principalAsset()
-                            + "; its fee is denominated in that token and cannot be compared to a lovelace tx fee");
+                            + "; refused structurally — the compound builder does not yet pay out "
+                            + "a non-ada principal, and lifting this is held on a product ruling "
+                            + "(FAB-77), not merely a pricing gap");
         }
 
         return new CompoundCandidate(loanId, escrow, datum, addedLiquidity, bond, poolId,

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/CompoundEconomics.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/CompoundEconomics.java
@@ -1,6 +1,7 @@
 package com.fluidtokens.aquarium.offchain.service.loans;
 
 import com.fluidtokens.aquarium.offchain.config.AppConfig;
+import com.fluidtokens.aquarium.offchain.model.AssetType;
 import com.fluidtokens.aquarium.offchain.model.loans.CompoundAssessment;
 import com.fluidtokens.aquarium.offchain.model.loans.CompoundExclusion;
 import jakarta.annotation.PostConstruct;
@@ -24,12 +25,22 @@ import java.math.BigInteger;
  * carries no oracle risk — which is why the floor here defaults to 0 rather than to the liquidation
  * path's 1_500_000 premium. See {@code AppConfig.CompoundConfiguration#profitMarginLovelace}.
  *
- * <h2>⛔ The unit trap this gate refuses rather than papers over</h2>
+ * <h2>⛔ The unit trap this gate no longer papers over by refusing outright</h2>
  * {@code compoudingFeePerMille} applies to the <b>principal asset</b>. For an ADA-principal pool the
- * fee is lovelace and comparing it to a lovelace transaction fee is sound. For a token-principal pool
- * it is a token quantity, and subtracting a lovelace cost from it produces a number that looks like
- * profit and means nothing. Pricing that token needs an oracle this path does not have, so a
- * non-ADA principal is {@link CompoundExclusion#PRINCIPAL_NOT_ADA} — refused, not guessed.
+ * fee is already lovelace and comparing it to a lovelace transaction fee is direct. For a
+ * token-principal pool it is a token quantity, and subtracting a lovelace cost from it directly
+ * would produce a number that looks like profit and means nothing — so it is priced first, through
+ * {@link PricingService} (the ONE place a token quantity becomes lovelace in this path), and only
+ * refused, as {@link CompoundExclusion#PRICE_UNAVAILABLE}, when that pricing itself fails: no oracle
+ * feed, a feed that is not usable at the instant asked, or a feed that is a {@code POOLED} variant.
+ * ADA is the identity in {@link PricingService#toLovelace} — no oracle is consulted for it, so this
+ * gate's ada behaviour is unchanged from before this class knew how to price anything else.
+ * <p>
+ * ⚑ <b>This method alone no longer refuses a non-ADA principal.</b> A candidate still never reaches
+ * here with one today — {@code CompoundCandidateScanner} keeps its own, separate,
+ * {@link CompoundExclusion#PRINCIPAL_NOT_ADA} refusal upstream, for reasons that have nothing to do
+ * with pricing (see that constant's javadoc). This class is written to be correct regardless, ready
+ * for the day that upstream gate lifts.
  */
 @Service
 @Slf4j
@@ -39,10 +50,13 @@ public class CompoundEconomics {
 
     private final AppConfig.CompoundConfiguration configuration;
     private final AppConfig.Network network;
+    private final PricingService pricingService;
 
-    public CompoundEconomics(AppConfig.CompoundConfiguration configuration, AppConfig.Network network) {
+    public CompoundEconomics(AppConfig.CompoundConfiguration configuration, AppConfig.Network network,
+                             PricingService pricingService) {
         this.configuration = configuration;
         this.network = network;
+        this.pricingService = pricingService;
     }
 
     /**
@@ -92,17 +106,21 @@ public class CompoundEconomics {
      * @param poolAndManagerLive whether BOTH the pool NFT and the pool-manager NFT carrying that
      *                           {@code poolId} are live — the two {@code quantity_of(...) == 1}
      *                           checks {@code lm_compound_action} performs
-     * @param principalIsAda  whether the pool's {@code principalAsset} is ADA
+     * @param principalAsset  the pool's {@code principalAsset} — priced via {@link PricingService},
+     *                        which is the identity for ada and consults the oracle for anything else
      * @param escrow          principal held in the asset manager, in the principal's own unit
      * @param feePerMille     {@code compoudingFeePerMille} from the live {@code PoolManagerDatum}
      * @param txFee           the measured fee of the built transaction, in lovelace
+     * @param atMillis        the instant to price the fee slice at — the transaction's own
+     *                        {@code validFrom} is the caller's usual choice
      */
     public CompoundAssessment assess(boolean bondNamesAPool,
                                      boolean poolAndManagerLive,
-                                     boolean principalIsAda,
+                                     AssetType principalAsset,
                                      BigInteger escrow,
                                      long feePerMille,
-                                     BigInteger txFee) {
+                                     BigInteger txFee,
+                                     long atMillis) {
         if (!configuration.isEnabled()) {
             return CompoundAssessment.refused(CompoundExclusion.NOT_ARMED);
         }
@@ -112,18 +130,24 @@ public class CompoundEconomics {
         if (!poolAndManagerLive) {
             return CompoundAssessment.refused(CompoundExclusion.POOL_NOT_LIVE);
         }
-        if (!principalIsAda) {
-            return CompoundAssessment.refused(CompoundExclusion.PRINCIPAL_NOT_ADA);
-        }
 
         BigInteger expectedFee = expectedFee(escrow, feePerMille);
-        BigInteger net = expectedFee.subtract(txFee);
+
+        PricingService.Priced priced = pricingService.toLovelace(principalAsset, expectedFee, atMillis);
+        if (!priced.isPriced()) {
+            log.info("compound: cannot price the {} fee slice ({} base units) at {}: {}",
+                    principalAsset.toUnit(), expectedFee, atMillis, priced.refusal());
+            return CompoundAssessment.refused(CompoundExclusion.PRICE_UNAVAILABLE);
+        }
+
+        BigInteger expectedFeeLovelace = priced.lovelace();
+        BigInteger net = expectedFeeLovelace.subtract(txFee);
         BigInteger floor = configuration.getProfitMarginLovelace();
         boolean approved = net.compareTo(floor) >= 0;
 
         return new CompoundAssessment(approved,
                 approved ? null : CompoundExclusion.NET_BELOW_FLOOR,
-                escrow, feePerMille, expectedFee, txFee, net, floor);
+                escrow, feePerMille, expectedFee, expectedFeeLovelace, txFee, net, floor);
     }
 
     /**

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/CompoundExecutor.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/CompoundExecutor.java
@@ -237,14 +237,19 @@ public class CompoundExecutor {
         }
 
         // ⛔ The gate runs on the BUILT transaction's own fee — measured, not estimated.
-        CompoundAssessment assessment = economics.assess(true, true, candidate.principalIsAda(),
-                candidate.addedLiquidity(), candidate.feePerMille(), transaction.getBody().getFee());
+        // The principal asset is passed honestly (never a boolean smuggling a pricing decision) —
+        // CompoundEconomics prices it via PricingService itself. Every candidate reaching here is
+        // still ada-principal (CompoundCandidateScanner's own gate, see PRINCIPAL_NOT_ADA), so this
+        // is always AssetType.ada() today, but it is spelled out in full for when that gate lifts.
+        CompoundAssessment assessment = economics.assess(true, true,
+                candidate.bond().datum().principalAsset(), candidate.addedLiquidity(),
+                candidate.feePerMille(), transaction.getBody().getFee(), now);
 
         if (!assessment.approved()) {
             log.info("compound NOT APPROVED {} escrow {}: {} — escrow {} at {}/1000 earns {}, tx fee {}, "
                             + "net {} against floor {}{}",
                     candidate.loanId(), candidate.escrowRef(), assessment.exclusion(),
-                    assessment.escrow(), assessment.feePerMille(), assessment.expectedFee(),
+                    assessment.escrow(), assessment.feePerMille(), assessment.expectedFeeLovelace(),
                     assessment.txFee(), assessment.net(), assessment.floor(),
                     assessment.zeroFeePool()
                             ? " (this pool publishes NO compounding fee; a negative floor is the only "
@@ -290,7 +295,7 @@ public class CompoundExecutor {
                 log.info("COMPOUNDED {} escrow {}: {} lovelace into pool {}, fee earned {}, tx fee {}, "
                                 + "net {} — tx {}",
                         candidate.loanId(), candidate.escrowRef(), candidate.addedLiquidity(),
-                        candidate.poolId(), assessment.expectedFee(), assessment.txFee(),
+                        candidate.poolId(), assessment.expectedFeeLovelace(), assessment.txFee(),
                         assessment.net(), result.getValue());
                 return;
             }

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidatePayInAdvanceTransactionBuilder.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidatePayInAdvanceTransactionBuilder.java
@@ -1246,6 +1246,26 @@ public final class LiquidatePayInAdvanceTransactionBuilder {
                             + "builder does not model — only PRICE_DATA_CHARLIE and the signed "
                             + "(AGGREGATED/DEDICATED) variants can be encoded");
         }
+        // FAB-83-1 audit F1 — THE ENTRY MUST BE USABLE NOW, NOT MERELY OF A MODELLED VARIANT. The
+        // scanner checked usableForLiquidation() when it assessed the candidate, but the registry
+        // refreshes every 30 s and the executor takes its oracle snapshot AFTER the scan; a refresh
+        // landing in that window can hand this builder a signed entry with ZERO signatures, and
+        // oracleRedeemer(entry, ...) would ship the empty list — the exact shape the deployed
+        // validator refuses (measured 2026-09-10: a real script denial, not an assembly failure).
+        // The convert builder guards this in build(); this one did not. Refused by NAME, so the
+        // executor records a verdict and re-considers next cycle, rather than a fault.
+        if (!entry.usableForLiquidation()) {
+            String why = switch (entry.feed().variant()) {
+                case AGGREGATED, DEDICATED -> "a signed feed carrying " + entry.signatures().size()
+                        + " signature(s) against a threshold of " + entry.threshold();
+                case PRICE_DATA_CHARLIE -> "a PRICE_DATA_CHARLIE feed with no Charli3 provider reference input";
+                default -> "no reference input";
+            };
+            throw new PayInAdvanceLiquidationRouter.PayInAdvanceNotModelledException(
+                    ("the %s oracle entry is not usable for liquidation right now: %s — the registry "
+                            + "snapshot this cycle cannot prove the price on chain; reconsidered next cycle")
+                            .formatted(leg, why));
+        }
     }
 
     /**

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidatePayInAdvanceTransactionBuilder.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidatePayInAdvanceTransactionBuilder.java
@@ -235,6 +235,15 @@ public final class LiquidatePayInAdvanceTransactionBuilder {
      * @param configUtxo       the main config reference input
      * @param lmConfigUtxo     the LenderManager config reference input
      * @param oracle           the Charli3-backed collateral oracle entry
+     * @param principalOracle  WALL 2/3 (token-principals slice) — the principal's own oracle entry, or
+     *                         {@code null} for an ada principal. {@code null} means "ada": {@code numbers()}
+     *                         uses {@link OraclePriceFeed#unit()} for the principal feed exactly as before,
+     *                         and {@link #referenceInputs} adds no extra reference input for it — the
+     *                         validator never reads one for ada ({@code retrieve_oracle_data} short-circuits
+     *                         on an empty policy id). Non-null for a token principal: its
+     *                         {@code referenceInput}, {@code referenceScript} and (if a c3 feed)
+     *                         {@code charlieProviderReferenceInput} join the reference-input set, and its
+     *                         feed prices both the redeemer equity and the lender payout.
      * @param validFromMillis  the instant the debt and equity are computed at — must be the POSIX time
      *                         {@code validFromSlot} converts back to, so the on-chain recomputation matches
      * @param validFromSlot    the validity range lower bound, in slots
@@ -254,6 +263,7 @@ public final class LiquidatePayInAdvanceTransactionBuilder {
                           Utxo configUtxo,
                           Utxo lmConfigUtxo,
                           OracleEntry oracle,
+                          OracleEntry principalOracle,
                           long validFromMillis,
                           /**
                            * The validity upper bound in milliseconds, derived from {@code validToSlot}
@@ -286,40 +296,66 @@ public final class LiquidatePayInAdvanceTransactionBuilder {
      * The five numbers, computed exactly as {@code LiquidateTransactionBuilder} and the on-chain
      * validators do: the debt and equity at {@code validFromMillis}, the fee from the bond's per-mille
      * rate, and — the pay-in-advance-specific one — the collateral the lender should receive converted
-     * to the principal currency (ADA) through the two oracles. Since the principal is ADA its feed is
-     * the 1:1 unit feed, so {@code convertFromAToBWithOracles} reduces to
-     * {@code ceil(collateralReceive priced in lovelace)}.
+     * to the principal currency through the two oracles
+     * ({@link LoanFinance#convertFromAToBWithOracles}, WALL 1). For an ADA principal
+     * {@code request.principalOracle()} is {@code null} and the principal feed is the 1:1 unit feed, so
+     * the composition reduces exactly to {@code ceil(collateralReceive priced in lovelace)} — today's
+     * number, unchanged (see {@link LoanFinance#convertFromAToBWithOracles}'s javadoc).
      */
     public Numbers numbers(Request request) {
-        return numbers(request.loan(), request.bond(), request.oracle(), request.validFromMillis());
+        return numbers(request.loan(), request.bond(), request.oracle(), request.principalOracle(),
+                request.validFromMillis());
     }
 
     /**
-     * The same five numbers, computed from the four things they actually depend on — <b>and notably
+     * The same five numbers, computed from the five things they actually depend on — <b>and notably
      * NOT from the wallet UTxO.</b>
      * <p>
-     * That is what makes T-052 possible: the ada this liquidation will ask the bot to pay the lender
+     * That is what makes T-052 possible: the amount this liquidation will ask the bot to pay the lender
      * ({@code convertedLoanCollateralToPrincipalAmount}) is knowable <em>before</em> a wallet input has
      * been chosen, so the input can be selected to cover it instead of being picked blind and hoped
-     * over. Every field below reads the loan, the bond, the oracle or the instant; none reads the
+     * over. Every field below reads the loan, the bond, the two oracles or the instant; none reads the
      * wallet. <b>Keep it that way</b> — a wallet read here would make the requirement depend on the
      * answer it is being used to compute.
+     *
+     * @deprecated kept ONLY for {@code LiquidationReadinessController} (out of this slice's file
+     * allowlist), which is unchanged by this overload — it always passed {@code null} for "the
+     * principal feed", by not knowing about one at all, and this preserves that exact behaviour rather
+     * than silently changing a caller this ticket does not touch. Every caller that knows the
+     * principal (the router, the dry-eval rigs) uses the five-argument form below.
      */
+    @Deprecated
     public Numbers numbers(Loan loan, LenderBond bond, OracleEntry oracle, long validFromMillis) {
+        return numbers(loan, bond, oracle, null, validFromMillis);
+    }
+
+    /**
+     * @param principalOracle WALL 2 — the principal's own oracle entry, or {@code null} for ada. The
+     *                        redeemer equity ({@code loan_claim_action}'s own recomputation) and the
+     *                        lender payout ({@code lm_liquidate_and_pay_in_advance_action}'s) both use
+     *                        this feed, never {@link OraclePriceFeed#unit()}, for a token principal —
+     *                        the two must agree bit-for-bit or the loan spend fails phase 2.
+     */
+    public Numbers numbers(Loan loan, LenderBond bond, OracleEntry oracle, OracleEntry principalOracle,
+                           long validFromMillis) {
         LoanDatum datum = loan.datum();
         LiquidationMode.Liquidation mode = (LiquidationMode.Liquidation) datum.liquidationMode();
         BigInteger collateralAmount = loan.collateralAmount();
+        OraclePriceFeed principalFeed = principalOracle != null ? principalOracle.feed() : OraclePriceFeed.unit();
 
         BigInteger remainingDebt = LoanFinance.remainingDebt(datum, validFromMillis);
         BigInteger equity = LoanFinance.redeemerEquity(mode, Rational.fromInt(collateralAmount),
-                Rational.fromInt(remainingDebt), OraclePriceFeed.unit(), oracle.feed());
+                Rational.fromInt(remainingDebt), principalFeed, oracle.feed());
         BigInteger liquidationFee = Rational.required(
                         collateralAmount.multiply(bond.datum().liquidationFeePerMille()),
                         BigInteger.valueOf(1000))
                 .floor();
         BigInteger collateralLenderShouldReceive = collateralAmount.subtract(equity).subtract(liquidationFee);
-        BigInteger converted = LoanFinance.toLovelace(
-                Rational.fromInt(collateralLenderShouldReceive), oracle.feed()).ceil();
+        // WALL 1 — the validator's exact composition, ONE ceil at the end. NOT
+        // toLovelace(...).ceil(): that shortcut skips the division by the principal feed entirely and
+        // coincides with this only when principalFeed is the unit feed (ada).
+        BigInteger converted = LoanFinance.convertFromAToBWithOracles(oracle.feed(), principalFeed,
+                Rational.fromInt(collateralLenderShouldReceive));
         return new Numbers(remainingDebt, equity, liquidationFee, collateralLenderShouldReceive, converted);
     }
 
@@ -462,17 +498,49 @@ public final class LiquidatePayInAdvanceTransactionBuilder {
                     "only %dms of oracle feed window left after validTo, %dms required".formatted(
                             feedRemainingAfterValidTo, request.oracleWindowMarginMillis()));
         }
+        // WALL 3 — the SAME V3 window check the collateral feed gets, applied to the principal feed
+        // too when it is real. Skipped for ada: OraclePriceFeed.unit()'s validFrom/validTo are 0/0 by
+        // construction and retrieve_oracle_data never reads them for an empty policy id.
+        if (request.principalOracle() != null) {
+            OraclePriceFeed principalFeed = request.principalOracle().feed();
+            long principalFeedRemainingAfterValidTo = principalFeed.validTo() - request.validToMillis();
+            if (!principalFeed.usableOver(request.validFromMillis(), request.validToMillis())) {
+                throw new PayInAdvanceLiquidationRouter.PayInAdvanceNotModelledException(
+                        "principal oracle feed window [%d,%d] does not cover tx window [%d,%d]".formatted(
+                                principalFeed.validFrom(), principalFeed.validTo(),
+                                request.validFromMillis(), request.validToMillis()));
+            }
+            if (principalFeedRemainingAfterValidTo < request.oracleWindowMarginMillis()) {
+                throw new PayInAdvanceLiquidationRouter.PayInAdvanceNotModelledException(
+                        "only %dms of principal oracle feed window left after validTo, %dms required"
+                                .formatted(principalFeedRemainingAfterValidTo,
+                                        request.oracleWindowMarginMillis()));
+            }
+        }
 
         List<TransactionInput> refInputs = referenceInputs(request);
         int configRefIndex = refIndex(refInputs, inputOf(request.configUtxo()), "main config");
         int lmConfigRefIndex = refIndex(refInputs, inputOf(request.lmConfigUtxo()), "lm config");
         int collateralOracleRefIndex = refIndex(refInputs, request.oracle().referenceInput(), "collateral oracle");
-        // Principal is ADA: retrieve_oracle_data short-circuits on policyId == "" and never reads the
-        // reference input, but the index must still be in range. Index 0 of the canonically sorted
-        // reference inputs always is — the same value LiquidateTransactionBuilder gives an ada leg.
-        int principalOracleRefIndex = 0;
+        // WALL 3 — for a token principal, a REAL reference input, derived by lookup exactly as the
+        // collateral one is. For ADA: retrieve_oracle_data short-circuits on policyId == "" and never
+        // reads the reference input, but the index must still be in range — index 0 of the canonically
+        // sorted reference inputs always is (the same value LiquidateTransactionBuilder gives an ada
+        // leg), and no extra reference input is added for it (see referenceInputs()).
+        int principalOracleRefIndex = request.principalOracle() != null
+                ? refIndex(refInputs, request.principalOracle().referenceInput(), "principal oracle")
+                : 0;
         int providerRefIndex = refIndex(refInputs, request.oracle().charlieProviderReferenceInput(),
                 "charli3 provider");
+        // WALL 3 — the principal oracle's own Charli3 provider, when it has one. lm_liquidate_and_pay_
+        // in_advance_action's redeemer carries a SEPARATE providerRefInputIndex per oracle invocation
+        // (one per withdraw-0 of the shared oracle validator), so this is independent of the
+        // collateral leg's providerRefIndex above.
+        Integer principalProviderRefIndex = null;
+        if (request.principalOracle() != null && request.principalOracle().charlieProviderReferenceInput() != null) {
+            principalProviderRefIndex = refIndex(refInputs,
+                    request.principalOracle().charlieProviderReferenceInput(), "principal charli3 provider");
+        }
 
         // The output indexes, COMPUTED from the emission order rather than observed off a throwaway
         // probe body (T-051, 2026-08-26). assemble() emits exactly three outputs, in this order:
@@ -499,7 +567,7 @@ public final class LiquidatePayInAdvanceTransactionBuilder {
 
         Transaction transaction = complete(request, assemble(request, numbers, configRefIndex,
                 lmConfigRefIndex, collateralOracleRefIndex, principalOracleRefIndex, providerRefIndex,
-                refInputs, lenderBondOutputIndex, assetOutputIndex),
+                principalProviderRefIndex, refInputs, lenderBondOutputIndex, assetOutputIndex),
                 (ctx, txn) -> assertStructure(txn, request, numbers, lenderBondOutputIndex,
                         assetOutputIndex));
         return transaction;
@@ -509,7 +577,8 @@ public final class LiquidatePayInAdvanceTransactionBuilder {
 
     private ScriptTx assemble(Request request, Numbers numbers, int configRefIndex, int lmConfigRefIndex,
                               int collateralOracleRefIndex, int principalOracleRefIndex,
-                              int providerRefIndex, List<TransactionInput> refInputs,
+                              int providerRefIndex, Integer principalProviderRefIndex,
+                              List<TransactionInput> refInputs,
                               long lenderBondOutputIndex, long assetOutputIndex) {
         ScriptTx tx = new ScriptTx();
         String loanId = request.loan().loanId();
@@ -533,8 +602,11 @@ public final class LiquidatePayInAdvanceTransactionBuilder {
                 bondEchoDatum(request));
         tx.payToContract(assetManagerAddress(), collateralEquityAmounts(request, numbers.equity()),
                 borrowerCompensationDatum(request));
-        tx.payToContract(assetManagerAddress(),
-                List.of(Amount.lovelace(numbers.convertedLoanCollateralToPrincipalAmount())),
+        // WALL 4 — paid in the PRINCIPAL ASSET. For ada: unchanged, ada-only (flatten == 1). For a
+        // token principal: the converted quantity of that token, min-ada left to cardano-client-lib to
+        // top up (trap 6) — the output becomes [min-ada rider, converted × principal], flatten == 2,
+        // exactly what validate_repayment_output's dosProtection demands for a non-ada repaymentAsset.
+        tx.payToContract(assetManagerAddress(), lenderConvertedAmounts(request, numbers),
                 lenderConvertedDatum(request));
 
         // ⛔ THE BOT'S COLLATERAL, PAID OUT BY NAME — and this output is the whole of S-15.
@@ -592,6 +664,21 @@ public final class LiquidatePayInAdvanceTransactionBuilder {
         tx.withdraw(request.oracle().rewardAddress(), BigInteger.ZERO,
                 LiquidationTxEncoder.oracleRedeemer(request.oracle().feed(), providerRefIndex, List.of()),
                 request.changeAddress());
+        // WALL 3 — the principal leg is a SEPARATE withdraw-0 invocation of the oracle validator, per
+        // OracleEntry's own javadoc: retrieve_oracle_data resolves its feed with
+        // pairs.get_first(self.redeemers, Withdraw(oraclePaymentCredential)) — one redeemer PER
+        // CREDENTIAL, and a token principal's oracle is deployed separately from the collateral's
+        // (its own verification keys / charlie_specs / oracle-asset parameters), so it carries its own
+        // reward address. Skipped when the two legs happen to share one credential (the same priced
+        // asset on both legs), because the ledger permits only one withdrawal per reward address and
+        // get_first would already resolve the collateral leg's own entry for it.
+        if (request.principalOracle() != null
+                && !request.principalOracle().rewardAddress().equals(request.oracle().rewardAddress())) {
+            tx.withdraw(request.principalOracle().rewardAddress(), BigInteger.ZERO,
+                    LiquidationTxEncoder.oracleRedeemer(request.principalOracle().feed(),
+                            principalProviderRefIndex == null ? 0 : principalProviderRefIndex, List.of()),
+                    request.changeAddress());
+        }
 
         tx.readFrom(refInputs.toArray(TransactionInput[]::new));
 
@@ -983,6 +1070,22 @@ public final class LiquidatePayInAdvanceTransactionBuilder {
         return List.of(Amount.asset(collateral.policyId() + collateral.assetName(), equity));
     }
 
+    /**
+     * WALL 4 — the lender's paid-in-advance value, in the PRINCIPAL asset. Ada: a plain lovelace
+     * amount (unchanged, {@code flatten == 1}). A token principal: the converted quantity of that
+     * token, min-ada left to cardano-client-lib to top up (trap 6) — {@code flatten == 2}, exactly
+     * what {@code validate_repayment_output}'s {@code dosProtection} demands for a non-ada
+     * {@code repaymentAsset}.
+     */
+    private List<Amount> lenderConvertedAmounts(Request request, Numbers numbers) {
+        AssetType principal = request.loan().datum().principalAsset();
+        if (principal.isAda()) {
+            return List.of(Amount.lovelace(numbers.convertedLoanCollateralToPrincipalAmount()));
+        }
+        return List.of(Amount.asset(principal.policyId() + principal.assetName(),
+                numbers.convertedLoanCollateralToPrincipalAmount()));
+    }
+
     // ---- addresses --------------------------------------------------------------------------------
 
     /**
@@ -1014,6 +1117,17 @@ public final class LiquidatePayInAdvanceTransactionBuilder {
                 request.oracle().referenceInput(),
                 request.oracle().referenceScript(),
                 request.oracle().charlieProviderReferenceInput()));
+        // WALL 3 — the principal's own reference input, reference script and (if a c3 feed) provider
+        // input, ONLY for a token principal. Ada adds nothing here: the validator never reads a
+        // reference input for it (retrieve_oracle_data short-circuits on the empty policy id), so
+        // adding one would cost fee and change nothing — exactly the ⚠ in the Request javadoc.
+        if (request.principalOracle() != null) {
+            refInputs.add(request.principalOracle().referenceInput());
+            refInputs.add(request.principalOracle().referenceScript());
+            if (request.principalOracle().charlieProviderReferenceInput() != null) {
+                refInputs.add(request.principalOracle().charlieProviderReferenceInput());
+            }
+        }
         // Only the subset this builder attaches AND the shared record can name: lmLiquidateAction and
         // assetManager are excluded here, exactly as in publishedScripts().
         LiquidateTransactionBuilder.ReferenceScripts scripts = request.referenceScripts();
@@ -1110,12 +1224,27 @@ public final class LiquidatePayInAdvanceTransactionBuilder {
         structural(assetOutputIndex != 0,
                 "the borrower compensation output must occupy filtered slot 0 (the bare loan index)");
 
-        // The lender's paid-in-advance output is ada-only (dosProtection flatten == 1) and covers the amount.
+        // WALL 4 — the lender's paid-in-advance output's shape depends on the principal asset.
+        // Ada: dosProtection demands flatten == 1 and the coin itself is the converted amount.
+        // Token: dosProtection demands flatten == 2 (the token plus its min-ada rider) and the
+        // VALIDATOR-CHECKED quantity is quantity_of(output, principalAsset), never the coin.
         TransactionOutput lenderOutput = assetOutputs.get((int) assetOutputIndex);
-        structural(flattenedCount(lenderOutput) == 1, "the lender converted output must be ada-only (flatten == 1)");
-        structural(lenderOutput.getValue().getCoin()
-                        .compareTo(numbers.convertedLoanCollateralToPrincipalAmount()) >= 0,
-                "the lender converted output holds less ada than convertedLoanCollateralToPrincipalAmount");
+        AssetType principal = request.loan().datum().principalAsset();
+        if (principal.isAda()) {
+            structural(flattenedCount(lenderOutput) == 1,
+                    "the lender converted output must be ada-only (flatten == 1)");
+            structural(lenderOutput.getValue().getCoin()
+                            .compareTo(numbers.convertedLoanCollateralToPrincipalAmount()) >= 0,
+                    "the lender converted output holds less ada than convertedLoanCollateralToPrincipalAmount");
+        } else {
+            structural(flattenedCount(lenderOutput) == 2,
+                    "the lender converted output must be the principal token plus its min-ada rider "
+                            + "(flatten == 2) for a non-ada principal");
+            structural(quantityOf(lenderOutput, principal)
+                            .compareTo(numbers.convertedLoanCollateralToPrincipalAmount()) >= 0,
+                    "the lender converted output holds less " + principal.toUnit()
+                            + " than convertedLoanCollateralToPrincipalAmount");
+        }
 
         // The borrower compensation output carries at least the equity in collateral tokens, flatten == 2.
         TransactionOutput borrowerOutput = assetOutputs.get(0);

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidatePayInAdvanceTransactionBuilder.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidatePayInAdvanceTransactionBuilder.java
@@ -459,6 +459,22 @@ public final class LiquidatePayInAdvanceTransactionBuilder {
      * Blockfrost.
      */
     public Transaction build(Request request) {
+        // V8 — THE ORACLE VARIANT, REFUSED BY NAME BEFORE ANYTHING ELSE RUNS. Only the two shapes
+        // OracleFeedConverter can encode are modelled: PRICE_DATA_CHARLIE (proven by a provider
+        // reference input) and the SIGNED feeds, AGGREGATED/DEDICATED (proven by the published
+        // signatures). POOLED and PRICE_DATA_ORCFAX carry fields that are not a plain price.
+        //
+        // ⚠ THIS RUNS FIRST, AHEAD OF numbers(), AND THAT ORDER IS LOAD-BEARING — measured. A POOLED
+        // feed never reaches a redeemer at all: numbers() prices it, and OraclePriceFeed.price()
+        // throws a bare UnsupportedOperationException for POOLED ("a `fail` in finance.ak"). Placed
+        // any later, this check is dead code for the one variant that most needs it, and the operator
+        // sees machinery breakage where the truth is a candidate this builder does not model.
+        // OracleEntry.usableForLiquidation() already refuses both upstream; this is the builder
+        // saying so in its own voice, so the executor records a REFUSED decision rather than a fault.
+        refuseUnmodelledVariant(request.oracle(), "collateral");
+        if (request.principalOracle() != null) {
+            refuseUnmodelledVariant(request.principalOracle(), "principal");
+        }
         Numbers numbers = numbers(request);
         // F0 (round 2) — EQUITY 0 IS THE VALIDATOR'S NORMAL CASE, NOT A SHAPE THIS BUILDER REFUSES.
         //
@@ -545,14 +561,22 @@ public final class LiquidatePayInAdvanceTransactionBuilder {
         int principalOracleRefIndex = request.principalOracle() != null
                 ? refIndex(refInputs, request.principalOracle().referenceInput(), "principal oracle")
                 : 0;
-        int providerRefIndex = refIndex(refInputs, request.oracle().charlieProviderReferenceInput(),
-                "charli3 provider");
+        // ⛔ A PROVIDER INDEX ONLY WHERE THERE IS A PROVIDER. Deriving it unconditionally is what
+        // made a multisig feed impossible: there is no provider UTxO to look up, so refIndex would
+        // hunt for a null coordinate. The variant decides — and it decides the redeemer encoding at
+        // the withdrawal too (see oracleRedeemer below); nothing else may.
+        Integer providerRefIndex = null;
+        if (request.oracle().feed().variant() == OraclePriceFeed.Variant.PRICE_DATA_CHARLIE) {
+            providerRefIndex = refIndex(refInputs, request.oracle().charlieProviderReferenceInput(),
+                    "charli3 provider");
+        }
         // WALL 3 — the principal oracle's own Charli3 provider, when it has one. lm_liquidate_and_pay_
         // in_advance_action's redeemer carries a SEPARATE providerRefInputIndex per oracle invocation
         // (one per withdraw-0 of the shared oracle validator), so this is independent of the
         // collateral leg's providerRefIndex above.
         Integer principalProviderRefIndex = null;
-        if (request.principalOracle() != null && request.principalOracle().charlieProviderReferenceInput() != null) {
+        if (request.principalOracle() != null
+                && request.principalOracle().feed().variant() == OraclePriceFeed.Variant.PRICE_DATA_CHARLIE) {
             principalProviderRefIndex = refIndex(refInputs,
                     request.principalOracle().charlieProviderReferenceInput(), "principal charli3 provider");
         }
@@ -600,7 +624,7 @@ public final class LiquidatePayInAdvanceTransactionBuilder {
 
     private ScriptTx assemble(Request request, Numbers numbers, int configRefIndex, int lmConfigRefIndex,
                               int collateralOracleRefIndex, int principalOracleRefIndex,
-                              int providerRefIndex, Integer principalProviderRefIndex,
+                              Integer providerRefIndex, Integer principalProviderRefIndex,
                               List<TransactionInput> refInputs,
                               long lenderBondOutputIndex, long assetOutputIndex) {
         ScriptTx tx = new ScriptTx();
@@ -695,7 +719,7 @@ public final class LiquidatePayInAdvanceTransactionBuilder {
                         List.of(assetOutputIndex)),
                 request.changeAddress());
         tx.withdraw(request.oracle().rewardAddress(), BigInteger.ZERO,
-                LiquidationTxEncoder.oracleRedeemer(request.oracle().feed(), providerRefIndex, List.of()),
+                oracleRedeemer(request.oracle(), providerRefIndex),
                 request.changeAddress());
         // WALL 3 — the principal leg is a SEPARATE withdraw-0 invocation of the oracle validator, per
         // OracleEntry's own javadoc: retrieve_oracle_data resolves its feed with
@@ -708,8 +732,7 @@ public final class LiquidatePayInAdvanceTransactionBuilder {
         if (request.principalOracle() != null
                 && !request.principalOracle().rewardAddress().equals(request.oracle().rewardAddress())) {
             tx.withdraw(request.principalOracle().rewardAddress(), BigInteger.ZERO,
-                    LiquidationTxEncoder.oracleRedeemer(request.principalOracle().feed(),
-                            principalProviderRefIndex == null ? 0 : principalProviderRefIndex, List.of()),
+                    oracleRedeemer(request.principalOracle(), principalProviderRefIndex),
                     request.changeAddress());
         }
 
@@ -1146,20 +1169,19 @@ public final class LiquidatePayInAdvanceTransactionBuilder {
     private List<TransactionInput> referenceInputs(Request request) {
         Set<TransactionInput> refInputs = new LinkedHashSet<>(List.of(
                 inputOf(request.configUtxo()),
-                inputOf(request.lmConfigUtxo()),
-                request.oracle().referenceInput(),
-                request.oracle().referenceScript(),
-                request.oracle().charlieProviderReferenceInput()));
+                inputOf(request.lmConfigUtxo())));
+        // ⛔ NULL-SAFE, exactly as ConvertTransactionBuilder#referenceInputs already is. A MULTISIG
+        // feed has NO Charli3 provider UTxO — and {@code List.of} refuses a null element outright, so
+        // the first-ever mainnet build died right here with a bare NullPointerException. A
+        // provider-less feed simply adds no provider input; a null is skipped rather than encoded as
+        // a coordinate that resolves to nothing.
+        oracleReferenceInputs(request.oracle()).forEach(refInputs::add);
         // WALL 3 — the principal's own reference input, reference script and (if a c3 feed) provider
         // input, ONLY for a token principal. Ada adds nothing here: the validator never reads a
         // reference input for it (retrieve_oracle_data short-circuits on the empty policy id), so
         // adding one would cost fee and change nothing — exactly the ⚠ in the Request javadoc.
         if (request.principalOracle() != null) {
-            refInputs.add(request.principalOracle().referenceInput());
-            refInputs.add(request.principalOracle().referenceScript());
-            if (request.principalOracle().charlieProviderReferenceInput() != null) {
-                refInputs.add(request.principalOracle().charlieProviderReferenceInput());
-            }
+            oracleReferenceInputs(request.principalOracle()).forEach(refInputs::add);
         }
         // Only the subset this builder attaches AND the shared record can name: lmLiquidateAction and
         // assetManager are excluded here, exactly as in publishedScripts().
@@ -1170,6 +1192,72 @@ public final class LiquidatePayInAdvanceTransactionBuilder {
                 .filter(Objects::nonNull)
                 .forEach(refInputs::add);
         return refInputs.stream().sorted(new TransactionInputComparator()).toList();
+    }
+
+    /**
+     * ⛔ <b>THE ORACLE REDEEMER, DECIDED BY THE FEED'S VARIANT AND BY NOTHING ELSE.</b>
+     * <p>
+     * A {@code PRICE_DATA_CHARLIE} feed carries no signature over its own bytes: {@code oracle.ak}
+     * validates it structurally against the Charli3 provider UTxO named by
+     * {@code provider_ref_input_index}, so the redeemer names that index and its signature list is
+     * legitimately EMPTY. A signed feed — {@code AGGREGATED} on mainnet, {@code DEDICATED} — takes
+     * the other branch, which runs {@code verify_ed25519_signature} against the feed's published
+     * signatures and has no provider index at all.
+     * <p>
+     * <b>The two are not interchangeable, and getting it wrong is PHASE 2.</b> Until 2026-09-10 this
+     * builder emitted the Charli3 shape unconditionally — a provider index plus
+     * {@code List.of()} — for every feed. Against a multisig deployment that assembles perfectly and
+     * fails the signature threshold on chain, after the fee is spent and with the collateral input
+     * consumed (CCL trap 8's failure tier). {@link ConvertTransactionBuilder} — the only builder that
+     * has ever built on mainnet — has encoded the signed shape since findings §40, and its comment at
+     * the collateral withdrawal names this builder's old call as exactly the fatal one. This is that
+     * lesson carried across, not a third encoding.
+     *
+     * @param providerRefIndex the provider's position among the reference inputs, non-null for a
+     *                         {@code PRICE_DATA_CHARLIE} feed and null for every other variant
+     */
+    private static PlutusData oracleRedeemer(OracleEntry entry, Integer providerRefIndex) {
+        return switch (entry.feed().variant()) {
+            case PRICE_DATA_CHARLIE -> LiquidationTxEncoder.oracleRedeemer(entry.feed(),
+                    Objects.requireNonNull(providerRefIndex,
+                            "a PRICE_DATA_CHARLIE feed has no provider reference-input index"),
+                    List.of());
+            case AGGREGATED, DEDICATED -> LiquidationTxEncoder.oracleRedeemer(entry.feed(),
+                    entry.signatures());
+            // Unreachable: refuseUnmodelledVariant rejects both before anything is assembled. Kept so
+            // the switch stays exhaustive and a new variant is a compile error, not a silent branch.
+            case POOLED, PRICE_DATA_ORCFAX -> throw new IllegalStateException(
+                    "unmodelled oracle variant " + entry.feed().variant() + " reached assembly");
+        };
+    }
+
+    /**
+     * Refuses a feed variant this builder cannot encode, <em>by name and before building</em> — a
+     * clean {@code REFUSED} decision about a candidate rather than an
+     * {@code UnsupportedOperationException} out of {@link OracleFeedConverter}.
+     */
+    private static void refuseUnmodelledVariant(OracleEntry entry, String leg) {
+        switch (entry.feed().variant()) {
+            case PRICE_DATA_CHARLIE, AGGREGATED, DEDICATED -> {
+            }
+            case POOLED, PRICE_DATA_ORCFAX -> throw new PayInAdvanceLiquidationRouter
+                    .PayInAdvanceNotModelledException("the %s oracle publishes a %s feed, which this "
+                            .formatted(leg, entry.feed().variant())
+                            + "builder does not model — only PRICE_DATA_CHARLIE and the signed "
+                            + "(AGGREGATED/DEDICATED) variants can be encoded");
+        }
+    }
+
+    /**
+     * One oracle leg's reference inputs — the NFT-bearing UTxO the validator reads the credential and
+     * value from, its published script, and (a {@code PRICE_DATA_CHARLIE} feed only) the Charli3
+     * provider UTxO. Any of them may be null, and a null is dropped rather than offered to
+     * {@code List.of}.
+     */
+    private static Stream<TransactionInput> oracleReferenceInputs(OracleEntry entry) {
+        return Stream.of(entry.referenceInput(), entry.referenceScript(),
+                        entry.charlieProviderReferenceInput())
+                .filter(Objects::nonNull);
     }
 
     private static int refIndex(List<TransactionInput> refInputs, TransactionInput input, String what) {

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidatePayInAdvanceTransactionBuilder.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidatePayInAdvanceTransactionBuilder.java
@@ -460,9 +460,24 @@ public final class LiquidatePayInAdvanceTransactionBuilder {
      */
     public Transaction build(Request request) {
         Numbers numbers = numbers(request);
-        if (numbers.equity().signum() <= 0) {
+        // F0 (round 2) — EQUITY 0 IS THE VALIDATOR'S NORMAL CASE, NOT A SHAPE THIS BUILDER REFUSES.
+        //
+        // loan_claim_action.ak:240-259 (deployed ff005fb) accepts `inputAction.equity == 0` outright
+        // — an `or { equity == 0, <borrower-compensation check> }` that SHORT-CIRCUITS before ever
+        // looking at a compensation output — and otherwise requires `equity >= 0 && equity ==
+        // max(computed_equity, 0)`. LoanFinance.redeemerEquity already floors a negative computed
+        // equity to ZERO, so "equity <= 0" this builder used to refuse was, in practice, ALWAYS
+        // exactly "equity == 0" — the underwater loan, which is the common liquidation and (2026-09-09)
+        // the live USDM loan today. Refusing it here was a precondition THIS BUILDER invented, not one
+        // the validator asked for.
+        //
+        // Only a genuinely negative equity — which redeemerEquity's own floor makes unreachable, kept
+        // here as defence in depth against a future change to that floor — is still refused: this
+        // builder still would not know what to pay the borrower a NEGATIVE compensation would mean.
+        if (numbers.equity().signum() < 0) {
             throw new IllegalStateException(
-                    "this builder models the positive-equity pay-in-advance layout; equity was "
+                    "this builder never models a negative equity (LoanFinance.redeemerEquity floors "
+                            + "it to zero; this is defence in depth, not the expected path); equity was "
                             + numbers.equity());
         }
         if (!request.bond().datum().shouldLiquidationConvertToPrincipal()) {
@@ -543,27 +558,35 @@ public final class LiquidatePayInAdvanceTransactionBuilder {
         }
 
         // The output indexes, COMPUTED from the emission order rather than observed off a throwaway
-        // probe body (T-051, 2026-08-26). assemble() emits exactly three outputs, in this order:
+        // probe body (T-051, 2026-08-26). assemble() emits the bond echo, then EITHER two OR one
+        // asset-manager outputs depending on equity (F0, round 2):
         //
         //   1. the bond echo, at the LenderManager credential  -> absolute body index
-        //   2. the borrower's equity compensation              -> asset-manager filtered slot 0
-        //   3. the lender's paid-in-advance ada                -> asset-manager filtered slot 1
+        //   2. the borrower's equity compensation, EQUITY > 0 ONLY -> asset-manager filtered slot 0
+        //   3. the lender's paid-in-advance principal          -> asset-manager filtered slot 0 or 1
         //
         // The bond echo is the FIRST output this builder adds, so its absolute position is whatever
         // cardano-client-lib prepended and nothing else — see OutputLayout.CCL_PREPENDED_OUTPUTS. The
         // asset index is into the FILTERED list, so it needs no such offset: the prepended dummy and
         // the appended change sit at the change address and the echo at the LenderManager credential,
-        // so none of them survives the asset-manager filter. loan_claim_action reads the borrower's
-        // compensation at the bare loan index, which pins it to slot 0 and leaves the lender's output
-        // at slot 1 — the constraint V5 re-asserts as `assetOutputIndex != 0`.
+        // so none of them survives the asset-manager filter.
+        //
+        // At equity > 0, loan_claim_action reads the borrower's compensation at the bare loan index,
+        // which pins it to slot 0 and leaves the lender's output at slot 1 — the constraint V5
+        // re-asserts as `assetOutputIndex != 0`. At equity == 0 the validator's own `or { equity == 0,
+        // .. }` never looks at slot 0 for a compensation output AT ALL (loan_claim_action.ak:273), so
+        // omitting that output (mirroring LiquidateTransactionBuilder:795's `if (equity.signum() > 0)`)
+        // and landing the lender's output at slot 0 is equally valid — there is no "bare loan index"
+        // constraint to satisfy when nothing reads that slot for this loan.
         //
         // ⚠ Unlike the plain path, this layout is NOT corroborated by an accepted transaction: no
         // convert-path liquidation has ever been submitted. What makes it safe is the same thing that
         // made the probe safe — V5 re-derives BOTH indexes from the FINISHED body, via the very same
         // locateBondOutput / locateLenderConvertedOutput helpers the probe used, and refuses on any
         // disagreement. A layout mistake is a build-time refusal, not a chain failure.
+        boolean payBorrowerCompensation = numbers.equity().signum() > 0;
         long lenderBondOutputIndex = OutputLayout.CCL_PREPENDED_OUTPUTS;
-        long assetOutputIndex = 1L;
+        long assetOutputIndex = payBorrowerCompensation ? 1L : 0L;
 
         Transaction transaction = complete(request, assemble(request, numbers, configRefIndex,
                 lmConfigRefIndex, collateralOracleRefIndex, principalOracleRefIndex, providerRefIndex,
@@ -595,13 +618,23 @@ public final class LiquidatePayInAdvanceTransactionBuilder {
                 LiquidationTxEncoder.loanMintRedeemer(configRefIndex, false, 0));
 
         // Outputs. The bond echo first, then — in the filtered asset-manager list — the borrower's
-        // equity compensation at slot 0 (loan_claim_action reads it at the bare loan index) and the
-        // lender's paid-in-advance ada at slot 1 (lm_liquidate_and_pay_in_advance_action reaches it
-        // through assetOutputIndexes).
+        // equity compensation (EQUITY > 0 ONLY, at slot 0 — loan_claim_action reads it at the bare
+        // loan index) and the lender's paid-in-advance principal (slot 1 when a compensation output
+        // exists, otherwise slot 0 — lm_liquidate_and_pay_in_advance_action reaches it through
+        // assetOutputIndexes, whichever slot that is).
+        //
+        // F0 (round 2) — AT EQUITY == 0, NO COMPENSATION OUTPUT IS EMITTED AT ALL. Mirrors
+        // LiquidateTransactionBuilder:795's `if (equity.signum() > 0)` exactly: loan_claim_action's own
+        // `or { inputAction.equity == 0, equity_sent_to_borrower(..) }` (ak:273) short-circuits on the
+        // first branch and never reads a compensation output for this loan, so emitting one anyway
+        // would be an unread, wasted min-ada outlay for a candidate that is already the bot's worst
+        // case (an underwater loan).
         tx.payToContract(request.bondUtxo().getAddress(), List.copyOf(request.bondUtxo().getAmount()),
                 bondEchoDatum(request));
-        tx.payToContract(assetManagerAddress(), collateralEquityAmounts(request, numbers.equity()),
-                borrowerCompensationDatum(request));
+        if (numbers.equity().signum() > 0) {
+            tx.payToContract(assetManagerAddress(), collateralEquityAmounts(request, numbers.equity()),
+                    borrowerCompensationDatum(request));
+        }
         // WALL 4 — paid in the PRINCIPAL ASSET. For ada: unchanged, ada-only (flatten == 1). For a
         // token principal: the converted quantity of that token, min-ada left to cardano-client-lib to
         // top up (trap 6) — the output becomes [min-ada rider, converted × principal], flatten == 2,
@@ -1206,7 +1239,12 @@ public final class LiquidatePayInAdvanceTransactionBuilder {
 
     // ---- structural re-derivation from the finished body ------------------------------------------
 
-    private void assertStructure(Transaction transaction, Request request, Numbers numbers,
+    // Package-private (not private) for the same reason LiquidateTransactionBuilder's
+    // assetOutputIndexesForEquities is: M19 (F4, slice-3 round-2 audit) needs to prove the
+    // flatten == 2 boundary is actually ENFORCED, not merely coincidentally true of every fixture's
+    // OUTPUT — see LiquidatePayInAdvanceTransactionBuilderTest, which hand-mutates a real built body
+    // and re-invokes this method directly rather than going through reflection.
+    void assertStructure(Transaction transaction, Request request, Numbers numbers,
                                  long lenderBondOutputIndex, long assetOutputIndex) {
         // The bond echo is where the claim redeemer says, and it is byte-identical to the input.
         structural(lenderBondOutputIndex == locateBondOutput(transaction, request),
@@ -1215,14 +1253,22 @@ public final class LiquidatePayInAdvanceTransactionBuilder {
         structural(request.bondUtxo().getInlineDatum().equalsIgnoreCase(echo.getInlineDatum().serializeToHex()),
                 "the bond echo datum is not byte-identical to the bond input datum");
 
-        // The asset-manager filtered list is [borrower compensation, lender converted], and
-        // assetOutputIndexes points at the lender one.
+        // F0 (round 2) — the asset-manager filtered list is [borrower compensation, lender converted]
+        // at EQUITY > 0, and JUST [lender converted] at EQUITY == 0 (assemble() emits no compensation
+        // output at all — loan_claim_action.ak:273's `or { equity == 0, .. }` never reads one).
+        // assetOutputIndexes points at the lender one either way.
+        boolean hasBorrowerCompensation = numbers.equity().signum() > 0;
         List<TransactionOutput> assetOutputs = assetManagerOutputs(transaction);
-        structural(assetOutputs.size() == 2, "expected exactly two asset-manager outputs, got " + assetOutputs.size());
+        int expectedAssetOutputs = hasBorrowerCompensation ? 2 : 1;
+        structural(assetOutputs.size() == expectedAssetOutputs,
+                "expected exactly " + expectedAssetOutputs + " asset-manager output(s), got "
+                        + assetOutputs.size());
         structural(assetOutputIndex == locateLenderConvertedOutput(transaction, request, numbers),
                 "assetOutputIndex " + assetOutputIndex + " no longer points at the lender converted output");
-        structural(assetOutputIndex != 0,
-                "the borrower compensation output must occupy filtered slot 0 (the bare loan index)");
+        if (hasBorrowerCompensation) {
+            structural(assetOutputIndex != 0,
+                    "the borrower compensation output must occupy filtered slot 0 (the bare loan index)");
+        }
 
         // WALL 4 — the lender's paid-in-advance output's shape depends on the principal asset.
         // Ada: dosProtection demands flatten == 1 and the coin itself is the converted amount.
@@ -1246,13 +1292,16 @@ public final class LiquidatePayInAdvanceTransactionBuilder {
                             + " than convertedLoanCollateralToPrincipalAmount");
         }
 
-        // The borrower compensation output carries at least the equity in collateral tokens, flatten == 2.
-        TransactionOutput borrowerOutput = assetOutputs.get(0);
-        AssetType collateral = request.loan().datum().collateral().assetType();
-        structural(quantityOf(borrowerOutput, collateral).compareTo(numbers.equity()) >= 0,
-                "the borrower compensation output holds less collateral than the equity");
-        structural(flattenedCount(borrowerOutput) == 2,
-                "the borrower compensation output must be a token plus its min-ada rider (flatten == 2)");
+        // The borrower compensation output, WHEN IT EXISTS (equity > 0), carries at least the equity
+        // in collateral tokens, flatten == 2. At equity == 0 (F0) there is no such output to check.
+        if (hasBorrowerCompensation) {
+            TransactionOutput borrowerOutput = assetOutputs.get(0);
+            AssetType collateral = request.loan().datum().collateral().assetType();
+            structural(quantityOf(borrowerOutput, collateral).compareTo(numbers.equity()) >= 0,
+                    "the borrower compensation output holds less collateral than the equity");
+            structural(flattenedCount(borrowerOutput) == 2,
+                    "the borrower compensation output must be a token plus its min-ada rider (flatten == 2)");
+        }
 
         // ⛔ S-15: the change that comes back must be SPENDABLE NEXT CYCLE.
         //

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutor.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutor.java
@@ -948,7 +948,18 @@ public class LiquidationExecutor {
                 try {
                     transaction = convertRouter.buildConvertLiquidation(assessment, loanUtxo.get(),
                             bondUtxo.get(), configUtxo, lmConfigUtxo,
-                            walletUtxos.isEmpty() ? null : walletUtxos.get(0), oraclesByUnit,
+                            // ⛔ NOMINABLE, not raw. Round 2 of the token-principals slice (fbcf6b1)
+                            // made `walletUtxos` the UNFILTERED listing so the token path could see
+                            // multi-asset utxos — and this line, unchanged, silently went from "first
+                            // ada-only utxo" to "first utxo Blockfrost returns": the OLDEST one at the
+                            // bot's address, which is where the published reference scripts sit. A
+                            // convert would have SPENT the loan_claim_action reference script (the
+                            // 2026-08-24 incident class WalletInputSelection.nominable exists to
+                            // prevent). Sizing this input properly is PR3's job; until then it is the
+                            // first NOMINABLE utxo, exactly what it was before fbcf6b1.
+                            nominableWalletUtxos(walletUtxos).isEmpty()
+                                    ? null : nominableWalletUtxos(walletUtxos).get(0),
+                            oraclesByUnit,
                             account.baseAddress(), validFromMillis, validToMillis);
                 } catch (ConvertLiquidationRouter.NoPoolException e) {
                     // Impossible, not unprofitable — and the fix is the operator's: set this market to

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutor.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutor.java
@@ -12,6 +12,7 @@ import com.bloxbean.cardano.client.backend.blockfrost.service.BFBackendService;
 import com.bloxbean.cardano.client.transaction.spec.Transaction;
 import com.bloxbean.cardano.client.transaction.spec.TransactionOutput;
 import com.bloxbean.cardano.client.transaction.util.TransactionUtil;
+import com.bloxbean.cardano.client.transaction.spec.Asset;
 import com.bloxbean.cardano.client.util.HexUtil;
 import com.bloxbean.cardano.client.address.AddressProvider;
 import com.bloxbean.cardano.client.address.Credential;
@@ -959,21 +960,46 @@ public class LiquidationExecutor {
                 // watch through the endpoint they already use.
             } else {
 
-            log.info("{} is a PAY-IN-ADVANCE liquidation: the bot PAYS the "
-                            + "lender in ada and acquires the collateral, rather than earning a fee",
-                    loanUtxoRef);
+            // ⛔ ANNOUNCE THE ASSET — "PAYS the lender in ada" was only ever true of the ada-principal
+            // shape; a token principal pays out that token, never ada. The AMOUNT is announced
+            // separately below, once the transaction exists and the figure can be MEASURED off it
+            // rather than re-derived — the same "off the finished body" discipline the builder's own
+            // index derivation uses.
+            AssetType payInAdvancePrincipal = assessment.loan().datum().principalAsset();
+            log.info("{} is a PAY-IN-ADVANCE liquidation: the bot PAYS the lender in {} and acquires "
+                            + "the collateral, rather than earning a fee",
+                    loanUtxoRef, payInAdvancePrincipal.isAda() ? "ada" : payInAdvancePrincipal.toUnit());
             // Convert loan: routed to the promoted, submit-incapable pay-in-advance builder. The same
             // window the plain path uses is handed to the router, which derives its own slots from it.
             try {
+                // Part 3 — the balance MarketGate's decide() checks: the sum of the principal asset
+                // across the wallet utxos a real selection could actually spend (nominate(), below) —
+                // never a utxo the selector would refuse, or the gate would allow what the build cannot
+                // fund (T-061's "a remedy is a claim" rule).
+                BigInteger principalBalance = payInAdvancePrincipal.isAda()
+                        ? walletUtxos.stream().filter(WalletInputSelection::nominable)
+                                .map(LedgerCeilings::lovelaceOf).reduce(BigInteger.ZERO, BigInteger::add)
+                        : walletUtxos.stream()
+                                .filter(u -> WalletInputSelection.nominableForToken(u, payInAdvancePrincipal))
+                                .map(u -> WalletInputSelection.tokenQuantityOf(u, payInAdvancePrincipal))
+                                .reduce(BigInteger.ZERO, BigInteger::add);
                 transaction = payInAdvanceRouter.buildConvertLiquidation(assessment, loanUtxo.get(),
-                        bondUtxo.get(), configUtxo, lmConfigUtxo, oraclesByUnit,
+                        bondUtxo.get(), configUtxo, lmConfigUtxo, oraclesByUnit, principalBalance,
                         // T-052 — the router knows the lender payout, this knows the wallet and the
                         // fee ceiling, and neither has to learn the other's job. It computes the
-                        // exact ada it must repay and asks for the SMALLEST input that covers that
+                        // exact amount it must repay and asks for the SMALLEST input that covers that
                         // plus the fee.
-                        lenderPayout -> nominate(walletUtxos, feeCeiling, lenderPayout, loanUtxoRef),
+                        lenderPayout -> nominate(walletUtxos, feeCeiling, payInAdvancePrincipal,
+                                lenderPayout, loanUtxoRef),
                         validFromMillis,
                         validToMillis);
+                // ⛔ THE AMOUNT — "PAYS the lender 1,033,850,000 c48cbb3d…0014df105553444d and
+                // acquires the collateral", never "ada" unless it is ada. Measured off the BUILT body
+                // (payInAdvanceAmountPaid), not re-derived, so this line cannot disagree with what the
+                // transaction actually pays.
+                BigInteger paid = payInAdvanceAmountPaid(transaction, payInAdvancePrincipal);
+                log.info("{} pays the lender {} {} and acquires the collateral", loanUtxoRef, paid,
+                        payInAdvancePrincipal.isAda() ? "lovelace" : payInAdvancePrincipal.toUnit());
             } catch (PayInAdvanceLiquidationRouter.WalletInputTooSmallException e) {
                 // T-061 — the router knows the lender payout and nothing about the wallet; THIS knows
                 // the wallet and the parameters. Neither can state every gate alone, so the message is
@@ -1052,7 +1078,7 @@ public class LiquidationExecutor {
             // that compounds — the biggest input gets consumed by whichever candidate runs first, so
             // a fee-only liquidation can spend the one input a principal-repaying candidate needed.
             Optional<Utxo> plainWalletUtxo =
-                    nominate(walletUtxos, feeCeiling, BigInteger.ZERO, loanUtxoRef);
+                    nominate(walletUtxos, feeCeiling, null, BigInteger.ZERO, loanUtxoRef);
             if (plainWalletUtxo.isEmpty()) {
                 // A refusal, not a failure: true of this candidate against this wallet, reproducible
                 // next cycle, and cured by a top-up. Never quarantined.
@@ -1240,11 +1266,68 @@ public class LiquidationExecutor {
         BigInteger minAdaFunded = minAdaFunded(assessment, transaction);
         // FIX 1/FIX 2: the floors test this margin-EXCLUDED number; the margin is applied separately.
         BigInteger floorProfit = expectedFee.subtract(txFee).subtract(minAdaFunded);
+
+        // ⛔ ECONOMICS GATE — the pay-in-advance TOKEN OUTLAY, token-principals slice.
+        //
+        // ada principal: PricingService.toLovelace is the IDENTITY for ada (no oracle lookup at all),
+        // and this branch is scoped to a NON-ada principal specifically, so the ada gate's arithmetic
+        // is UNCHANGED — pin it. Before this, nothing subtracted the pay-in-advance payout at all: for
+        // ada that is correct (the ada paid out and the collateral value received are the same mark,
+        // through the SAME oracle feed used to build the transaction, so they cancel and only the fee
+        // slice is real profit). For a TOKEN principal that cancellation is NOT guaranteed here: this
+        // gate prices the outlay through PricingService's OWN, independently-sourced feed — which can
+        // disagree with the oracle feed the validator actually priced the transaction against — so it
+        // must be subtracted as a real, separately-priced cost rather than assumed away.
+        //
+        // Direction: PricingService.toLovelace ROUNDS FLOOR (its own javadoc: correct for pricing
+        // EARNED amounts, which is what expectedFee above is). Applied to an OUTLAY, floor would
+        // UNDERSTATE the cost and flatter the bot — the wrong direction for a number being subtracted.
+        // So the outlay is taken at floor()+1: a cheap, always-safe correction to the ceiling side
+        // (never below the true value; at most one lovelace above it) without needing Rational's own
+        // ceil() through a code path PricingService does not expose.
+        String tokenOutlayDetail = "";
+        if (isPayInAdvanceRoute(assessment)) {
+            AssetType payInAdvancePrincipal = assessment.loan().datum().principalAsset();
+            if (!payInAdvancePrincipal.isAda()) {
+                BigInteger payout = payInAdvanceAmountPaid(transaction, payInAdvancePrincipal);
+                FluidOracleClient client = oracleClient.getIfAvailable();
+                if (client == null) {
+                    String priceDetail = ("PRICE_UNAVAILABLE: no oracle client bean, so the pay-in-advance "
+                            + "outlay of %s %s cannot be priced into lovelace")
+                            .formatted(payout, payInAdvancePrincipal.toUnit());
+                    decisionLog.record(decision(assessment, now, LiquidationDecision.Outcome.PRICE_UNAVAILABLE,
+                            "PRICE_UNAVAILABLE", priceDetail));
+                    log.info("the pay-in-advance liquidation of {} was refused: {}",
+                            assessment.loan().utxoRef(), priceDetail);
+                    return;
+                }
+                PricingService.Priced priced = new PricingService(client)
+                        .toLovelace(payInAdvancePrincipal, payout, now);
+                if (!priced.isPriced()) {
+                    PricingService.PriceRefusal refusal = priced.refusal();
+                    String priceDetail = ("PRICE_UNAVAILABLE: cannot price the pay-in-advance outlay of "
+                            + "%s %s into lovelace — %s (feed window [%s,%s], age %sms at %s)").formatted(
+                            payout, payInAdvancePrincipal.toUnit(), refusal.reason(),
+                            refusal.feedValidFrom(), refusal.feedValidTo(), refusal.feedAgeMillis(), now);
+                    decisionLog.record(decision(assessment, now, LiquidationDecision.Outcome.PRICE_UNAVAILABLE,
+                            "PRICE_UNAVAILABLE", priceDetail));
+                    log.info("the pay-in-advance liquidation of {} was refused: {}",
+                            assessment.loan().utxoRef(), priceDetail);
+                    return;
+                }
+                BigInteger tokenOutlayLovelace = outlayCeilBiased(priced.lovelace());
+                floorProfit = floorProfit.subtract(tokenOutlayLovelace);
+                tokenOutlayDetail = " - token outlay %s %s (%s lovelace, ceil-biased)"
+                        .formatted(payout, payInAdvancePrincipal.toUnit(), tokenOutlayLovelace);
+            }
+        }
+
         BigInteger margin = configuration.getProfitMarginLovelace();
         BigInteger expectedProfit = floorProfit.subtract(margin);
 
-        String detail = "fee slice %s lovelace - tx fee %s - min-ada %s = floor %s; - margin %s = %s"
-                .formatted(expectedFee, txFee, minAdaFunded, floorProfit, margin, expectedProfit);
+        String detail = "fee slice %s lovelace - tx fee %s - min-ada %s%s = floor %s; - margin %s = %s"
+                .formatted(expectedFee, txFee, minAdaFunded, tokenOutlayDetail, floorProfit, margin,
+                        expectedProfit);
 
         int size;
         String cborHex;
@@ -1754,6 +1837,21 @@ public class LiquidationExecutor {
      * belongs in the profitability floor is an ECONOMICS decision and is not made here: adding it
      * would be a new cost term, not a correction of a miscount. Recorded in findings §57 as open.
      */
+    /**
+     * ⛔ THE DIRECTION — extracted so it is unit-testable on its own, without a whole built
+     * transaction. {@link PricingService#toLovelace} rounds {@code floor()}, which is correct for
+     * pricing an EARNED amount (this method's caller's {@code expectedFee} term) but WRONG for an
+     * OUTLAY: floor understates the cost and flatters the bot. {@code floor() + 1} is a cheap,
+     * always-safe correction toward the ceiling side (never below the true value, at most one
+     * lovelace above it) — see {@code record()}'s own comment for why a fresh {@code Rational.ceil()}
+     * call is not used instead. A mutant that drops the {@code + 1} (i.e. uses the bare floor for the
+     * outlay) must be caught by a test that can tell the two apart — see
+     * {@code LiquidationExecutorTest#outlayCeilBiasedAddsOneToTheFlooredPrice}.
+     */
+    static BigInteger outlayCeilBiased(BigInteger flooredLovelace) {
+        return flooredLovelace.add(BigInteger.ONE);
+    }
+
     private boolean isPayInAdvanceRoute(LiquidationAssessment assessment) {
         if (!assessment.bond().datum().shouldLiquidationConvertToPrincipal()) {
             return false;
@@ -1895,15 +1993,47 @@ public class LiquidationExecutor {
     }
 
     /**
+     * ⚠ A conservative CEILING for the min-ada rider a token-principal lender output needs, sized for
+     * wallet-selection headroom rather than computed from live protocol parameters — {@code
+     * LedgerCeilings} has no min-ada helper and this class does not derive one (out of this slice's
+     * file allowlist). Over-estimating is the safe direction here (this class's own javadoc, and
+     * {@link WalletInputSelection}'s): a single-asset min-ada output on {@code coinsPerUtxoSize} 4310
+     * measures well under 1.5 ada in every fixture seen so far, so 2 ada leaves real headroom rather
+     * than sitting on the edge.
+     */
+    private static final BigInteger TOKEN_PRINCIPAL_MIN_ADA_CEILING = BigInteger.valueOf(2_000_000L);
+
+    /**
      * T-052 — nominate the wallet input for ONE candidate: the smallest that covers the fee ceiling
-     * plus whatever extra ada this liquidation itself must pay out.
+     * plus whatever extra outlay this liquidation itself must pay out.
+     * <p>
+     * Part 2 of the token-principals slice — TOKEN-AWARE. When {@code principal} is a real token AND
+     * there is an outlay to fund, the nominated utxo must carry {@code extraOutlay} of THAT token
+     * (never lovelace) plus enough ada alongside it for the fee ceiling and the min-ada rider on the
+     * lender's output — {@link WalletInputSelection#smallestSufficientToken}. The ada-only path below
+     * is otherwise BYTE-IDENTICAL to before: same selection, same log shape.
      *
-     * @param extraOutlay ada this transaction pays from the bot's own wallet beyond the fee — the
-     *                    lender payout on the principal-repaying path, and {@code ZERO} on the
-     *                    fee-only path, which is the distinction the whole ticket is about
+     * @param principal   the loan's principal asset; irrelevant (and may be {@code null}) when
+     *                    {@code extraOutlay} is zero — the fee-only path never reads it
+     * @param extraOutlay this transaction pays out from the bot's own wallet beyond the fee, in
+     *                    PRINCIPAL units — ada for an ada principal, the principal's own base units for
+     *                    a token one — and {@code ZERO} on the fee-only path, which is the distinction
+     *                    the whole ticket is about
      */
     private Optional<Utxo> nominate(List<Utxo> walletUtxos, Optional<BigInteger> feeCeiling,
-                                    BigInteger extraOutlay, String loanUtxoRef) {
+                                    AssetType principal, BigInteger extraOutlay, String loanUtxoRef) {
+        if (principal != null && !principal.isAda() && extraOutlay.signum() > 0) {
+            BigInteger requiredAda = feeCeiling.orElse(BigInteger.ZERO).add(TOKEN_PRINCIPAL_MIN_ADA_CEILING);
+            Optional<Utxo> chosen = WalletInputSelection.smallestSufficientToken(
+                    walletUtxos, principal, extraOutlay, requiredAda);
+            chosen.ifPresent(utxo -> log.info("{} nominates wallet utxo {}#{} ({} {} + {} lovelace) for "
+                            + "a requirement of {} {} + {} lovelace (fee ceiling + min-ada rider){}",
+                    loanUtxoRef, utxo.getTxHash(), utxo.getOutputIndex(),
+                    WalletInputSelection.tokenQuantityOf(utxo, principal), principal.toUnit(),
+                    LedgerCeilings.lovelaceOf(utxo), extraOutlay, principal.toUnit(), requiredAda,
+                    feeCeiling.isPresent() ? "" : " (fee ceiling unavailable this cycle)"));
+            return chosen;
+        }
         Optional<Utxo> chosen = feeCeiling
                 .map(ceiling -> WalletInputSelection.smallestSufficient(
                         walletUtxos, ceiling.add(extraOutlay)))
@@ -1915,6 +2045,47 @@ public class LiquidationExecutor {
                 feeCeiling.map(Object::toString).orElse("an unknown fee"), extraOutlay,
                 feeCeiling.isPresent() ? "" : " (largest, protocol params unavailable)"));
         return chosen;
+    }
+
+    /**
+     * The amount actually paid to the lender on the pay-in-advance path, MEASURED off the built
+     * transaction's asset-manager outputs rather than re-derived — the announce line's source of
+     * truth, so it can never disagree with what the transaction pays. For ada: the ada-only
+     * asset-manager output's coin (the borrower compensation output, when the collateral is a token,
+     * carries no ada of its own beyond its min-ada rider and no multi-asset lender output competes
+     * with it here). For a token principal: the asset-manager output's quantity of {@code principal}.
+     */
+    private BigInteger payInAdvanceAmountPaid(Transaction transaction, AssetType principal) {
+        String assetManagerCredential = registry.getAssetManagerSpendScriptHash();
+        BigInteger paid = BigInteger.ZERO;
+        for (TransactionOutput output : transaction.getBody().getOutputs()) {
+            if (!assetManagerCredential.equals(paymentCredentialOf(output.getAddress()))) {
+                continue;
+            }
+            if (principal.isAda()) {
+                boolean carriesTokens = output.getValue().getMultiAssets() != null
+                        && !output.getValue().getMultiAssets().isEmpty();
+                if (!carriesTokens) {
+                    paid = paid.max(output.getValue().getCoin());
+                }
+            } else {
+                paid = paid.max(quantityOf(output, principal));
+            }
+        }
+        return paid;
+    }
+
+    /** The quantity of {@code asset} an output's value holds. Zero if it holds none. */
+    private static BigInteger quantityOf(TransactionOutput output, AssetType asset) {
+        if (output.getValue().getMultiAssets() == null) {
+            return BigInteger.ZERO;
+        }
+        return output.getValue().getMultiAssets().stream()
+                .filter(multiAsset -> multiAsset.getPolicyId().equalsIgnoreCase(asset.policyId()))
+                .flatMap(multiAsset -> multiAsset.getAssets().stream())
+                .filter(a -> HexUtil.encodeHexString(a.getNameAsBytes()).equalsIgnoreCase(asset.assetName()))
+                .map(Asset::getValue)
+                .reduce(BigInteger.ZERO, BigInteger::add);
     }
 
     /**

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutor.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutor.java
@@ -740,13 +740,30 @@ public class LiquidationExecutor {
         //
         // Nothing is loosened for LIVE: a liquidation still cannot be built without a wallet input,
         // and the refusal is now explicit and counted rather than a silent early return.
-        List<Utxo> walletUtxos = nominableWalletUtxos();
-        if (walletUtxos.isEmpty()) {
+        List<Utxo> allWalletUtxos = appUtxoService.listWalletUtxo();
+        if (nominableWalletUtxos(allWalletUtxos).isEmpty()) {
             log.warn("{} buildable candidate(s) found but no ada-only wallet utxo is available, so "
                     + "none can be built; the scan above is still a complete record of what was seen "
                     + "and priced", buildable.size());
             return;
         }
+        // ⛔ F3/F7 (round 2) — THE FULL WALLET, NOT THE GATE'S OWN ADA-ONLY SUBSET.
+        //
+        // nominableWalletUtxos() above answers ONE question — "is there an ada-only utxo to fund
+        // ANYTHING with at all" — and that gate is correct to keep: every liquidation, whatever its
+        // principal, needs one for the fee/collateral input. But before this fix its FILTERED RESULT
+        // was what got threaded through the rest of this method, and every multi-asset (token-
+        // carrying) wallet utxo was gone before nominate() or the principal-balance sum ever ran. A
+        // TOKEN-PRINCIPAL candidate's market-gate balance was therefore ALWAYS zero, and no wallet
+        // utxo the operator could ever fund would change that — the USDM-funded bot in this ticket's
+        // own motivating scenario could not have been fixed by F0 alone.
+        //
+        // WalletInputSelection's own functions each filter for their OWN purpose already —
+        // `nominable` (ada-only) for the fee/collateral path, `nominableForToken` for the
+        // token-principal one, both applied downstream (nominate(), the principal-balance sum,
+        // collateralGate, walletDiagnosis) — so handing them the UNFILTERED wallet is what makes each
+        // one see what it is actually looking for.
+        List<Utxo> walletUtxos = allWalletUtxos;
         // T-052 — the fee ceiling every liquidation must cover regardless of its shape. The
         // principal-repaying path adds its lender payout on top; the fee-only path needs nothing more,
         // which is the whole point: it must not be made to demand an input sized for the other case.
@@ -981,6 +998,16 @@ public class LiquidationExecutor {
                                 .map(LedgerCeilings::lovelaceOf).reduce(BigInteger.ZERO, BigInteger::add)
                         : walletUtxos.stream()
                                 .filter(u -> WalletInputSelection.nominableForToken(u, payInAdvancePrincipal))
+                                // ⛔ F7 (round 2) — count ONLY utxos the selector could actually pick.
+                                // nominableForToken alone says "carries the token, no datum, no
+                                // reference script" — it says NOTHING about whether the utxo also
+                                // carries enough ada to fund a build, so a 2,000 USDM + 1.4 ADA utxo
+                                // passed it and inflated the balance MarketGate saw by a candidate the
+                                // wallet could never actually fund (M13). requiredAda mirrors
+                                // nominate()'s own formula exactly — the same figure the SELECTOR this
+                                // balance is supposed to describe is bound by.
+                                .filter(u -> LedgerCeilings.lovelaceOf(u).compareTo(feeCeiling
+                                        .orElse(BigInteger.ZERO).add(TOKEN_PRINCIPAL_MIN_ADA_CEILING)) >= 0)
                                 .map(u -> WalletInputSelection.tokenQuantityOf(u, payInAdvancePrincipal))
                                 .reduce(BigInteger.ZERO, BigInteger::add);
                 transaction = payInAdvanceRouter.buildConvertLiquidation(assessment, loanUtxo.get(),
@@ -1032,20 +1059,33 @@ public class LiquidationExecutor {
                 // lets a reader tell the two triggers apart.
                 //
                 // ⛔ AND THE REMEDY IS CONDITIONAL, because only ONE of the two triggers has one.
-                // "Set this market to CONVERT" is sound advice for a non-ada principal — the convert
+                // "Set this market to CONVERT" is routable advice for a non-ada principal — the convert
                 // router genuinely supports one (it resolves a collateral/principal pool and prices the
-                // principal leg through its own feed). It is WRONG advice for non-positive equity,
-                // which says nothing about the mechanism and everything about this loan right now.
+                // principal leg through its own feed). It is WRONG advice for a negative equity, which
+                // says nothing about the mechanism and everything about this loan right now.
                 // ⚠ And the cost of the wrong advice is not a wasted cycle: `action` is a MARKET-level
                 // setting keyed by principal asset, so taking it re-routes EVERY loan in that market
                 // away from pay-in-advance. The substitution between these two mechanisms is the one
                 // this file already calls "the one substitution that spends money nobody authorised".
                 // An equity-sign refusal must never be the reason an operator makes it.
+                //
+                // ⛔ REMEDY WORDING (Machine Owner ruling, 2026-09-09) — "routable" is not "profitable".
+                // For the live USDM loan the FLDT/USDM Minswap pool returns ~827M against a 980M
+                // minimum_receive: a convert order there would build, submit, and REFUND — it does not
+                // fill the debt. Until PR3's POOL_TOO_THIN pre-check exists, the remedy must carry that
+                // caveat rather than read as an unconditional fix.
+                // ⚠ On feat/token-principals the router's outright non-ada-principal refusal no longer
+                // exists (6d8427f), and F0 (round 2) means the negative-equity trigger this fires from
+                // is unreachable in practice (LoanFinance.redeemerEquity floors it to zero) — so this
+                // branch is a rare, defence-in-depth line here. `main` still carries the outright
+                // non-ada refusal, and this wording lands there via PR2's merge — so the conditional
+                // shape (and its pair test) stays intact rather than being simplified away.
                 String principalUnit = assessment.loan().datum().principalAsset().toUnit();
                 String remedy = assessment.loan().datum().principalAsset().isAda()
                         ? ""
                         : "; this market's principal is not ada — if it should still be liquidated, set "
-                                + "its action to CONVERT so Minswap fronts the principal instead";
+                                + "its action to CONVERT — only if a Minswap pool can fill the debt; a "
+                                + "thin pool refunds rather than fills";
                 log.info("the pay-in-advance liquidation of {} (principal {}) was refused: {} — not "
                                 + "quarantined, reconsidered every cycle{}",
                         loanUtxoRef, principalUnit, e.getMessage(), remedy);
@@ -1267,44 +1307,70 @@ public class LiquidationExecutor {
         // FIX 1/FIX 2: the floors test this margin-EXCLUDED number; the margin is applied separately.
         BigInteger floorProfit = expectedFee.subtract(txFee).subtract(minAdaFunded);
 
-        // ⛔ ECONOMICS GATE — the pay-in-advance TOKEN OUTLAY, token-principals slice.
+        // ⛔ ECONOMICS GATE — THE REAL TRADE, token-principals slice, F1 (round 2).
         //
         // ada principal: PricingService.toLovelace is the IDENTITY for ada (no oracle lookup at all),
         // and this branch is scoped to a NON-ada principal specifically, so the ada gate's arithmetic
-        // is UNCHANGED — pin it. Before this, nothing subtracted the pay-in-advance payout at all: for
-        // ada that is correct (the ada paid out and the collateral value received are the same mark,
-        // through the SAME oracle feed used to build the transaction, so they cancel and only the fee
-        // slice is real profit). For a TOKEN principal that cancellation is NOT guaranteed here: this
-        // gate prices the outlay through PricingService's OWN, independently-sourced feed — which can
-        // disagree with the oracle feed the validator actually priced the transaction against — so it
-        // must be subtracted as a real, separately-priced cost rather than assumed away.
+        // is UNCHANGED — pin it. For ada the ada paid out and the collateral value received are the
+        // same mark, through the SAME oracle feed used to build the transaction, so they cancel and
+        // floorProfit above (fee slice - tx fee - min-ada) already is the real number — untouched here.
         //
-        // Direction: PricingService.toLovelace ROUNDS FLOOR (its own javadoc: correct for pricing
-        // EARNED amounts, which is what expectedFee above is). Applied to an OUTLAY, floor would
-        // UNDERSTATE the cost and flatter the bot — the wrong direction for a number being subtracted.
-        // So the outlay is taken at floor()+1: a cheap, always-safe correction to the ceiling side
-        // (never below the true value; at most one lovelace above it) without needing Rational's own
-        // ceil() through a code path PricingService does not expose.
+        // For a TOKEN principal that cancellation is NOT guaranteed: F1 found that the PREVIOUS fix
+        // subtracted the outlay ALONE against expectedFee (the liquidation-fee SLICE, a small number),
+        // which is arithmetically always negative — pinned mainnet figures 200,427,602 lovelace fee
+        // slice minus a 4,789,432,924-lovelace outlay is -4,591 ADA on a genuinely profitable trade.
+        // The missing term was the CREDIT for what the bot actually acquires: the FULL collateral
+        // share it takes (collateralAmount - equity, fee included — LiquidatePayInAdvanceTransaction
+        // Builder's own botCollateral, S-15's named output), not just the liquidationFee slice.
+        //
+        // floorProfit is therefore REPLACED (not added to) for this branch: acquired - outlay - txFee
+        // - riders, exactly the plain path's shape (fee slice - txFee - riders) with "fee slice"
+        // widened to the REAL trade this path actually makes. Both acquired and outlay are priced
+        // through PricingService, at the SAME instant (`now`) — never mixed with collateralFeed above,
+        // which is a DIFFERENT, validator-pinned source that can disagree with PricingService's own.
+        //
+        // Direction: PricingService.toLovelace ROUNDS FLOOR — correct for acquired (an EARNED amount)
+        // and WRONG for the outlay, where floor would UNDERSTATE the cost and flatter the bot. So the
+        // outlay alone is taken at floor()+1 (outlayCeilBiased): a cheap, always-safe correction to the
+        // ceiling side (never below the true value; at most one lovelace above it).
         String tokenOutlayDetail = "";
         if (isPayInAdvanceRoute(assessment)) {
             AssetType payInAdvancePrincipal = assessment.loan().datum().principalAsset();
             if (!payInAdvancePrincipal.isAda()) {
                 BigInteger payout = payInAdvanceAmountPaid(transaction, payInAdvancePrincipal);
+                AssetType collateralAsset = assessment.loan().datum().collateral().assetType();
+                BigInteger acquiredQuantity = assessment.loan().collateralAmount().subtract(assessment.equity());
                 FluidOracleClient client = oracleClient.getIfAvailable();
                 if (client == null) {
-                    String priceDetail = ("PRICE_UNAVAILABLE: no oracle client bean, so the pay-in-advance "
-                            + "outlay of %s %s cannot be priced into lovelace")
-                            .formatted(payout, payInAdvancePrincipal.toUnit());
+                    String priceDetail = ("PRICE_UNAVAILABLE: no oracle client bean, so neither the "
+                            + "acquired collateral (%s %s) nor the pay-in-advance outlay (%s %s) can be "
+                            + "priced into lovelace").formatted(acquiredQuantity, collateralAsset.toUnit(),
+                            payout, payInAdvancePrincipal.toUnit());
                     decisionLog.record(decision(assessment, now, LiquidationDecision.Outcome.PRICE_UNAVAILABLE,
                             "PRICE_UNAVAILABLE", priceDetail));
                     log.info("the pay-in-advance liquidation of {} was refused: {}",
                             assessment.loan().utxoRef(), priceDetail);
                     return;
                 }
-                PricingService.Priced priced = new PricingService(client)
-                        .toLovelace(payInAdvancePrincipal, payout, now);
-                if (!priced.isPriced()) {
-                    PricingService.PriceRefusal refusal = priced.refusal();
+                PricingService pricingService = new PricingService(client);
+                PricingService.Priced pricedAcquired = pricingService.toLovelace(collateralAsset,
+                        acquiredQuantity, now);
+                if (!pricedAcquired.isPriced()) {
+                    PricingService.PriceRefusal refusal = pricedAcquired.refusal();
+                    String priceDetail = ("PRICE_UNAVAILABLE: cannot price the acquired collateral of "
+                            + "%s %s into lovelace — %s (feed window [%s,%s], age %sms at %s)").formatted(
+                            acquiredQuantity, collateralAsset.toUnit(), refusal.reason(),
+                            refusal.feedValidFrom(), refusal.feedValidTo(), refusal.feedAgeMillis(), now);
+                    decisionLog.record(decision(assessment, now, LiquidationDecision.Outcome.PRICE_UNAVAILABLE,
+                            "PRICE_UNAVAILABLE", priceDetail));
+                    log.info("the pay-in-advance liquidation of {} was refused: {}",
+                            assessment.loan().utxoRef(), priceDetail);
+                    return;
+                }
+                PricingService.Priced pricedOutlay = pricingService.toLovelace(payInAdvancePrincipal,
+                        payout, now);
+                if (!pricedOutlay.isPriced()) {
+                    PricingService.PriceRefusal refusal = pricedOutlay.refusal();
                     String priceDetail = ("PRICE_UNAVAILABLE: cannot price the pay-in-advance outlay of "
                             + "%s %s into lovelace — %s (feed window [%s,%s], age %sms at %s)").formatted(
                             payout, payInAdvancePrincipal.toUnit(), refusal.reason(),
@@ -1315,10 +1381,19 @@ public class LiquidationExecutor {
                             assessment.loan().utxoRef(), priceDetail);
                     return;
                 }
-                BigInteger tokenOutlayLovelace = outlayCeilBiased(priced.lovelace());
-                floorProfit = floorProfit.subtract(tokenOutlayLovelace);
-                tokenOutlayDetail = " - token outlay %s %s (%s lovelace, ceil-biased)"
-                        .formatted(payout, payInAdvancePrincipal.toUnit(), tokenOutlayLovelace);
+                BigInteger acquiredLovelace = pricedAcquired.lovelace();
+                BigInteger tokenOutlayLovelace = outlayCeilBiased(pricedOutlay.lovelace());
+                // REPLACES floorProfit — expectedFee (the fee-slice-only figure) is not part of this
+                // trade's real economics; acquiredLovelace already includes it (botCollateral =
+                // collateralAmount - equity, the FULL share, fee included).
+                floorProfit = acquiredLovelace.subtract(tokenOutlayLovelace).subtract(txFee).subtract(minAdaFunded);
+                // The fee-slice number the OUTER detail line below is about to print is not this
+                // trade's real economics (F1) — REPLACED means exactly that: ignore "fee slice .. =
+                // floor" for this candidate and read this bracket instead.
+                tokenOutlayDetail = (" [REPLACED (F1, token principal): acquired %s %s (%s lovelace) - "
+                        + "outlay %s %s (%s lovelace, ceil-biased)]")
+                        .formatted(acquiredQuantity, collateralAsset.toUnit(), acquiredLovelace,
+                                payout, payInAdvancePrincipal.toUnit(), tokenOutlayLovelace);
             }
         }
 
@@ -1809,13 +1884,28 @@ public class LiquidationExecutor {
         //
         // ⇒ The discriminator is now the ROUTING'S OWN — the same MarketGate call, on the same loan —
         // rather than a proxy for it. A proxy that was true when written is exactly what drifted.
+        //
+        // ⛔ F2 (round 2) — IDENTIFY THE RIDER BY ROLE, NEVER BY "TOKEN-BEARING AT MY ADDRESS".
+        // "carriesTokens" above (2026-09-05's fix) narrowed the SCOPE (which routes) but not the
+        // PREDICATE (which outputs), and the predicate is what a token-principal candidate breaks: the
+        // wallet utxo funding the lender's principal payout can carry MORE of that principal (e.g.
+        // USDM) than the payout needs, and the leftover comes back as the bot's own CHANGE at the same
+        // address — a token-bearing output that is not S-15's collateral rider at all. "carriesTokens"
+        // cannot tell the two apart, so it counted the bot's own returning USDM as an expense.
+        //
+        // The S-15 rider is identified by what it actually IS: the output the builder pays the
+        // ACQUIRED COLLATERAL to, by name (LiquidatePayInAdvanceTransactionBuilder's named collateral
+        // output). Filtering on the COLLATERAL asset specifically — never "any asset" — is filtering by
+        // ROLE: a principal-token change output does not carry the collateral asset (a single loan has
+        // exactly one collateral type), so it can never be mistaken for the rider, regardless of how
+        // much of the principal happens to ride along in the bot's own wallet input.
         if (isPayInAdvanceRoute(assessment)) {
+            AssetType collateralAsset = assessment.loan().datum().collateral().assetType();
             BigInteger rider = BigInteger.ZERO;
             for (TransactionOutput output : transaction.getBody().getOutputs()) {
                 boolean mine = account != null && account.baseAddress().equals(output.getAddress());
-                boolean carriesTokens = output.getValue().getMultiAssets() != null
-                        && !output.getValue().getMultiAssets().isEmpty();
-                if (mine && carriesTokens) {
+                boolean isTheCollateralRider = quantityOf(output, collateralAsset).signum() > 0;
+                if (mine && isTheCollateralRider) {
                     rider = rider.add(output.getValue().getCoin());
                 }
             }
@@ -1961,9 +2051,18 @@ public class LiquidationExecutor {
      * long as it sat in the wallet — and a refusal is not quarantined, so nothing would ever break
      * the loop out of it. Filtering it out here costs one clause; not filtering it costs the slice
      * its entire output, with no symptom louder than a repeated refusal reason.
+     * <p>
+     * ⛔ <b>THIS IS A GATE, NOT A SELECTION LIST — its RETURN VALUE must never be threaded through the
+     * rest of a cycle (F3, round 2).</b> It used to be: {@code cycle()} called this with no argument,
+     * fetched the wallet itself, filtered to ada-only, and handed that ada-only subset to everything
+     * downstream — including the token-principal balance sum and {@code nominate()}'s token branch.
+     * Every multi-asset (token-carrying) wallet utxo was therefore gone before either ever ran, so a
+     * token-principal candidate's market-gate balance was ALWAYS zero regardless of what the wallet
+     * actually held — discovered writing the first executor-level test to fund one for real. The
+     * caller now passes the wallet in (fetched once) and keeps the UNFILTERED list for everything
+     * else; this method now answers only "is there at least one ada-only utxo to fund ANYTHING with".
      */
-    private List<Utxo> nominableWalletUtxos() {
-        List<Utxo> walletUtxos = appUtxoService.listWalletUtxo();
+    private List<Utxo> nominableWalletUtxos(List<Utxo> walletUtxos) {
         if (walletUtxos.isEmpty()) {
             log.warn("No wallet UTXOs found for account: {}", account.baseAddress());
             return List.of();
@@ -2023,6 +2122,30 @@ public class LiquidationExecutor {
     private Optional<Utxo> nominate(List<Utxo> walletUtxos, Optional<BigInteger> feeCeiling,
                                     AssetType principal, BigInteger extraOutlay, String loanUtxoRef) {
         if (principal != null && !principal.isAda() && extraOutlay.signum() > 0) {
+            // ⛔ F8 (round 2) — WHICH RIDERS requiredAda COVERS, AND WHICH IT DOES NOT.
+            //
+            // requiredAda = feeCeiling + TOKEN_PRINCIPAL_MIN_ADA_CEILING covers the fee ceiling PLUS
+            // ONE rider: the min-ada on the LENDER's own converted output. It does NOT sum the S-15
+            // collateral rider (the bot's own acquired-collateral output — measured 1,176,630 lovelace
+            // on the pinned rig) or the change output's own min-ada. Measured together those riders
+            // exceed what a bare 2 ADA ceiling covers.
+            //
+            // That is a DELIBERATE reliance on CCL's balancer, not an oversight: ReferenceScriptSafe
+            // UtxoSelection's own selector (wired in LiquidatePayInAdvanceTransactionBuilder#complete)
+            // picks MORE ada-only wallet utxos automatically whenever the nominated one falls short
+            // during balancing — the exact mechanism trap 21 / T-050 already rely on for the plain
+            // path's fee. It only holds when the wallet actually CARRIES ada-only headroom besides the
+            // token-carrying utxo nominated here, so a wallet that does not is logged rather than
+            // discovered for the first time at build failure.
+            long adaOnlySpares = walletUtxos.stream().filter(WalletInputSelection::nominable).count();
+            if (adaOnlySpares < 2) {
+                log.warn("{} nominates a token-principal wallet utxo with only {} ada-only utxo(s) "
+                                + "besides it; the S-15 collateral rider and the change output's own "
+                                + "min-ada are funded by CCL's balancer picking MORE of them during "
+                                + "build, not by requiredAda here — fund at least 2 ada-only utxos "
+                                + "alongside the {} wallet utxo to be safe",
+                        loanUtxoRef, adaOnlySpares, principal.toUnit());
+            }
             BigInteger requiredAda = feeCeiling.orElse(BigInteger.ZERO).add(TOKEN_PRINCIPAL_MIN_ADA_CEILING);
             Optional<Utxo> chosen = WalletInputSelection.smallestSufficientToken(
                     walletUtxos, principal, extraOutlay, requiredAda);

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/LoanFinance.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/LoanFinance.java
@@ -51,6 +51,32 @@ public final class LoanFinance {
                 .orElseThrow(() -> new ArithmeticException("oracle price is zero"));
     }
 
+    /**
+     * {@code finance.convertFromAToBWithOracles} (WALL 1 of the token-principal pay-in-advance slice)
+     * — converts an amount denominated in {@code a}'s currency into {@code b}'s currency through two
+     * oracle feeds, in the validator's <b>exact</b> composition:
+     * {@code ceil( fromLovelace( toLovelace(aAmount, aFeed), bFeed ) )} — ONE {@link Rational#ceil()},
+     * at the END, over the exact rational.
+     * <p>
+     * <b>This is NOT {@code toLovelace(aAmount, aFeed).ceil()}.</b> That shortcut — ceiling the
+     * intermediate lovelace figure and never dividing by {@code bFeed} at all — coincides with this
+     * method only when {@code bFeed} is the 1:1 unit feed ({@link OraclePriceFeed#unit()}, i.e. an ada
+     * {@code b}), which is exactly why the ada-principal pay-in-advance path never caught it: for a
+     * token {@code b} it under-divides by the token's own price and pays a LOVELACE-SIZED figure as if
+     * it were the token — measured 4.63× too much at the pinned mainnet candidate (4,789,432,923
+     * instead of 1,033,850,765 USDM base units).
+     * <p>
+     * For {@code a} = the collateral leg and {@code b} = the principal leg, this is
+     * {@code convertedLoanCollateralToPrincipalAmount} — a VALIDATOR-CHECKED figure
+     * ({@code validate_repayment_output} requires {@code quantity_of(output, principalAsset) >=} this
+     * exact number), never economics: callers must not round it any other way.
+     */
+    public static BigInteger convertFromAToBWithOracles(OraclePriceFeed aFeed, OraclePriceFeed bFeed,
+                                                         Rational aAmount) {
+        Rational aAmountInLovelace = toLovelace(aAmount, aFeed);
+        return fromLovelace(aAmountInLovelace, bFeed).ceil();
+    }
+
     // ---- debt ---------------------------------------------------------------------------
 
     /** {@code rational.new(datum.interestRate, 10000)} — the scaling {@code loan_claim_action.ak:83} applies. */

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/MarketGate.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/MarketGate.java
@@ -71,7 +71,17 @@ public final class MarketGate {
         /** The market's action is {@code CONVERT}, so pay-in-advance is not the chosen mechanism here. */
         MARKET_ACTION_IS_CONVERT,
         /** {@code ANTICIPATE}, but the cap is below what the protocol requires the bot to front. */
-        ABOVE_MARKET_CAP
+        ABOVE_MARKET_CAP,
+        /**
+         * {@code ANTICIPATE}, under the cap, but the bot's own NOMINABLE wallet balance of the
+         * principal asset is below what the protocol requires it to front. Distinct from
+         * {@link #ABOVE_MARKET_CAP} on purpose — the two demand different operator responses ("fund
+         * the wallet" vs "raise the cap") and collapsing them into one refusal would hide which is
+         * true. Part 3 of the token-principals slice: before this, {@code decide} had no balance term
+         * at all — {@code required.min(cap)} — so a bot holding zero of the principal with a generous
+         * cap passed this gate and died in the build.
+         */
+        INSUFFICIENT_BALANCE
     }
 
     /**
@@ -126,8 +136,13 @@ public final class MarketGate {
      *
      * @param principal the loan's principal asset — the market
      * @param required  {@code convertedLoanCollateralToPrincipalAmount}: what must be fronted
+     * @param balance   the sum of {@code principal} across the bot's own NOMINABLE wallet UTxOs — the
+     *                  ones a real wallet selection could actually spend (Part 2 of the
+     *                  token-principals slice). <b>Never a UTxO the selector would refuse</b> — that
+     *                  is the lie the executor's T-061 javadoc warns about: a remedy is a claim, and
+     *                  "fund the wallet" must be sufficient.
      */
-    public Decision decide(AssetType principal, BigInteger required) {
+    public Decision decide(AssetType principal, BigInteger required, BigInteger balance) {
         String unit = principal == null ? null : principal.toUnit();
         Mode effective = effectiveMode(principal);
 
@@ -152,13 +167,21 @@ public final class MarketGate {
         BigInteger cap = Objects.requireNonNull(marketFor(principal).getCap(),
                 "action: ANTICIPATE without a cap should have aborted startup");
 
-        // min(balance, cap), exactly as specified.
-        BigInteger anticipatable = required.min(cap);
+        // ⛔ anticipatable = min(balance, cap) — MADE TRUE, not merely claimed. Before Part 3 the code
+        // was `required.min(cap)`, so a bot holding ZERO of the principal with a generous cap still
+        // computed anticipatable == required and passed. On the ada path the downstream wallet
+        // nomination was the de-facto balance check; on a token path there was none at all.
+        BigInteger anticipatable = balance.min(cap);
         if (anticipatable.compareTo(required) < 0) {
-            return new Decision(anticipatable, required, cap, Refusal.ABOVE_MARKET_CAP,
-                    ("market %s is capped at %s but this candidate requires %s to be fronted; the "
+            boolean balanceLimited = balance.compareTo(cap) < 0;
+            Refusal why = balanceLimited ? Refusal.INSUFFICIENT_BALANCE : Refusal.ABOVE_MARKET_CAP;
+            String detail = balanceLimited
+                    ? ("market %s holds %s %s, needs %s to front this candidate (cap %s)")
+                            .formatted(unit, balance, unit, required, cap)
+                    : ("market %s is capped at %s but this candidate requires %s to be fronted; the "
                             + "protocol does not allow fronting part of a loan, so it is refused "
-                            + "rather than reduced").formatted(unit, cap, required));
+                            + "rather than reduced").formatted(unit, cap, required);
+            return new Decision(anticipatable, required, cap, why, detail);
         }
         return new Decision(anticipatable, required, cap, null,
                 "market " + unit + " allows " + required + " of " + cap);

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/MarketGate.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/MarketGate.java
@@ -173,14 +173,22 @@ public final class MarketGate {
         // nomination was the de-facto balance check; on a token path there was none at all.
         BigInteger anticipatable = balance.min(cap);
         if (anticipatable.compareTo(required) < 0) {
-            boolean balanceLimited = balance.compareTo(cap) < 0;
-            Refusal why = balanceLimited ? Refusal.INSUFFICIENT_BALANCE : Refusal.ABOVE_MARKET_CAP;
-            String detail = balanceLimited
-                    ? ("market %s holds %s %s, needs %s to front this candidate (cap %s)")
-                            .formatted(unit, balance, unit, required, cap)
-                    : ("market %s is capped at %s but this candidate requires %s to be fronted; the "
+            // F6 (round 2) — CHECK THE CAP FIRST. `balance.compareTo(cap) < 0` alone conflates two
+            // independent facts: it is true whenever the cap ITSELF is already below what the
+            // protocol requires (required > cap), regardless of the balance, because a balance that
+            // is merely "less than an insufficient cap" says nothing about whether the wallet could
+            // have funded it. The two refusals demand OPPOSITE operator responses ("raise the cap" vs
+            // "fund the wallet"), so the cap — the binding constraint whenever it is the smaller one —
+            // must be checked BEFORE any balance reasoning. Only when the cap WOULD allow this
+            // candidate (cap >= required) does a shortfall mean the balance itself is what is short.
+            boolean capItselfInsufficient = cap.compareTo(required) < 0;
+            Refusal why = capItselfInsufficient ? Refusal.ABOVE_MARKET_CAP : Refusal.INSUFFICIENT_BALANCE;
+            String detail = capItselfInsufficient
+                    ? ("market %s is capped at %s but this candidate requires %s to be fronted; the "
                             + "protocol does not allow fronting part of a loan, so it is refused "
-                            + "rather than reduced").formatted(unit, cap, required);
+                            + "rather than reduced").formatted(unit, cap, required)
+                    : ("market %s holds %s %s, needs %s to front this candidate (cap %s)")
+                            .formatted(unit, balance, unit, required, cap);
             return new Decision(anticipatable, required, cap, why, detail);
         }
         return new Decision(anticipatable, required, cap, null,

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/PayInAdvanceLiquidationRouter.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/PayInAdvanceLiquidationRouter.java
@@ -131,19 +131,16 @@ public class PayInAdvanceLiquidationRouter {
                                         Utxo configUtxo,
                                         Utxo lmConfigUtxo,
                                         Map<String, OracleEntry> oraclesByUnit,
+                                        BigInteger principalBalance,
                                         Function<BigInteger, Optional<Utxo>> walletSelector,
                                         long validFromMillis,
                                         long validToMillis) {
         LoanDatum datum = assessment.loan().datum();
 
-        // Precondition guards, before the builder is touched. The promoted builder prices the
-        // principal leg as ada and throws IllegalStateException on equity <= 0; a convert loan outside
-        // that shape is a candidate this seam cannot yet model, so it is a CLEAN refusal here rather
-        // than a crash or a quarantine downstream.
-        if (!datum.principalAsset().isAda()) {
-            throw new PayInAdvanceNotModelledException(
-                    "pay-in-advance not yet modelled for non-ada principal");
-        }
+        // Precondition guard, before the builder is touched. The promoted builder throws
+        // IllegalStateException on equity <= 0; a convert loan outside that shape is a candidate this
+        // seam cannot yet model, so it is a CLEAN refusal here rather than a crash or a quarantine
+        // downstream.
         if (assessment.equity() == null || assessment.equity().signum() <= 0) {
             throw new PayInAdvanceNotModelledException(
                     "pay-in-advance not yet modelled for non-positive equity");
@@ -153,6 +150,21 @@ public class PayInAdvanceLiquidationRouter {
         // executor's snapshot and the plain builder use, never the priced asset.
         OracleEntry collateralOracle =
                 oraclesByUnit.get(datum.collateral().oracleTokenAsset().toUnit());
+
+        // WALL 3 — the principal's own oracle, keyed by the ORACLE-TOKEN unit the loan datum names
+        // (datum.principalOracleAsset()), never by the priced asset — the oraclesByUnit snapshot is
+        // keyed by oracle NFT, and an asset priced by two feeds would otherwise pick the wrong one.
+        // null for ada, exactly as LiquidatePayInAdvanceTransactionBuilder.Request.principalOracle()
+        // documents: ada needs no principal oracle at all.
+        OracleEntry principalOracle = null;
+        if (!datum.principalAsset().isAda()) {
+            principalOracle = oraclesByUnit.get(datum.principalOracleAsset().toUnit());
+            if (principalOracle == null) {
+                throw new PayInAdvanceNotModelledException(
+                        "pay-in-advance not yet modelled: no oracle entry for principal oracle asset "
+                                + datum.principalOracleAsset().toUnit());
+            }
+        }
 
         // The window and the redeemer's validFrom are derived EXACTLY as the plain path
         // (LiquidateTransactionBuilder.build ~578-580) and the dry-eval fixture do: the requested
@@ -167,10 +179,11 @@ public class PayInAdvanceLiquidationRouter {
 
         // T-052 — THE WALLET INPUT IS CHOSEN TO COVER THIS LIQUIDATION, NOT PICKED BLIND.
         //
-        // This is the principal-repaying path: the collateral is a token, so the ada the lender is
-        // paid comes out of the BOT'S OWN WALLET. That amount is
+        // This is the principal-repaying path: the collateral is a token, so the principal the lender
+        // is paid comes out of the BOT'S OWN WALLET (ada for an ada principal; the principal TOKEN
+        // itself for a token one — see WalletInputSelection's token-aware nomination). That amount is
         // convertedLoanCollateralToPrincipalAmount, and it is knowable here because numbers() reads
-        // the loan, the bond, the oracle and the instant — NEVER the wallet. The caller hands in a
+        // the loan, the bond, the two oracles and the instant — NEVER the wallet. The caller hands in a
         // selector rather than a UTxO, so the choice is made where the amount is known, and the
         // builder still knows nothing about liquidation types.
         //
@@ -180,8 +193,8 @@ public class PayInAdvanceLiquidationRouter {
         // lender's converted share is not bounded by the debt. The exact number costs nothing here;
         // a wrong bound costs the candidate, and fails at evaluation with an EMPTY ScriptFailures map
         // that reads as "a script refused" rather than "you are short" (measured 2026-08-24).
-        LiquidatePayInAdvanceTransactionBuilder.Numbers numbers =
-                builder.numbers(assessment.loan(), assessment.bond(), collateralOracle, slotFromMillis);
+        LiquidatePayInAdvanceTransactionBuilder.Numbers numbers = builder.numbers(assessment.loan(),
+                assessment.bond(), collateralOracle, principalOracle, slotFromMillis);
         BigInteger lenderPayout = numbers.convertedLoanCollateralToPrincipalAmount();
 
         // ⛔ THE MARKET GATE — before a wallet utxo is chosen and before anything is built.
@@ -190,25 +203,35 @@ public class PayInAdvanceLiquidationRouter {
         // Giovanni's rule applied to the number it is about: anticipatable = min(balance, cap), and
         // only when the market is enabled. It sits here rather than beside the profitability floors
         // because it is a POLICY question — "will we take this exposure at all" — and it is settled
-        // before any economics, exactly as a disabled market should be.
-        MarketGate.Decision market = marketGate().decide(datum.principalAsset(), lenderPayout);
+        // before any economics, exactly as a disabled market should be. `principalBalance` is the
+        // executor's own sum of the principal asset across the NOMINABLE wallet utxos — the ones the
+        // selector below can actually spend — so the gate cannot allow a candidate the wallet cannot
+        // fund (MarketGate's own javadoc, Part 3 of the token-principals slice).
+        MarketGate.Decision market = marketGate().decide(datum.principalAsset(), lenderPayout, principalBalance);
         if (!market.allowed()) {
             throw new MarketGateRefusedException(
                     "%s: %s (anticipatable %s of a required %s)".formatted(
                             market.refusal(), market.detail(), market.anticipatable(), market.required()));
         }
+        boolean adaPrincipal = datum.principalAsset().isAda();
+        String principalUnit = adaPrincipal ? "ada" : datum.principalAsset().toUnit();
         Utxo walletUtxo = walletSelector.apply(lenderPayout)
-                .orElseThrow(() -> new WalletInputTooSmallException(
-                        ("no ada-only wallet utxo can fund this convert liquidation: it repays the "
+                .orElseThrow(() -> new WalletInputTooSmallException(adaPrincipal
+                        ? ("no ada-only wallet utxo can fund this convert liquidation: it repays the "
                                 + "lender %s lovelace on top of the fee, and no single nominable utxo "
                                 + "covers that. Fund the wallet with one ada-only utxo of at least "
-                                + "that amount plus fee headroom.").formatted(lenderPayout)));
+                                + "that amount plus fee headroom.").formatted(lenderPayout)
+                        : ("no wallet utxo can fund this convert liquidation: it repays the lender %s "
+                                + "%s on top of the fee, and no single nominable utxo covers that. Fund "
+                                + "the wallet with one utxo holding at least %s %s alongside enough ada "
+                                + "for the fee ceiling and the min-ada rider.").formatted(
+                                lenderPayout, principalUnit, lenderPayout, principalUnit)));
 
         LiquidatePayInAdvanceTransactionBuilder.Request request =
                 new LiquidatePayInAdvanceTransactionBuilder.Request(
                         assessment.loan(), loanUtxo, assessment.bond(), bondUtxo, walletUtxo,
-                        configUtxo, lmConfigUtxo, collateralOracle, slotFromMillis, slotToMillis,
-                        slots[0], slots[1],
+                        configUtxo, lmConfigUtxo, collateralOracle, principalOracle,
+                        slotFromMillis, slotToMillis, slots[0], slots[1],
                         // The bot keeps the collateral and pays change back to itself: the fee/collateral
                         // wallet UTxO is one of its own, so its address is the change address — the same
                         // identity account.baseAddress() carries on the plain path.

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/PayInAdvanceLiquidationRouter.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/PayInAdvanceLiquidationRouter.java
@@ -33,13 +33,17 @@ import java.util.Map;
  * here signs, submits, or flips a veto.
  *
  * <h2>Refusal is a clean REFUSED row, not a crash</h2>
- * The promoted builder models only the real {@code f855d1b4…} shape: an <b>ada principal</b> priced
- * through the collateral oracle, and a <b>strictly positive equity</b> (it throws
- * {@code IllegalStateException} on equity ≤ 0). A convert loan outside that shape is not an error to
- * quarantine — it is a candidate this seam cannot yet model — so both preconditions are checked
- * <em>before</em> the builder is ever called and signalled with {@link PayInAdvanceNotModelledException},
- * which the executor maps to a {@code REFUSED} decision. The builder is never handed a shape it would
- * throw on, and no {@link Transaction} is produced for one.
+ * The promoted builder models {@code equity >= 0} — F0 (round 2) lifted the outright refusal of
+ * equity 0, which is the validator's normal case ({@code loan_claim_action.ak:240-259} accepts it
+ * outright) and the common liquidation, not an edge case. It still throws
+ * {@code IllegalStateException} on a genuinely negative equity, which
+ * {@code LoanFinance.redeemerEquity}'s own floor makes unreachable — defence in depth, never the
+ * expected path. A convert loan outside what the seam can model (a non-ada principal with no
+ * matching oracle entry) is not an error to quarantine — it is a candidate this seam cannot yet
+ * model — so that precondition is checked <em>before</em> the builder is ever called and signalled
+ * with {@link PayInAdvanceNotModelledException}, which the executor maps to a {@code REFUSED}
+ * decision. The builder is never handed a shape it would throw on, and no {@link Transaction} is
+ * produced for one.
  */
 @Service
 @Slf4j
@@ -122,8 +126,10 @@ public class PayInAdvanceLiquidationRouter {
      *                        path passes
      * @throws WalletInputTooSmallException      when no nominable wallet utxo covers the lender
      *                                          payout this liquidation must fund
-     * @throws PayInAdvanceNotModelledException when the principal is not ada, or the equity is not
-     *                                          strictly positive — a clean refusal, no transaction built
+     * @throws PayInAdvanceNotModelledException when the loan's own principal-oracle asset has no
+     *                                          matching oracle entry — a clean refusal, no transaction
+     *                                          built. (F0, round 2: equity 0 is no longer a trigger —
+     *                                          it is the validator's normal, buildable case.)
      */
     Transaction buildConvertLiquidation(LiquidationAssessment assessment,
                                         Utxo loanUtxo,
@@ -137,13 +143,15 @@ public class PayInAdvanceLiquidationRouter {
                                         long validToMillis) {
         LoanDatum datum = assessment.loan().datum();
 
-        // Precondition guard, before the builder is touched. The promoted builder throws
-        // IllegalStateException on equity <= 0; a convert loan outside that shape is a candidate this
-        // seam cannot yet model, so it is a CLEAN refusal here rather than a crash or a quarantine
-        // downstream.
-        if (assessment.equity() == null || assessment.equity().signum() <= 0) {
+        // Precondition guard, before the builder is touched. F0 (round 2): equity 0 is now MODELLED
+        // — it is the validator's normal case and the common liquidation (the live USDM loan today) —
+        // so this only refuses a genuinely negative equity, which LoanFinance.redeemerEquity's own
+        // floor makes unreachable in practice. Kept as a clean refusal (never a crash) purely as
+        // defence in depth: if that floor ever changed, this seam still would not know how to model a
+        // negative equity, and the promoted builder still throws IllegalStateException on one.
+        if (assessment.equity() == null || assessment.equity().signum() < 0) {
             throw new PayInAdvanceNotModelledException(
-                    "pay-in-advance not yet modelled for non-positive equity");
+                    "pay-in-advance not yet modelled for a negative equity");
         }
 
         // The collateral oracle is found by the oracle NFT the loan datum names — the same key the

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/PricingService.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/PricingService.java
@@ -1,0 +1,146 @@
+package com.fluidtokens.aquarium.offchain.service.loans;
+
+import com.fluidtokens.aquarium.offchain.model.AssetType;
+import com.fluidtokens.aquarium.offchain.model.loans.OraclePriceFeed;
+import com.fluidtokens.aquarium.offchain.model.loans.Rational;
+import org.springframework.stereotype.Service;
+
+import java.math.BigInteger;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * The one place a token quantity becomes lovelace for the liquidation economics, and it fails
+ * closed.
+ * <p>
+ * <b>No decimals scaling, anywhere in this class, and there must never be one.</b> The oracle
+ * feed's price is lovelace <em>per base unit</em> ({@code feed.price()} in {@link LoanFinance}), so
+ * {@code baseUnits * price = lovelace} exactly — the registry's {@code decimals} field is for
+ * DISPLAY only, and applying it here would introduce a 10^n error while reading like correctness.
+ * Verified against live mainnet data 2026-09-09: FLDT's registry price is
+ * {@code 21785609/100000000} lovelace per base unit; 23,000,000,000 base units (23,000 FLDT at 6
+ * decimals) times that is 5,010,690,070 lovelace = 5,010.69 ADA — no scaling anywhere.
+ * <p>
+ * <b>Fails closed.</b> A missing, stale or unpriceable feed is a refusal, never a fallback price:
+ * there is no 1:1 assumption and no last-known price anywhere below.
+ */
+@Service
+public class PricingService {
+
+    private final FluidOracleClient oracleClient;
+
+    public PricingService(FluidOracleClient oracleClient) {
+        this.oracleClient = oracleClient;
+    }
+
+    /** Which of the three refusal cases a {@link Priced} carries. */
+    public enum RefusalReason {
+        /** No oracle entry exists for this asset at all. */
+        NO_FEED,
+        /** A feed exists, but is not usable at the instant asked — expired, or not yet valid. */
+        NOT_USABLE_AT_INSTANT,
+        /**
+         * A feed exists (and, if its window is checked, may even cover the instant), but is a
+         * {@code POOLED} variant. {@code get_token_amount_in_lovelace} is an outright {@code fail}
+         * on that variant on chain (hazard: {@link OraclePriceFeed#price()} throws for it) — a
+         * known, permanent property of the asset, never a transient machinery fault.
+         */
+        POOLED
+    }
+
+    /**
+     * Why a {@link Priced} carries no lovelace figure — enough for an operator to act on: the asset
+     * unit, the instant that was asked for, the feed's own window when a feed exists at all, its
+     * age at that instant, and which of the three cases applies.
+     *
+     * @param asset          the asset that could not be priced
+     * @param atMillis       the instant pricing was requested for
+     * @param reason         which of the three refusal cases this is
+     * @param feedValidFrom  the held feed's {@code validFrom}, or {@code null} when {@link #reason}
+     *                       is {@link RefusalReason#NO_FEED}
+     * @param feedValidTo    the held feed's {@code validTo}, or {@code null} under the same condition
+     * @param feedAgeMillis  {@code atMillis - feedValidFrom} — how old the feed is at the instant
+     *                       asked, negative when the feed has not started yet; {@code null} under
+     *                       the same condition as the two above
+     */
+    public record PriceRefusal(AssetType asset, long atMillis, RefusalReason reason,
+                               Long feedValidFrom, Long feedValidTo, Long feedAgeMillis) {
+    }
+
+    /** Either the priced amount in lovelace, or why not — never both. */
+    public record Priced(BigInteger lovelace, PriceRefusal refusal) {
+
+        public boolean isPriced() {
+            return refusal == null;
+        }
+
+        static Priced priced(BigInteger lovelace) {
+            return new Priced(lovelace, null);
+        }
+
+        static Priced refused(PriceRefusal refusal) {
+            return new Priced(null, refusal);
+        }
+    }
+
+    /**
+     * {@code amount}, in {@code asset}'s own base units, expressed in lovelace at {@code atMillis}.
+     * <p>
+     * <b>ADA is the identity.</b> {@link AssetType#isAda()} returns {@code amount} unchanged without
+     * consulting the oracle at all — no feed lookup, no validity check, byte-for-byte the input.
+     * <p>
+     * For every other asset, pricing goes through {@link FluidOracleClient#findFeed}, the
+     * validity-enforcing accessor — never {@link FluidOracleClient#findFeedIgnoringValidity}, whose
+     * own javadoc forbids using it to price. That second accessor is consulted only when
+     * {@code findFeed} came back empty, and only to classify WHY: telling "no feed for this asset at
+     * all" apart from "a feed exists but is not usable here" — a different sentence for an operator
+     * reading the refusal, never a step towards pricing anyway.
+     * <p>
+     * A feed that is live at {@code atMillis} but a {@code POOLED} variant is refused by name rather
+     * than let {@link OraclePriceFeed#price()} throw — {@code findFeed} filters on TIME only, never
+     * on variant, so a live-and-pooled feed reaches this method same as any other.
+     * <p>
+     * Rounded DOWN ({@link Rational#floor()}). This method is used to price amounts about to be
+     * treated as EARNED — a fee slice, compared against a cost — so rounding up would state more
+     * lovelace than the feed actually supports and flatter whatever profitability check reads the
+     * result. Rounding down is the direction that does not flatter the bot.
+     */
+    public Priced toLovelace(AssetType asset, BigInteger amount, long atMillis) {
+        Objects.requireNonNull(asset, "asset");
+        Objects.requireNonNull(amount, "amount");
+
+        if (asset.isAda()) {
+            return Priced.priced(amount);
+        }
+
+        Optional<OraclePriceFeed> usable = oracleClient.findFeed(asset, atMillis);
+        if (usable.isPresent()) {
+            OraclePriceFeed feed = usable.get();
+            if (feed.variant() == OraclePriceFeed.Variant.POOLED) {
+                return Priced.refused(refusalFor(asset, atMillis, RefusalReason.POOLED, feed));
+            }
+            Rational lovelace = LoanFinance.toLovelace(Rational.fromInt(amount), feed);
+            return Priced.priced(lovelace.floor());
+        }
+
+        // Not usable at atMillis through findFeed. findFeedIgnoringValidity is used ONLY to
+        // classify why — its result is never passed to LoanFinance.toLovelace.
+        Optional<OraclePriceFeed> any = oracleClient.findFeedIgnoringValidity(asset);
+        if (any.isEmpty()) {
+            return Priced.refused(new PriceRefusal(asset, atMillis, RefusalReason.NO_FEED,
+                    null, null, null));
+        }
+        OraclePriceFeed feed = any.get();
+        // POOLED is a permanent property of the asset and the more informative fact, so it takes
+        // precedence over "not usable right now" even when the held feed also happens to be stale.
+        RefusalReason reason = feed.variant() == OraclePriceFeed.Variant.POOLED
+                ? RefusalReason.POOLED : RefusalReason.NOT_USABLE_AT_INSTANT;
+        return Priced.refused(refusalFor(asset, atMillis, reason, feed));
+    }
+
+    private static PriceRefusal refusalFor(AssetType asset, long atMillis, RefusalReason reason,
+                                           OraclePriceFeed feed) {
+        return new PriceRefusal(asset, atMillis, reason, feed.validFrom(), feed.validTo(),
+                atMillis - feed.validFrom());
+    }
+}

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/PricingService.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/PricingService.java
@@ -13,13 +13,13 @@ import java.util.Optional;
  * The one place a token quantity becomes lovelace for the liquidation economics, and it fails
  * closed.
  * <p>
- * <b>No decimals scaling, anywhere in this class, and there must never be one.</b> The oracle
+ * <b>No 10^n scaling of any kind in this class, and there must never be one.</b> The oracle
  * feed's price is lovelace <em>per base unit</em> ({@code feed.price()} in {@link LoanFinance}), so
- * {@code baseUnits * price = lovelace} exactly — the registry's {@code decimals} field is for
+ * {@code baseUnits * price = lovelace} exactly — the registry's display-precision field is for
  * DISPLAY only, and applying it here would introduce a 10^n error while reading like correctness.
  * Verified against live mainnet data 2026-09-09: FLDT's registry price is
  * {@code 21785609/100000000} lovelace per base unit; 23,000,000,000 base units (23,000 FLDT at 6
- * decimals) times that is 5,010,690,070 lovelace = 5,010.69 ADA — no scaling anywhere.
+ * display units) times that is 5,010,690,070 lovelace = 5,010.69 ADA — no scaling anywhere.
  * <p>
  * <b>Fails closed.</b> A missing, stale or unpriceable feed is a refusal, never a fallback price:
  * there is no 1:1 assumption and no last-known price anywhere below.

--- a/src/main/java/com/fluidtokens/aquarium/offchain/util/WalletInputSelection.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/util/WalletInputSelection.java
@@ -1,6 +1,8 @@
 package com.fluidtokens.aquarium.offchain.util;
 
+import com.bloxbean.cardano.client.api.model.Amount;
 import com.bloxbean.cardano.client.api.model.Utxo;
+import com.fluidtokens.aquarium.offchain.model.AssetType;
 
 import java.math.BigInteger;
 import java.util.Comparator;
@@ -99,6 +101,71 @@ public final class WalletInputSelection {
         return utxos.stream()
                 .filter(WalletInputSelection::nominable)
                 .map(LedgerCeilings::lovelaceOf)
+                .max(BigInteger::compareTo);
+    }
+
+    // ---- token-principal nomination (ADDITIVE — Part 2 of the token-principals slice) -------------
+    //
+    // A pay-in-advance liquidation on a TOKEN principal must front that token, not ada, so the utxo
+    // that funds it must carry the principal asset alongside enough ada for the fee ceiling and the
+    // min-ada rider on the lender's output. `nominable` above requires `getAmount().size() == 1` —
+    // ADA ONLY — so it filters out exactly the multi-asset (principal + min-ada) utxo this shape
+    // needs; that rule is untouched here, because the 2026-08-24 incident it defends against is about
+    // the plain SPEND/collateral input, which stays ada-only on every path. This is a SEPARATE,
+    // ADDITIVE rule for a SEPARATE purpose.
+
+    /**
+     * Carries at least one unit of {@code principal} (a non-ada token), no reference script, no datum
+     * of either kind — the same datum/reference-script exclusions {@link #nominable} applies, for the
+     * same reason (a datum-bearing or reference-script-carrying utxo is not a plain spendable input).
+     * <b>Does not require ada-only</b> — the whole point is a utxo carrying the token AND its min-ada
+     * rider together, exactly the shape a real funding transaction produces.
+     */
+    public static boolean nominableForToken(Utxo utxo, AssetType principal) {
+        if (utxo.getReferenceScriptHash() != null || utxo.getInlineDatum() != null
+                || utxo.getDataHash() != null || utxo.getAmount() == null) {
+            return false;
+        }
+        String unit = principal.toUnit();
+        return utxo.getAmount().stream().anyMatch(a -> unit.equalsIgnoreCase(a.getUnit()));
+    }
+
+    /** The quantity of {@code asset} an amount list holds. Zero if it holds none. */
+    public static BigInteger tokenQuantityOf(Utxo utxo, AssetType asset) {
+        if (utxo.getAmount() == null) {
+            return BigInteger.ZERO;
+        }
+        String unit = asset.toUnit();
+        return utxo.getAmount().stream()
+                .filter(a -> unit.equalsIgnoreCase(a.getUnit()))
+                .map(Amount::getQuantity)
+                .reduce(BigInteger.ZERO, BigInteger::add);
+    }
+
+    /**
+     * The smallest {@link #nominableForToken} UTxO holding at least {@code requiredPrincipal} of
+     * {@code principal} AND at least {@code requiredAda} lovelace alongside it, or empty when none
+     * does. Ordered by the PRINCIPAL quantity — the scarcer resource on this path — the same
+     * smallest-that-suffices rule {@link #smallestSufficient} applies to ada.
+     *
+     * @param requiredAda a CEILING (fee ceiling plus the min-ada rider), never an estimate — see the
+     *                    class javadoc on why under-estimating is the dangerous direction
+     */
+    public static Optional<Utxo> smallestSufficientToken(List<Utxo> utxos, AssetType principal,
+                                                          BigInteger requiredPrincipal,
+                                                          BigInteger requiredAda) {
+        return utxos.stream()
+                .filter(u -> nominableForToken(u, principal))
+                .filter(u -> tokenQuantityOf(u, principal).compareTo(requiredPrincipal) >= 0)
+                .filter(u -> LedgerCeilings.lovelaceOf(u).compareTo(requiredAda) >= 0)
+                .min(Comparator.comparing(u -> tokenQuantityOf(u, principal)));
+    }
+
+    /** The largest nominable-for-token holding of {@code principal}, for diagnostics. */
+    public static Optional<BigInteger> largestNominableToken(List<Utxo> utxos, AssetType principal) {
+        return utxos.stream()
+                .filter(u -> nominableForToken(u, principal))
+                .map(u -> tokenQuantityOf(u, principal))
                 .max(BigInteger::compareTo);
     }
 }

--- a/src/main/resources/templates/readiness.html
+++ b/src/main/resources/templates/readiness.html
@@ -132,12 +132,17 @@
           <span class="reason" th:text="${r.routeDetail}">why</span>
         </td>
         <td class="mono">
-          <span th:if="${r.advanceLovelace != null}" th:text="${r.advanceLovelace}">0</span>
-          <span th:if="${r.advanceLovelace == null and r.route == 'CAPITAL IN ADVANCE'}"
+          <!-- F5 (round 2) — name the UNIT beside the figure: r.principalUnit is the SAME asset this
+               amount is denominated in, never lovelace, and a 4.63x-wrong number in the wrong unit is
+               exactly the failure this caption exists to prevent. -->
+          <span th:if="${r.advancePrincipalAmount != null}" th:text="${r.advancePrincipalAmount}">0</span>
+          <span class="reason" th:if="${r.advancePrincipalAmount != null}"
+                th:text="${#strings.abbreviate(r.principalUnit, 24)}">unit</span>
+          <span th:if="${r.advancePrincipalAmount == null and r.route == 'CAPITAL IN ADVANCE'}"
                 class="unknown">unknown</span>
-          <span th:if="${r.advanceLovelace == null and r.route != 'CAPITAL IN ADVANCE'}"
+          <span th:if="${r.advancePrincipalAmount == null and r.route != 'CAPITAL IN ADVANCE'}"
                 class="reason">&mdash;</span>
-          <span class="reason" th:if="${r.advanceLovelace != null}">principal the operator must have ready</span>
+          <span class="reason" th:if="${r.advancePrincipalAmount != null}">principal the operator must have ready</span>
         </td>
       </tr>
       <tr th:if="${#lists.isEmpty(rows)}">

--- a/src/test/java/com/fluidtokens/aquarium/offchain/LiquidatePayInAdvanceProductionWiringLiveTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/LiquidatePayInAdvanceProductionWiringLiveTest.java
@@ -301,7 +301,9 @@ class LiquidatePayInAdvanceProductionWiringLiveTest {
 
         long now = System.currentTimeMillis();
         var request = new LiquidatePayInAdvanceTransactionBuilder.Request(loan, loanUtxo, bond,
-                bondUtxo, walletUtxo, configUtxo, lmConfigUtxo, oracleEntry, now, now + 120_000L,
+                bondUtxo, walletUtxo, configUtxo, lmConfigUtxo, oracleEntry,
+                null,   // ada principal — see the Request javadoc
+                now, now + 120_000L,
                 slotOf(now - 60_000L), slotOf(now + 120_000L), bot.baseAddress(),
                 referenceScripts(), 30_000L);
 

--- a/src/test/java/com/fluidtokens/aquarium/offchain/LoanFinanceTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/LoanFinanceTest.java
@@ -168,4 +168,91 @@ class LoanFinanceTest {
                                 Rational.fromInt(30_000_000), Rational.ZERO, ltv, feed(1, 1), feed(3, 10)),
                 "0 * (3/10) is 0/10, which is not structurally rational.zero — the contract fails here");
     }
+
+    // ---- WALL 1: convertFromAToBWithOracles ----------------------------------------------------
+
+    /**
+     * The pinned mainnet candidate (loan {@code 279499ff…}, docs/lending-v4-findings.md §59): 23 B
+     * FLDT collateral, 920,000,000 FLDT fee, equity 95,611,485 FLDT at the 20:04Z sample — so the
+     * lender's collateral share is {@code 23,000,000,000 − 95,611,485 − 920,000,000 = 21,984,388,515}
+     * FLDT, at FLDT {@code 21785609/1e8} and USDM {@code 463261535/1e8} lovelace-per-base-unit.
+     * <p>
+     * <b>This is the number the rig asserts, not "≈1,034 USDM"</b> — the exact rational is
+     * {@code 1,033,850,764.8641…}, so the ceiling below matters.
+     */
+    @Test
+    void convertFromAToBWithOraclesMatchesThePinnedMainnetCandidate() {
+        Rational lenderShare = Rational.fromInt(BigInteger.valueOf(21_984_388_515L));
+        OraclePriceFeed fldt = feed(21_785_609L, 100_000_000L);
+        OraclePriceFeed usdm = feed(463_261_535L, 100_000_000L);
+
+        BigInteger payout = LoanFinance.convertFromAToBWithOracles(fldt, usdm, lenderShare);
+
+        assertEquals(BigInteger.valueOf(1_033_850_765L), payout);
+    }
+
+    /**
+     * ⛔ THE 4.63× BUG this wall exists to kill. The pre-fix code was
+     * {@code toLovelace(share, collateralFeed).ceil()} — the lovelace figure, ceiled, paid out AS the
+     * principal — which never divides by the principal feed at all. At the pinned figures that pays
+     * 4,789,432,923 where the validator demands 1,033,850,765: 4.63× too much.
+     */
+    @Test
+    void theOldOneFeedShortcutOverpaysByFourPointSixThreeTimes() {
+        Rational lenderShare = Rational.fromInt(BigInteger.valueOf(21_984_388_515L));
+        OraclePriceFeed fldt = feed(21_785_609L, 100_000_000L);
+
+        BigInteger oldBuggyShortcut = LoanFinance.toLovelace(lenderShare, fldt).ceil();
+
+        assertEquals(BigInteger.valueOf(4_789_432_923L), oldBuggyShortcut,
+                "the one-feed shortcut this wall replaces — kept here so the magnitude of the bug "
+                        + "this fixes is never lost");
+    }
+
+    /**
+     * ADA principal: {@code bFeed} is the 1:1 unit feed, so {@code fromLovelace(x, unit) == x} and
+     * {@code convertFromAToBWithOracles} reduces exactly to today's {@code toLovelace(..).ceil()} —
+     * the INVARIANT that keeps the ada pay-in-advance path byte-identical.
+     */
+    @Test
+    void adaPrincipalReducesToTodaysNumber() {
+        Rational share = Rational.fromInt(BigInteger.valueOf(21_984_388_515L));
+        OraclePriceFeed collateralFeed = feed(21_785_609L, 100_000_000L);
+
+        BigInteger viaTwoFeedComposition =
+                LoanFinance.convertFromAToBWithOracles(collateralFeed, OraclePriceFeed.unit(), share);
+        BigInteger viaTodaysFormula = LoanFinance.toLovelace(share, collateralFeed).ceil();
+
+        assertEquals(viaTodaysFormula, viaTwoFeedComposition,
+                "an ada principal must produce EXACTLY what the pre-existing single-feed arithmetic did");
+    }
+
+    /**
+     * ⚠ The rounding ORDER hazard named in the slice contract: ceil-then-divide (ceiling the
+     * intermediate lovelace amount to an integer, THEN dividing by the principal feed and ceiling
+     * again) and divide-then-ceil (the validator's own order — one ceil, at the end, over the exact
+     * rational) CAN differ by one. Feeds chosen so they do: a=1 at feed 1/3 -> 1/3 lovelace;
+     * <ul>
+     *   <li>correct (divide-then-ceil): {@code ceil( (1/3) / (1/2) ) = ceil(2/3) = 1}</li>
+     *   <li>wrong (ceil-then-divide): {@code ceil( ceil(1/3) / (1/2) ) = ceil( 1 / (1/2) ) = ceil(2) = 2}</li>
+     * </ul>
+     * The pinned mainnet candidate does NOT exercise this — checked at three equity samples, all
+     * diff 0 — so this synthetic pair is what proves the ORDER, not merely the composition.
+     */
+    @Test
+    void roundingOrderMattersAndTheValidatorsOrderIsDivideThenCeil() {
+        OraclePriceFeed aFeed = feed(1, 3);
+        OraclePriceFeed bFeed = feed(1, 2);
+        Rational aAmount = Rational.fromInt(BigInteger.ONE);
+
+        BigInteger correct = LoanFinance.convertFromAToBWithOracles(aFeed, bFeed, aAmount);
+        BigInteger ceilThenDivide = LoanFinance
+                .fromLovelace(Rational.fromInt(LoanFinance.toLovelace(aAmount, aFeed).ceil()), bFeed)
+                .ceil();
+
+        assertEquals(BigInteger.ONE, correct, "divide-then-ceil, the validator's order");
+        assertEquals(BigInteger.TWO, ceilThenDivide, "ceil-then-divide — one lovelace higher here");
+        org.junit.jupiter.api.Assertions.assertNotEquals(correct, ceilThenDivide,
+                "the two orders must genuinely differ for this test to prove anything about ORDER");
+    }
 }

--- a/src/test/java/com/fluidtokens/aquarium/offchain/controller/LiquidationReadinessControllerTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/controller/LiquidationReadinessControllerTest.java
@@ -1,6 +1,20 @@
 package com.fluidtokens.aquarium.offchain.controller;
 
+import com.bloxbean.cardano.client.common.model.Networks;
+import com.bloxbean.cardano.client.transaction.spec.TransactionInput;
+import com.fluidtokens.aquarium.offchain.config.AppConfig;
+import com.fluidtokens.aquarium.offchain.model.AssetType;
+import com.fluidtokens.aquarium.offchain.model.loans.LenderBond;
+import com.fluidtokens.aquarium.offchain.model.loans.Loan;
+import com.fluidtokens.aquarium.offchain.model.loans.LoanDatum;
+import com.fluidtokens.aquarium.offchain.model.loans.OracleEntry;
+import com.fluidtokens.aquarium.offchain.model.loans.OraclePriceFeed;
+import com.fluidtokens.aquarium.offchain.model.loans.RepaymentMode;
+import com.fluidtokens.aquarium.offchain.service.LoansContractRegistry;
+import com.fluidtokens.aquarium.offchain.service.loans.FluidOracleClient;
+import com.fluidtokens.aquarium.offchain.service.loans.LoanFixtures;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -9,8 +23,10 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -111,8 +127,154 @@ class LiquidationReadinessControllerTest {
 
         assertNull(r.healthFactor());
         assertNull(r.feeValueLovelace());
-        assertNull(r.advanceLovelace());
+        assertNull(r.advancePrincipalAmount());
         assertEquals("no usable oracle feed", r.healthUnknownReason());
         assertTrue(r.sortKey() == Double.MAX_VALUE, "and it sorts last");
+    }
+
+    // ======================================================================================
+    // F5 (round 2) — advanceAmount() must route through the REAL principal oracle, never the
+    // deprecated 4-arg numbers() overload that silently priced every principal as ada.
+    // ======================================================================================
+
+    private static final AssetType COLLATERAL_TOKEN =
+            new AssetType("aa".repeat(28), "434f4c4c");
+    private static final AssetType COLLATERAL_ORACLE_NFT =
+            new AssetType("bb".repeat(28), "434f4c4c4f5241434c45");
+    private static final AssetType PRINCIPAL_TOKEN =
+            new AssetType("cc".repeat(28), "5553444d");
+    private static final AssetType PRINCIPAL_ORACLE_NFT =
+            new AssetType("dd".repeat(28), "5553444d4f5241434c45");
+
+    /** A stand-in whose {@code findEntry} answers from a fixed map — {@code findEntry} is public, so
+     * this is overridable across packages without touching {@code FluidOracleClient} at all. */
+    private static final class FakeOracleClient extends FluidOracleClient {
+
+        private final java.util.Map<AssetType, OracleEntry> byToken;
+
+        FakeOracleClient(OracleEntry... entries) {
+            super("http://unused.invalid");
+            byToken = new java.util.HashMap<>();
+            for (OracleEntry entry : entries) {
+                // findEntry (production) is keyed by the PRICED asset — entry.token() — never the
+                // oracle NFT (entry.oracleToken(), which is findEntryByOracleToken's key instead).
+                byToken.put(entry.token(), entry);
+            }
+        }
+
+        @Override
+        public Optional<OracleEntry> findEntry(AssetType token) {
+            return Optional.ofNullable(byToken.get(token));
+        }
+    }
+
+    private static <T> ObjectProvider<T> provide(T value) {
+        return new ObjectProvider<>() {
+            @Override
+            public T getObject() {
+                return value;
+            }
+
+            @Override
+            public T getObject(Object... args) {
+                return value;
+            }
+
+            @Override
+            public T getIfAvailable() {
+                return value;
+            }
+
+            @Override
+            public T getIfUnique() {
+                return value;
+            }
+        };
+    }
+
+    private static LiquidationReadinessController controllerWith(FluidOracleClient client,
+                                                                  LoansContractRegistry registry) {
+        AppConfig.Network network = new AppConfig.Network() {
+            @Override
+            public com.bloxbean.cardano.client.common.model.Network getCardanoNetwork() {
+                return Networks.testnet();
+            }
+        };
+        return new LiquidationReadinessController(provide(null), provide(null), provide(null),
+                provide(client), provide(null), provide(registry), null, network);
+    }
+
+    /**
+     * ⛔ THE BUG THIS TEST EXISTS TO CATCH. A collateral priced 1:1 in lovelace and a principal priced
+     * 2 lovelace per base unit: the CORRECT figure divides the collateral's lovelace value by the
+     * principal's own price (WALL 1's two-feed composition) and the OLD (deprecated 4-arg) figure did
+     * not divide by anything — it silently treated the principal as ada. The two numbers differ by
+     * exactly the principal's price factor here (195,000,000 vs 97,500,000), so a test that could pass
+     * under either formula would prove nothing; this one cannot.
+     * <p>
+     * Arithmetic pinned by hand: remainingDebt = 100,000,000 (0% interest, 1 installment) ⇒ equity =
+     * floor(300,000,000·1 - 100,000,000·1 - 0.05·100,000,000·1) = 90,000,000 ⇒ liquidationFee =
+     * floor(300,000,000·50/1000) = 15,000,000 ⇒ collateralLenderShouldReceive = 300,000,000 - 90,000,000
+     * - 15,000,000 = 195,000,000 ⇒ converted = ceil(195,000,000·1 / 2) = 97,500,000.
+     */
+    @Test
+    void advanceAmountRoutesThroughTheRealPrincipalOracleNotTheAdaShortcut() {
+        LoanDatum datum = LoanFixtures.loanDatum(PRINCIPAL_TOKEN, PRINCIPAL_ORACLE_NFT,
+                BigInteger.valueOf(100_000_000L), BigInteger.ZERO,
+                LoanFixtures.tokenCollateral(COLLATERAL_TOKEN, COLLATERAL_ORACLE_NFT), 0L,
+                LoanFixtures.liquidation(), new RepaymentMode.PrincipalAndInterestOnInstallments(), false);
+        Loan loan = new Loan("f0".repeat(32), 0, "addr_test1_placeholder", "loanid00",
+                BigInteger.valueOf(300_000_000L), BigInteger.valueOf(3_000_000L), datum);
+        LenderBond bond = new LenderBond("f0".repeat(32), 1, "addr_test1_placeholder", "loanid00", "",
+                LoanFixtures.bondDatum(BigInteger.valueOf(50), LoanFixtures.noStakeCredential(),
+                        PRINCIPAL_TOKEN));
+
+        OracleEntry collateralOracle = LoanFixtures.charli3(COLLATERAL_TOKEN, COLLATERAL_ORACLE_NFT,
+                "11".repeat(28), OraclePriceFeed.priceDataCharlie(COLLATERAL_TOKEN,
+                        BigInteger.ONE, BigInteger.ONE, 0L, 10_000_000L),
+                input("22"), input("33"), input("44"));
+        OracleEntry principalOracle = LoanFixtures.charli3(PRINCIPAL_TOKEN, PRINCIPAL_ORACLE_NFT,
+                "55".repeat(28), OraclePriceFeed.priceDataCharlie(PRINCIPAL_TOKEN,
+                        BigInteger.TWO, BigInteger.ONE, 0L, 10_000_000L),
+                input("66"), input("77"), input("88"));
+        FakeOracleClient client = new FakeOracleClient(collateralOracle, principalOracle);
+        LiquidationReadinessController controller = controllerWith(client, LoanFixtures.registry());
+
+        BigInteger advance = controller.advanceAmount(loan, bond, 1_000L);
+
+        assertEquals(BigInteger.valueOf(97_500_000L), advance,
+                "must be the two-feed WALL-1 composition, not the ada-shortcut figure");
+        assertNotEquals(BigInteger.valueOf(195_000_000L), advance,
+                "195,000,000 is what the deprecated null-principal-oracle overload would have "
+                        + "produced — seeing it here means the fix regressed");
+    }
+
+    /** advanceAmount refuses (null) rather than guess when the loan's OWN principal oracle is missing. */
+    @Test
+    void advanceAmountIsNullWhenNoPrincipalOracleEntryExists() {
+        LoanDatum datum = LoanFixtures.loanDatum(PRINCIPAL_TOKEN, PRINCIPAL_ORACLE_NFT,
+                BigInteger.valueOf(100_000_000L), BigInteger.ZERO,
+                LoanFixtures.tokenCollateral(COLLATERAL_TOKEN, COLLATERAL_ORACLE_NFT), 0L,
+                LoanFixtures.liquidation(), new RepaymentMode.PrincipalAndInterestOnInstallments(), false);
+        Loan loan = new Loan("f0".repeat(32), 0, "addr_test1_placeholder", "loanid00",
+                BigInteger.valueOf(300_000_000L), BigInteger.valueOf(3_000_000L), datum);
+        LenderBond bond = new LenderBond("f0".repeat(32), 1, "addr_test1_placeholder", "loanid00", "",
+                LoanFixtures.bondDatum(BigInteger.valueOf(50), LoanFixtures.noStakeCredential(),
+                        PRINCIPAL_TOKEN));
+
+        OracleEntry collateralOracle = LoanFixtures.charli3(COLLATERAL_TOKEN, COLLATERAL_ORACLE_NFT,
+                "11".repeat(28), OraclePriceFeed.priceDataCharlie(COLLATERAL_TOKEN,
+                        BigInteger.ONE, BigInteger.ONE, 0L, 10_000_000L),
+                input("22"), input("33"), input("44"));
+        // ONLY the collateral oracle is registered — no entry for the principal.
+        FakeOracleClient client = new FakeOracleClient(collateralOracle);
+        LiquidationReadinessController controller = controllerWith(client, LoanFixtures.registry());
+
+        assertNull(controller.advanceAmount(loan, bond, 1_000L),
+                "a missing principal oracle must read UNKNOWN (null), never fall back to ada pricing");
+    }
+
+    private static TransactionInput input(String prefix) {
+        return LoanFixtures.input(prefix.repeat(32), 0);
     }
 }

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/CompoundCandidateScannerTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/CompoundCandidateScannerTest.java
@@ -259,7 +259,13 @@ class CompoundCandidateScannerTest {
         assertEquals(CompoundExclusion.BOND_NOT_FOUND, scan.candidates().getFirst().exclusion());
     }
 
-    /** A token-principal pool: refused rather than compared against a lovelace fee. */
+    /**
+     * A token-principal pool: still refused structurally here — NOT because
+     * {@code CompoundEconomics} cannot compare a token fee to a lovelace tx fee any more (it can, via
+     * {@code PricingService}, see {@code CompoundEconomicsTest}), but because the compound builder
+     * does not yet pay out a non-ada principal and lifting this is held on a product ruling
+     * (FAB-77). See {@code CompoundExclusion.PRINCIPAL_NOT_ADA}'s javadoc.
+     */
     @Test
     void aTokenPrincipalPoolIsRefused() {
         var principal = new AssetType("0b77d150c275bd0a600633e4be7d09f83c4b9f00981e22ac9c9d3f62",
@@ -275,6 +281,8 @@ class CompoundCandidateScannerTest {
         assertEquals(CompoundExclusion.PRINCIPAL_NOT_ADA, c.exclusion());
         assertEquals(BigInteger.valueOf(200_000_000L), c.addedLiquidity(),
                 "the principal quantity is still reported, in the principal's own unit");
+        assertFalse(c.detail().contains("cannot be compared"),
+                "the old reason is stale now that CompoundEconomics CAN price a token fee: " + c.detail());
     }
 
     /** An unreadable pool-manager datum must read as a zero fee, never as a high one. */

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/CompoundEconomicsTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/CompoundEconomicsTest.java
@@ -1,16 +1,20 @@
 package com.fluidtokens.aquarium.offchain.service.loans;
 
 import com.fluidtokens.aquarium.offchain.config.AppConfig;
+import com.fluidtokens.aquarium.offchain.model.AssetType;
 import com.fluidtokens.aquarium.offchain.model.loans.CompoundAssessment;
 import com.fluidtokens.aquarium.offchain.model.loans.CompoundExclusion;
+import com.fluidtokens.aquarium.offchain.model.loans.OraclePriceFeed;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigInteger;
+import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -21,29 +25,56 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p>The shape that encodes "owns it" is the same one the liquidation margin uses: a floor the
  * operator <b>states</b>, never a check they switch off. So there is no boolean here to disable the
  * gate — arming zero-fee work means stating a negative number, which still bounds the loss.
+ *
+ * <p>Since the oracle-pricing slice (2026-09-09), {@link CompoundEconomics#assess} also prices a
+ * non-ada principal's fee slice through {@link PricingService} — every test up to that heading uses
+ * ada throughout, unchanged from before that slice; the ones under it exercise the new pricing path
+ * directly, independent of whether {@code CompoundCandidateScanner} routes a live candidate to it
+ * today (it does not yet — see {@code CompoundExclusion.PRINCIPAL_NOT_ADA}'s javadoc).
  */
 class CompoundEconomicsTest {
 
     private static final BigInteger ESCROW_45_ADA = BigInteger.valueOf(45_000_000L);
     private static final BigInteger TX_FEE = BigInteger.valueOf(300_000L);
+    private static final long AT_MILLIS = 1_700_000_000_000L;
+
+    private static final AssetType TOKEN =
+            new AssetType("c0eaf6cea665d1b99647a9d24461984103de0492da93e7af29fe5d9", "5553444d");
+
+    /** Ada never reaches the oracle, so a dummy, un-loaded client is exactly as good as a real one. */
+    private static PricingService dummyPricingService() {
+        return new PricingService(new FluidOracleClient("http://unused.invalid"));
+    }
 
     private static CompoundEconomics economics(boolean enabled, long floorLovelace, String network) {
         var cfg = new AppConfig.CompoundConfiguration(enabled, 60L, BigInteger.valueOf(floorLovelace));
         var net = new AppConfig.Network();
         ReflectionTestUtils.setField(net, "network", network);
-        return new CompoundEconomics(cfg, net);
+        return new CompoundEconomics(cfg, net, dummyPricingService());
+    }
+
+    private static CompoundEconomics economics(boolean enabled, long floorLovelace, String network,
+                                               PricingService pricingService) {
+        var cfg = new AppConfig.CompoundConfiguration(enabled, 60L, BigInteger.valueOf(floorLovelace));
+        var net = new AppConfig.Network();
+        ReflectionTestUtils.setField(net, "network", network);
+        return new CompoundEconomics(cfg, net, pricingService);
     }
 
     private static CompoundEconomics armed(long floorLovelace) {
         return economics(true, floorLovelace, "preview");
     }
 
+    // ---- the ada path, unchanged since before the oracle-pricing slice -------------------------
+
     /** A paying pool: 45 ADA escrow at 5‰ earns 225_000, which does not clear a 300_000 fee. */
     @Test
     void aFeeThatDoesNotCoverTheTransactionIsRefusedAtTheSafeDefault() {
-        CompoundAssessment a = armed(0).assess(true, true, true, ESCROW_45_ADA, 5L, TX_FEE);
+        CompoundAssessment a = armed(0).assess(true, true, AssetType.ada(), ESCROW_45_ADA, 5L, TX_FEE, AT_MILLIS);
 
         assertEquals(BigInteger.valueOf(225_000L), a.expectedFee());
+        assertEquals(BigInteger.valueOf(225_000L), a.expectedFeeLovelace(),
+                "for an ada principal the priced figure must equal the on-chain one exactly");
         assertEquals(BigInteger.valueOf(-75_000L), a.net());
         assertFalse(a.approved());
         assertEquals(CompoundExclusion.NET_BELOW_FLOOR, a.exclusion());
@@ -53,7 +84,7 @@ class CompoundEconomicsTest {
     @Test
     void aFeeThatCoversTheTransactionIsApproved() {
         CompoundAssessment a = armed(0)
-                .assess(true, true, true, BigInteger.valueOf(200_000_000L), 5L, TX_FEE);
+                .assess(true, true, AssetType.ada(), BigInteger.valueOf(200_000_000L), 5L, TX_FEE, AT_MILLIS);
 
         assertEquals(BigInteger.valueOf(1_000_000L), a.expectedFee());
         assertEquals(BigInteger.valueOf(700_000L), a.net());
@@ -63,8 +94,8 @@ class CompoundEconomicsTest {
     /** Exact break-even is allowed by the default floor of 0 — it is not a loss. */
     @Test
     void exactBreakEvenIsApprovedAtTheDefaultFloor() {
-        CompoundAssessment a = armed(0)
-                .assess(true, true, true, BigInteger.valueOf(60_000_000L), 5L, BigInteger.valueOf(300_000L));
+        CompoundAssessment a = armed(0).assess(true, true, AssetType.ada(),
+                BigInteger.valueOf(60_000_000L), 5L, BigInteger.valueOf(300_000L), AT_MILLIS);
 
         assertEquals(BigInteger.ZERO, a.net());
         assertTrue(a.approved(), "net == floor must pass: the floor is a minimum, not a strict bound");
@@ -76,7 +107,7 @@ class CompoundEconomicsTest {
      */
     @Test
     void aZeroFeePoolIsRefusedOutOfTheBox() {
-        CompoundAssessment a = armed(0).assess(true, true, true, ESCROW_45_ADA, 0L, TX_FEE);
+        CompoundAssessment a = armed(0).assess(true, true, AssetType.ada(), ESCROW_45_ADA, 0L, TX_FEE, AT_MILLIS);
 
         assertTrue(a.zeroFeePool());
         assertEquals(BigInteger.ZERO, a.expectedFee());
@@ -93,39 +124,56 @@ class CompoundEconomicsTest {
     void aStatedNegativeFloorArmsZeroFeeWorkAndStillBoundsTheLoss() {
         CompoundEconomics armedAtALoss = armed(-2_000_000L);
 
-        CompoundAssessment allowed = armedAtALoss.assess(true, true, true, ESCROW_45_ADA, 0L, TX_FEE);
+        CompoundAssessment allowed =
+                armedAtALoss.assess(true, true, AssetType.ada(), ESCROW_45_ADA, 0L, TX_FEE, AT_MILLIS);
         assertTrue(allowed.approved(), "a -2 ADA stated bound must accept a 0.3 ADA loss");
         assertTrue(allowed.zeroFeePool());
 
         // Still a bound, not an off switch: a loss beyond the stated figure is refused.
-        CompoundAssessment tooExpensive = armedAtALoss
-                .assess(true, true, true, ESCROW_45_ADA, 0L, BigInteger.valueOf(2_500_000L));
+        CompoundAssessment tooExpensive = armedAtALoss.assess(true, true, AssetType.ada(),
+                ESCROW_45_ADA, 0L, BigInteger.valueOf(2_500_000L), AT_MILLIS);
         assertFalse(tooExpensive.approved(), "a stated bound must still refuse a worse loss");
         assertEquals(CompoundExclusion.NET_BELOW_FLOOR, tooExpensive.exclusion());
-    }
-
-    /**
-     * ⛔ THE UNIT TRAP. A token-principal pool's fee is a token quantity; subtracting a lovelace tx
-     * fee from it yields a number that looks like profit and is not. Refused, never guessed.
-     */
-    @Test
-    void aNonAdaPrincipalIsRefusedRatherThanCompared() {
-        CompoundAssessment a = armed(0)
-                .assess(true, true, false, BigInteger.valueOf(999_000_000L), 50L, TX_FEE);
-
-        assertFalse(a.approved());
-        assertEquals(CompoundExclusion.PRINCIPAL_NOT_ADA, a.exclusion());
-        assertNullNet(a);
     }
 
     @Test
     void theStructuralRefusalsFireBeforeAnyArithmetic() {
         assertEquals(CompoundExclusion.NOT_ARMED,
-                economics(false, 0, "preview").assess(true, true, true, ESCROW_45_ADA, 50L, TX_FEE).exclusion());
+                economics(false, 0, "preview")
+                        .assess(true, true, AssetType.ada(), ESCROW_45_ADA, 50L, TX_FEE, AT_MILLIS).exclusion());
         assertEquals(CompoundExclusion.BOND_NAMES_NO_POOL,
-                armed(0).assess(false, true, true, ESCROW_45_ADA, 50L, TX_FEE).exclusion());
+                armed(0).assess(false, true, AssetType.ada(), ESCROW_45_ADA, 50L, TX_FEE, AT_MILLIS).exclusion());
         assertEquals(CompoundExclusion.POOL_NOT_LIVE,
-                armed(0).assess(true, false, true, ESCROW_45_ADA, 50L, TX_FEE).exclusion());
+                armed(0).assess(true, false, AssetType.ada(), ESCROW_45_ADA, 50L, TX_FEE, AT_MILLIS).exclusion());
+    }
+
+    /**
+     * ⛔ THE ADA PATH MUST NOT CHANGE. Driven through an oracle client that throws on ANY call, so
+     * this test would fail loudly the moment the ada path started consulting the oracle at all — the
+     * invariant is "byte-for-byte unchanged", not merely "produces the same number".
+     */
+    @Test
+    void theAdaPathNeverConsultsTheOracle() {
+        var throwingClient = new FluidOracleClient("http://unused.invalid") {
+            @Override
+            public Optional<OraclePriceFeed> findFeed(AssetType asset, long atMillis) {
+                throw new AssertionError("the ada path must not consult the oracle at all");
+            }
+
+            @Override
+            public Optional<OraclePriceFeed> findFeedIgnoringValidity(AssetType asset) {
+                throw new AssertionError("the ada path must not consult the oracle at all");
+            }
+        };
+        CompoundEconomics economics =
+                economics(true, 0, "preview", new PricingService(throwingClient));
+
+        CompoundAssessment a = assertDoesNotThrow(() ->
+                economics.assess(true, true, AssetType.ada(), ESCROW_45_ADA, 5L, TX_FEE, AT_MILLIS));
+
+        assertEquals(BigInteger.valueOf(225_000L), a.expectedFeeLovelace());
+        assertEquals(BigInteger.valueOf(-75_000L), a.net());
+        assertFalse(a.approved());
     }
 
     /**
@@ -178,8 +226,98 @@ class CompoundEconomicsTest {
         economics(true, 0L, "mainnet").announceAndGuard();
     }
 
+    // ---- the oracle-pricing slice: a non-ada principal is priced, not blanket-refused ------------
+
+    /**
+     * ⛔ THE OLD BEHAVIOUR THIS REPLACES. Before this slice a non-ada principal was refused outright
+     * with {@code PRINCIPAL_NOT_ADA} regardless of whether a price existed. {@link CompoundEconomics}
+     * itself no longer does that — it prices the fee slice and decides on the number. (A live
+     * candidate still never reaches here with a non-ada principal today: see
+     * {@code CompoundCandidateScanner}, which keeps its own separate, structural
+     * {@code PRINCIPAL_NOT_ADA} gate for reasons that have nothing to do with pricing.)
+     */
+    @Test
+    void aTokenPrincipalWithAnAvailablePriceIsPricedAndDecidedOnTheNumber() {
+        var client = new StubOracleClient();
+        // 2 lovelace per base unit — a fee of 500_000 base units prices to 1_000_000 lovelace.
+        client.usable = OraclePriceFeed.aggregated(TOKEN, BigInteger.TWO, BigInteger.ONE,
+                AT_MILLIS - 1_000, AT_MILLIS + 1_000);
+        CompoundEconomics economics = economics(true, 0, "preview", new PricingService(client));
+
+        // escrow 100_000_000 base units at 5‰ = 500_000 base units of fee.
+        CompoundAssessment a = economics.assess(true, true, TOKEN,
+                BigInteger.valueOf(100_000_000L), 5L, TX_FEE, AT_MILLIS);
+
+        assertEquals(BigInteger.valueOf(500_000L), a.expectedFee(), "still in the principal's own unit");
+        assertEquals(BigInteger.valueOf(1_000_000L), a.expectedFeeLovelace(), "priced: 500_000 * 2");
+        assertEquals(BigInteger.valueOf(700_000L), a.net(), "1_000_000 - 300_000 tx fee");
+        assertTrue(a.approved());
+    }
+
+    @Test
+    void aTokenPrincipalWithNoFeedRefusesAsPriceUnavailable() {
+        CompoundEconomics economics =
+                economics(true, 0, "preview", new PricingService(new StubOracleClient()));
+
+        CompoundAssessment a = economics.assess(true, true, TOKEN,
+                BigInteger.valueOf(999_000_000L), 50L, TX_FEE, AT_MILLIS);
+
+        assertFalse(a.approved());
+        assertEquals(CompoundExclusion.PRICE_UNAVAILABLE, a.exclusion());
+        assertNullNet(a);
+    }
+
+    @Test
+    void aTokenPrincipalWithAStaleFeedRefusesAsPriceUnavailable() {
+        var client = new StubOracleClient();
+        client.anyHeld = OraclePriceFeed.aggregated(TOKEN, BigInteger.ONE, BigInteger.ONE, 1_000L, 2_000L);
+        CompoundEconomics economics = economics(true, 0, "preview", new PricingService(client));
+
+        CompoundAssessment a = economics.assess(true, true, TOKEN,
+                BigInteger.valueOf(999_000_000L), 50L, TX_FEE, AT_MILLIS);
+
+        assertFalse(a.approved());
+        assertEquals(CompoundExclusion.PRICE_UNAVAILABLE, a.exclusion());
+        assertNullNet(a);
+    }
+
+    /** ⛔ A POOLED feed must refuse, never throw — asserted here at the assess() boundary too. */
+    @Test
+    void aTokenPrincipalWithAPooledFeedRefusesWithoutThrowing() {
+        var client = new StubOracleClient();
+        client.usable = new OraclePriceFeed(OraclePriceFeed.Variant.POOLED, TOKEN,
+                BigInteger.ONE, BigInteger.ONE, AT_MILLIS - 1_000, AT_MILLIS + 1_000);
+        CompoundEconomics economics = economics(true, 0, "preview", new PricingService(client));
+
+        CompoundAssessment a = assertDoesNotThrow(() -> economics.assess(true, true, TOKEN,
+                BigInteger.valueOf(999_000_000L), 50L, TX_FEE, AT_MILLIS));
+
+        assertFalse(a.approved());
+        assertEquals(CompoundExclusion.PRICE_UNAVAILABLE, a.exclusion());
+    }
+
     private static void assertNullNet(CompoundAssessment a) {
         assertTrue(a.net() == null && a.expectedFee() == null,
                 "a structural refusal must not publish arithmetic that was never valid");
+    }
+
+    /** Same shape as {@code PricingServiceTest}'s stub — local so this file stays self-contained. */
+    private static final class StubOracleClient extends FluidOracleClient {
+        private OraclePriceFeed usable;
+        private OraclePriceFeed anyHeld;
+
+        StubOracleClient() {
+            super("http://unused.invalid");
+        }
+
+        @Override
+        public Optional<OraclePriceFeed> findFeed(AssetType asset, long atMillis) {
+            return Optional.ofNullable(usable);
+        }
+
+        @Override
+        public Optional<OraclePriceFeed> findFeedIgnoringValidity(AssetType asset) {
+            return Optional.ofNullable(anyHeld);
+        }
     }
 }

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/CompoundExecutorTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/CompoundExecutorTest.java
@@ -38,6 +38,11 @@ class CompoundExecutorTest {
     private static final LoansContractRegistry REGISTRY = LoanFixtures.shippedPreviewRegistry();
     private static final Account ACCOUNT = new Account(LoanFixtures.NETWORK);
     private static final String LOAN_ID = "e833a769ea3a480343175e253eab799ec0b058c99de30cc17160dc37";
+
+    /** Every candidate here is ada-principal, so this never actually reaches the oracle. */
+    private static PricingService pricingService() {
+        return new PricingService(new FluidOracleClient("http://unused.invalid"));
+    }
     private static final String POOL_ID = "00d3513725536642b6fe985ce9ec87d1ebb880497d92e0a8495bc6d0bf";
     private static final BigInteger ESCROW = BigInteger.valueOf(29_109_268L);
 
@@ -126,7 +131,7 @@ class CompoundExecutorTest {
                 LoanFixtures.utxoSupplier(universe), EvalFixtures.protocolParams(), null);
         var executor = new CompoundExecutor(configuration, network, blockEventListener,
                 new FakeAppUtxoService(walletUtxos), ACCOUNT,
-                new FakeScanner(candidates), new CompoundEconomics(configuration, network),
+                new FakeScanner(candidates), new CompoundEconomics(configuration, network, pricingService()),
                 builder, new FakeResolver(), LoanFixtures.utxoSupplier(universe), LoanFixtures.converters(), submitter);
         return new Wiring(executor, submitted);
     }
@@ -201,7 +206,7 @@ class CompoundExecutorTest {
         };
         var executor = new CompoundExecutor(configuration, network, blockEventListener,
                 new FakeAppUtxoService(List.of(wallet())), ACCOUNT, scanner,
-                new CompoundEconomics(configuration, network),
+                new CompoundEconomics(configuration, network, pricingService()),
                 new CompoundTransactionBuilder(REGISTRY, Networks.preview(),
                         LoanFixtures.utxoSupplier(universe()), EvalFixtures.protocolParams(), null),
                 new FakeResolver(), LoanFixtures.utxoSupplier(universe()), LoanFixtures.converters(),

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/ExecutorContextResolutionTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/ExecutorContextResolutionTest.java
@@ -151,9 +151,14 @@ class ExecutorContextResolutionTest {
         }
 
         @Bean
+        PricingService pricingService() {
+            return new PricingService(new FluidOracleClient("http://unused.invalid"));
+        }
+
+        @Bean
         CompoundEconomics economics(AppConfig.CompoundConfiguration configuration,
-                                    AppConfig.Network network) {
-            return new CompoundEconomics(configuration, network);
+                                    AppConfig.Network network, PricingService pricingService) {
+            return new CompoundEconomics(configuration, network, pricingService);
         }
 
         @Bean

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidateForRealTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidateForRealTest.java
@@ -128,7 +128,7 @@ public class LiquidateForRealTest {
             LenderBond bond = new LenderBond(t.tx(), 3, bu.getAddress(), t.loanId(), bu.getInlineDatum(), bd);
 
             var req = new LiquidatePayInAdvanceTransactionBuilder.Request(loan, lu, bond, bu, wallet,
-                    cfg(b, CFG), cfg(b, LMCFG), entry, fromMs, toMs, sl[0], sl[1],
+                    cfg(b, CFG), cfg(b, LMCFG), entry, null, fromMs, toMs, sl[0], sl[1],
                     signer.baseAddress(),
                     new LiquidateTransactionBuilder.ReferenceScripts(null, null, null, null,
                             new TransactionInput(REF_LOAN_CLAIM, 0), null, null), MARGIN);

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidatePayInAdvanceDryEvalTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidatePayInAdvanceDryEvalTest.java
@@ -405,7 +405,7 @@ class LiquidatePayInAdvanceDryEvalTest {
         LiquidatePayInAdvanceTransactionBuilder.Request refRequest =
                 new LiquidatePayInAdvanceTransactionBuilder.Request(base.loan(), base.loanUtxo(),
                         base.bond(), base.bondUtxo(), base.walletUtxo(), base.configUtxo(),
-                        base.lmConfigUtxo(), base.oracle(), base.validFromMillis(),
+                        base.lmConfigUtxo(), base.oracle(), base.principalOracle(), base.validFromMillis(),
                         base.validToMillis(), base.validFromSlot(),
                         base.validToSlot(), base.changeAddress(),
                         new LiquidateTransactionBuilder.ReferenceScripts(
@@ -696,7 +696,7 @@ class LiquidatePayInAdvanceDryEvalTest {
         return new LiquidatePayInAdvanceTransactionBuilder.Request(r.loan(), r.loanUtxo(), r.bond(),
                 r.bondUtxo(),
                 LoanFixtures.adaUtxo(TX_WALLET, 0, LoanFixtures.botAddress(), lovelace),
-                r.configUtxo(), r.lmConfigUtxo(), r.oracle(), r.validFromMillis(), r.validToMillis(),
+                r.configUtxo(), r.lmConfigUtxo(), r.oracle(), r.principalOracle(), r.validFromMillis(), r.validToMillis(),
                 r.validFromSlot(), r.validToSlot(), r.changeAddress(), r.referenceScripts(),
                 r.oracleWindowMarginMillis());
     }
@@ -799,7 +799,7 @@ class LiquidatePayInAdvanceDryEvalTest {
                         FEED_VALID_FROM, feedValidTo),
                 ORACLE_REF_INPUT, ORACLE_REF_SCRIPT, C3_PROVIDER);
         return new LiquidatePayInAdvanceTransactionBuilder.Request(r.loan(), r.loanUtxo(), r.bond(),
-                r.bondUtxo(), r.walletUtxo(), r.configUtxo(), r.lmConfigUtxo(), narrowed,
+                r.bondUtxo(), r.walletUtxo(), r.configUtxo(), r.lmConfigUtxo(), narrowed, r.principalOracle(),
                 r.validFromMillis(), r.validToMillis(), r.validFromSlot(), r.validToSlot(),
                 r.changeAddress(), r.referenceScripts(), r.oracleWindowMarginMillis());
     }
@@ -900,7 +900,10 @@ class LiquidatePayInAdvanceDryEvalTest {
         long validToMillis = millisOf(converters().slot().slotToTime(slots[1]));
         LiquidatePayInAdvanceTransactionBuilder.Request request =
                 new LiquidatePayInAdvanceTransactionBuilder.Request(loan, loanUtxo, bond, bondUtxo,
-                        WALLET_UTXO, CONFIG_UTXO, LM_CONFIG_UTXO, oracle, validFromMillis,
+                        WALLET_UTXO, CONFIG_UTXO, LM_CONFIG_UTXO, oracle,
+                        // WALL 2/3 — this fixture's principal is ada; null means "ada", exactly as
+                        // the Request javadoc documents. The ada-principal invariant rig.
+                        null, validFromMillis,
                         validToMillis, slots[0], slots[1], LoanFixtures.botAddress(),
                         // All-inline shape: every validator travels in the witness set.
                         LiquidateTransactionBuilder.ReferenceScripts.none(),

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidatePayInAdvanceLiveDryEvalTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidatePayInAdvanceLiveDryEvalTest.java
@@ -1,0 +1,811 @@
+package com.fluidtokens.aquarium.offchain.service.loans;
+
+import com.bloxbean.cardano.aiken.AikenTransactionEvaluator;
+import com.bloxbean.cardano.client.address.AddressProvider;
+import com.bloxbean.cardano.client.address.Credential;
+import com.bloxbean.cardano.client.api.TransactionEvaluator;
+import com.bloxbean.cardano.client.api.model.Amount;
+import com.bloxbean.cardano.client.api.model.EvaluationResult;
+import com.bloxbean.cardano.client.api.model.ProtocolParams;
+import com.bloxbean.cardano.client.api.model.Result;
+import com.bloxbean.cardano.client.api.model.Utxo;
+import com.bloxbean.cardano.client.backend.api.DefaultProtocolParamsSupplier;
+import com.bloxbean.cardano.client.backend.blockfrost.service.BFBackendService;
+import com.bloxbean.cardano.client.common.model.Networks;
+import com.bloxbean.cardano.client.common.model.SlotConfigs;
+import com.bloxbean.cardano.client.plutus.blueprint.PlutusBlueprintUtil;
+import com.bloxbean.cardano.client.plutus.blueprint.model.PlutusVersion;
+import com.bloxbean.cardano.client.plutus.spec.BigIntPlutusData;
+import com.bloxbean.cardano.client.plutus.spec.ConstrPlutusData;
+import com.bloxbean.cardano.client.plutus.spec.ListPlutusData;
+import com.bloxbean.cardano.client.plutus.spec.PlutusScript;
+import com.bloxbean.cardano.client.plutus.spec.Redeemer;
+import com.bloxbean.cardano.client.plutus.spec.RedeemerTag;
+import com.bloxbean.cardano.client.transaction.spec.Asset;
+import com.bloxbean.cardano.client.transaction.spec.MultiAsset;
+import com.bloxbean.cardano.client.transaction.spec.Transaction;
+import com.bloxbean.cardano.client.transaction.spec.TransactionInput;
+import com.bloxbean.cardano.client.transaction.spec.TransactionOutput;
+import com.bloxbean.cardano.client.transaction.spec.Withdrawal;
+import com.bloxbean.cardano.client.util.HexUtil;
+import com.fluidtokens.aquarium.offchain.model.AssetType;
+import com.fluidtokens.aquarium.offchain.model.loans.LenderBond;
+import com.fluidtokens.aquarium.offchain.model.loans.LenderManagerDatum;
+import com.fluidtokens.aquarium.offchain.model.loans.Loan;
+import com.fluidtokens.aquarium.offchain.model.loans.LoanDatum;
+import com.fluidtokens.aquarium.offchain.model.loans.OracleEntry;
+import com.fluidtokens.aquarium.offchain.model.loans.Rational;
+import com.fluidtokens.aquarium.offchain.service.LoansContractRegistry;
+import com.fluidtokens.aquarium.offchain.util.LedgerCeilings;
+import com.fluidtokens.aquarium.offchain.util.WalletInputSelection;
+import org.cardanofoundation.conversions.CardanoConverters;
+import org.cardanofoundation.conversions.ClasspathConversionsFactory;
+import org.cardanofoundation.conversions.domain.NetworkType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import java.math.BigInteger;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * ⛔ <b>The TOKEN-PRINCIPAL sibling of {@link ConvertLiveDryEvalTest}</b> — same shape, same
+ * discipline, driving {@link LiquidatePayInAdvanceTransactionBuilder} for a loan whose principal is
+ * USDM (not ada), so that {@code request.principalOracle()} (the token-principals slice, WALLS 1-4)
+ * is exercised against the real deployed PlutusV3 machine with <b>two real oracle legs</b>.
+ *
+ * <h2>Why this had to be a LIVE rig</h2>
+ * Findings §59.6 (docs/lending-v4-findings.md:5558-5601): the offline rigs cannot synthesise a second
+ * real oracle asset. {@code charlie_specs}/{@code verification_keys} are closed validator parameters
+ * and each priced asset is its own compiled oracle script ({@code retrieve_oracle_data} resolves its
+ * feed with {@code pairs.get_first(self.redeemers, Withdraw(oraclePaymentCredential))} — one redeemer
+ * per credential). This repo only ever had real chain coordinates for ONE deployed oracle asset
+ * offline. The live mainnet chain has both FLDT's and USDM's oracles deployed for real, so only a
+ * live rig can drive both legs through the real machine at once.
+ *
+ * <h2>⚠ Gated on its OWN key, deliberately</h2>
+ * {@code BLOCKFROST_MAINNET_KEY}, not {@code BLOCKFROST_KEY} — same reasoning as
+ * {@link ConvertLiveDryEvalTest}: a preview key pointed at mainnet reads as a code failure (HTTP 403),
+ * not a config problem.
+ *
+ * <h2>⛔ READ-ONLY. NOTHING IS SUBMITTED.</h2>
+ * Every {@link BFBackendService} here is constructed from a Blockfrost key with read scope only. The
+ * production constructor of {@link LiquidatePayInAdvanceTransactionBuilder} used below returns an
+ * <b>unsigned</b> {@link Transaction} — there is no signer, no key, no {@code complete()}/submit call
+ * anywhere in this file.
+ *
+ * <h2>What this proves, and what it does not</h2>
+ * It proves the scripts pass — phase 2, the failure that forfeits collateral — for the token-principal
+ * shape, for real, against both real oracles. It says nothing about the ledger's phase 1 (fees,
+ * min-ada, witness sets, collateral adequacy — CCL trap 11).
+ */
+@EnabledIfEnvironmentVariable(named = "BLOCKFROST_MAINNET_KEY", matches = ".+")
+class LiquidatePayInAdvanceLiveDryEvalTest {
+
+    private static final String URL = "https://cardano-mainnet.blockfrost.io/api/v0/";
+    private static final String ORACLE_REGISTRY_URL = "https://api.fluidtokens.com/get-oracle-tokens";
+
+    // ---- the pinned live candidate, verified on chain 2026-09-09 ----------------------------------
+
+    private static final String LOAN_TX =
+            "0d080eb21bf4951af926acdab34a5b12b0aaf4c62c52bc6b999fc849967f6c4a";
+    private static final int LOAN_IX = 1;
+    private static final int BOND_IX = 3;
+    private static final String LOAN_ID = "279499ff77d9c8efacda5940a06659f091e1aaa15ce929f779d8d3fd";
+
+    private static final AssetType FLDT =
+            new AssetType("577f0b1342f8f8f4aed3388b80a8535812950c7a892495c0ecdf0f1e", "0014df10464c4454");
+    private static final AssetType USDM =
+            new AssetType("c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad", "0014df105553444d");
+
+    /**
+     * The bot wallet, public. Holds USDM in a multi-asset UTxO — set {@code REAL_BOT_WALLET} to a
+     * different address to exercise a different wallet's shape; this is the default because the
+     * whole point of this rig is the token-aware selection from slice 3 against the REAL shape.
+     */
+    private static final String BOT_WALLET =
+            "addr1q8kfqpcpm3c77sstcf9a5mzgfa0eya5rd2h8838hpd75fymg9lkpepnud2jejx80dujud0wn3sw86q7hrs95lg3utwkqvd5zcd";
+
+    // ---- the main/LM config — the SAME global config ConvertLiveDryEvalTest pins and verifies ------
+
+    private static final String CONFIG_TX =
+            "7b9f20dbadaebe1400915e4a63444a9eb7515c21c1114d4bc9c77f1455148cb0";
+    private static final int CONFIG_IX = 0;
+    private static final String LM_CONFIG_TX =
+            "78d4a273b15382a671bb04fe647a9b621665427f1405e3903817beecfde35bfa";
+    private static final int LM_CONFIG_IX = 0;
+
+    // ---- mainnet deployment coordinates (same registry ConvertLiveDryEvalTest derives) -------------
+
+    private static final String CONFIG_POLICY = "db2c498e1b93da91e6a79f58526a1e66591d97ace3f8e43d2619b416";
+    private static final String LM_CONFIG_POLICY = "a56b0ac2654663f395601601a7825649e5488905648747e912d870e4";
+    private static final String ASSET_NAME = "706172616d6574657273";
+    private static final String SMART_TOKENS = "fca77bcce1e5e73c97a0bfa8c90f7cd2faff6fd6ed5b6fec1c04eefa";
+    private static final String MS_POOL_POLICY = "f5808c2c990d86da54bfc97d89cee6efa20cd8461616359478d96b4c";
+    private static final String MS_POOL_SPEND = "ea07b733d932129c378af627436e7cbc2ef0bf96e0036bb51b3bde6b";
+    private static final String MS_ORDER_SPEND = "c3e28c36c3447315ba5a56f33da6a6ddc1770a876a8d9f0cb3a97c4c";
+
+    // ---- the two oracle deployments, for the TICKET's cross-check (test 2) ------------------------
+    // ⚠ Fetched live via FluidOracleClient by TOKEN for the actual build — these constants are only
+    // a cross-check that the live registry still publishes what the ticket pinned 2026-09-09.
+
+    private static final String ORACLE_POLICY = "93794f9b7f3dc632cb889c7aec7d334f016f532e64f16141b6895f5b";
+    private static final AssetType FLDT_ORACLE = new AssetType(ORACLE_POLICY, "6f7261636c65464c44544333");
+    private static final AssetType USDM_ORACLE = new AssetType(ORACLE_POLICY, "6f7261636c655553444d4333");
+    private static final TransactionInput FLDT_ORACLE_REF_INPUT = new TransactionInput(
+            "e874273fd5a4765920837d3ec0d0a3bdcb6e689911335de971a38b5ca4a881f5", 0);
+    private static final TransactionInput FLDT_ORACLE_REF_SCRIPT = new TransactionInput(
+            "e5943f9241ceaaae437c35d8d5e769cbae60e2eebb0f5077ac9ebd54aa23a3fb", 0);
+    private static final TransactionInput USDM_ORACLE_REF_INPUT = new TransactionInput(
+            "5f6bbacd3da81e917812049192fffba44e0c6b2bbd397f8c2a296d7afbee9d6b", 0);
+    private static final TransactionInput USDM_ORACLE_REF_SCRIPT = new TransactionInput(
+            "2d557048a3750f00549641048cd82081a8f033479c5d0454886b224675d2c975", 1);
+
+    // ---- operator defaults, mirrored from application.yaml's mainnet document ----------------------
+
+    /** {@code loans.liquidation.oracle-window-margin-seconds}, mainnet default 30. */
+    private static final long ORACLE_WINDOW_MARGIN_MILLIS = 30_000L;
+    /** {@code loans.liquidation.validity-window-seconds}, mainnet default 120. */
+    private static final long VALIDITY_WINDOW_MILLIS = 120_000L;
+    /** {@code LiquidationExecutor.TOKEN_PRINCIPAL_MIN_ADA_CEILING} — mirrored, not imported (private there). */
+    private static final BigInteger TOKEN_PRINCIPAL_MIN_ADA_CEILING = BigInteger.valueOf(2_000_000L);
+
+    /** What the evaluator actually said, kept because CCL's wrapper throws it away. */
+    private static String lastEvaluatorMessage;
+
+    private static BFBackendService backend() {
+        return new BFBackendService(URL, System.getenv("BLOCKFROST_MAINNET_KEY"));
+    }
+
+    private static LoansContractRegistry registry() {
+        return new LoansContractRegistry(CONFIG_POLICY, LM_CONFIG_POLICY, ASSET_NAME, SMART_TOKENS,
+                MS_POOL_POLICY, MS_POOL_SPEND, MS_ORDER_SPEND);
+    }
+
+    private static Utxo output(BFBackendService backend, String txHash, int index) throws Exception {
+        Result<Utxo> r = backend.getUtxoService().getTxOutput(txHash, index);
+        assertTrue(r.isSuccessful(), "could not read " + txHash + "#" + index + ": " + r.getResponse());
+        return r.getValue();
+    }
+
+    private static List<Utxo> liveWalletUtxos(BFBackendService backend, String address) throws Exception {
+        Result<List<Utxo>> r = backend.getUtxoService().getUtxos(address, 100, 1);
+        assertTrue(r.isSuccessful(), "could not read the wallet's UTxOs: " + r.getResponse());
+        List<Utxo> all = new ArrayList<>(r.getValue());
+        assertFalse(all.isEmpty(), "the wallet at " + address + " holds no UTxOs");
+        System.out.println("REAL WALLET: " + all.size() + " UTxOs at " + address);
+        return all;
+    }
+
+    private static String oracleScriptCbor(BFBackendService backend, OracleEntry entry) throws Exception {
+        Utxo published = output(backend, entry.referenceScript().getTransactionId(),
+                entry.referenceScript().getIndex());
+        Result<String> cbor = backend.getScriptService()
+                .getPlutusScriptCbor(published.getReferenceScriptHash());
+        assertTrue(cbor.isSuccessful(), "could not fetch the oracle script: " + cbor.getResponse());
+        return cbor.getValue();
+    }
+
+    private static void entryReferenceInputs(BFBackendService backend, OracleEntry entry,
+                                             List<Utxo> universe) throws Exception {
+        universe.add(output(backend, entry.referenceInput().getTransactionId(),
+                entry.referenceInput().getIndex()));
+        universe.add(output(backend, entry.referenceScript().getTransactionId(),
+                entry.referenceScript().getIndex()));
+        if (entry.charlieProviderReferenceInput() != null) {
+            universe.add(output(backend, entry.charlieProviderReferenceInput().getTransactionId(),
+                    entry.charlieProviderReferenceInput().getIndex()));
+        }
+    }
+
+    /**
+     * The six shipped reference-script coordinates THIS builder honours (mirrors {@code attachValidators}
+     * / {@code publishedScripts} in {@link LiquidatePayInAdvanceTransactionBuilder}): loan, loan-spend,
+     * lender-manager, lender-manager-spend, loan-claim-action, and — unlike the convert rig —
+     * {@code lm-liquidate-and-pay-in-advance-action} rather than {@code lm-liquidate-and-convert-action}.
+     * Read from {@code application.yaml}, not copied from it (same reasoning {@link ConvertLiveDryEvalTest}
+     * documents): a coordinate move in config cannot leave this rig behind.
+     */
+    private static LiquidateTransactionBuilder.ReferenceScripts referenceScripts() {
+        return new LiquidateTransactionBuilder.ReferenceScripts(
+                shippedRef("loan"), shippedRef("loan-spend"), shippedRef("lender-manager"),
+                shippedRef("lender-manager-spend"), shippedRef("loan-claim-action"),
+                null, null, shippedRef("lm-liquidate-and-pay-in-advance-action"), null);
+    }
+
+    private static List<TransactionInput> referenceScriptCoordinates(
+            LiquidateTransactionBuilder.ReferenceScripts scripts) {
+        return Stream.of(scripts.loan(), scripts.loanSpend(), scripts.lenderManager(),
+                        scripts.lenderManagerSpend(), scripts.loanClaimAction(),
+                        scripts.lmLiquidateAndPayInAdvanceAction())
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    /**
+     * The {@code txHash#index} default the MAINNET document ships for one liquidation reference
+     * script. Only the mainnet document is consulted — the preview one deliberately blanks these.
+     * Mirrors {@link ConvertLiveDryEvalTest#shippedRef}.
+     */
+    private static TransactionInput shippedRef(String key) {
+        String yaml;
+        try {
+            yaml = java.nio.file.Files.readString(
+                    java.nio.file.Path.of("src/main/resources/application.yaml"));
+        } catch (java.io.IOException e) {
+            throw new IllegalStateException("cannot read application.yaml", e);
+        }
+        int preview = yaml.indexOf("on-profile: preview");
+        String mainnet = preview > 0 ? yaml.substring(0, preview) : yaml;
+
+        java.util.regex.Matcher m = java.util.regex.Pattern
+                .compile("(?m)^\\s*" + java.util.regex.Pattern.quote(key)
+                        + ":\\s*\\$\\{[A-Z_]+:([0-9a-f]{64})#(\\d+)}\\s*$")
+                .matcher(mainnet);
+        assertTrue(m.find(), "application.yaml's mainnet document ships no reference-script "
+                + "coordinate for '" + key + "'; the rig reads what production reads, so a missing "
+                + "key here is a real configuration gap rather than a test problem");
+        return TransactionInput.builder()
+                .transactionId(m.group(1)).index(Integer.parseInt(m.group(2))).build();
+    }
+
+    /** Mirrors {@code PayInAdvanceLiquidationRouter.validitySlots} — inward clamp, same rule. */
+    private static long[] validitySlots(CardanoConverters converters, long validFromMillis, long validToMillis) {
+        long slotFrom = converters.time().toSlot(utc(validFromMillis));
+        if (millisOf(converters.slot().slotToTime(slotFrom)) < validFromMillis) {
+            slotFrom += 1;
+        }
+        long slotTo = converters.time().toSlot(utc(validToMillis));
+        if (millisOf(converters.slot().slotToTime(slotTo)) > validToMillis) {
+            slotTo -= 1;
+        }
+        return new long[]{slotFrom, slotTo};
+    }
+
+    private static LocalDateTime utc(long millis) {
+        return LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneOffset.UTC);
+    }
+
+    private static long millisOf(LocalDateTime time) {
+        return time.toInstant(ZoneOffset.UTC).toEpochMilli();
+    }
+
+    // ---- the build ----------------------------------------------------------------------------------
+
+    private record Built(Transaction transaction, List<Utxo> universe, List<PlutusScript> oracleScripts,
+                         LiquidatePayInAdvanceTransactionBuilder.Request request,
+                         LiquidatePayInAdvanceTransactionBuilder.Numbers numbers,
+                         LoansContractRegistry registry, TransactionEvaluator evaluator) {
+    }
+
+    private Built build() throws Exception {
+        BFBackendService backend = backend();
+        LoansContractRegistry registry = registry();
+        CardanoConverters converters = ClasspathConversionsFactory.createConverters(NetworkType.MAINNET);
+
+        Utxo loanUtxo = output(backend, LOAN_TX, LOAN_IX);
+        Utxo bondUtxo = output(backend, LOAN_TX, BOND_IX);
+        Utxo configUtxo = output(backend, CONFIG_TX, CONFIG_IX);
+        Utxo lmConfigUtxo = output(backend, LM_CONFIG_TX, LM_CONFIG_IX);
+
+        LoanDatum loanDatum = new LoanDatumConverter().deserialize(loanUtxo.getInlineDatum());
+        LenderManagerDatum bondDatum = new LenderManagerDatumConverter().deserialize(bondUtxo.getInlineDatum());
+        assertEquals(USDM, loanDatum.principalAsset(), "the pinned loan's principal is not USDM");
+        assertEquals(FLDT, loanDatum.collateral().assetType(), "the pinned loan's collateral is not FLDT");
+        assertTrue(bondDatum.shouldLiquidationConvertToPrincipal(),
+                "the pinned bond is not a pay-in-advance (convert) bond");
+        var liquidation = (com.fluidtokens.aquarium.offchain.model.loans.LiquidationMode.Liquidation)
+                loanDatum.liquidationMode();
+
+        BigInteger collateralAmount = BigInteger.valueOf(loanUtxo.getAmount().stream()
+                .filter(a -> a.getUnit().equalsIgnoreCase(FLDT.toUnit()))
+                .findFirst().orElseThrow(() -> new IllegalStateException("loan utxo carries no FLDT"))
+                .getQuantity().longValueExact());
+        BigInteger loanLovelace = loanUtxo.getAmount().stream()
+                .filter(a -> a.getUnit().equalsIgnoreCase("lovelace"))
+                .findFirst().map(Amount::getQuantity).orElse(BigInteger.ZERO);
+
+        Loan loan = new Loan(LOAN_TX, LOAN_IX, loanUtxo.getAddress(), LOAN_ID, collateralAmount, loanLovelace,
+                loanDatum);
+        LenderBond bond = new LenderBond(LOAN_TX, BOND_IX, bondUtxo.getAddress(), LOAN_ID,
+                bondUtxo.getInlineDatum(), bondDatum);
+
+        // ⛔ The two real oracle legs, FETCHED by TOKEN — the same FluidOracleClient the convert rig
+        // uses. Both are `preferredOracle: multisig` on mainnet (not c3, unlike preview); the client
+        // resolves whatever variant the registry publishes and the builder does what it does for it.
+        FluidOracleClient oracles = new FluidOracleClient(ORACLE_REGISTRY_URL);
+        oracles.refresh();
+        OracleEntry fldtEntry = oracles.findEntry(FLDT)
+                .orElseThrow(() -> new IllegalStateException("no mainnet oracle entry for FLDT"));
+        OracleEntry usdmEntry = oracles.findEntry(USDM)
+                .orElseThrow(() -> new IllegalStateException("no mainnet oracle entry for USDM"));
+        assertTrue(fldtEntry.usableForLiquidation(),
+                "the live FLDT feed is not usable: signatures=" + fldtEntry.signatures().size()
+                        + " threshold=" + fldtEntry.threshold());
+        assertTrue(usdmEntry.usableForLiquidation(),
+                "the live USDM feed is not usable: signatures=" + usdmEntry.signatures().size()
+                        + " threshold=" + usdmEntry.threshold());
+        // WALL 3's precondition: a SECOND withdraw-0 only fires when the two oracle credentials
+        // differ. If they ever collided this rig would silently stop exercising the thing it exists
+        // for, so refuse loudly rather than build a single-oracle transaction under a two-oracle name.
+        assertFalse(fldtEntry.rewardAddress().equals(usdmEntry.rewardAddress()),
+                "FLDT and USDM share one oracle credential on mainnet today — WALL 3's second "
+                        + "withdraw-0 would be skipped and this rig would prove nothing about it");
+
+        // The window: strictly inside BOTH feeds' windows, with the operator's margin left over both,
+        // then clamped inward to whole slots exactly as PayInAdvanceLiquidationRouter does — the
+        // builder's V3 check reads request.validToMillis(), which must be the POSIX time
+        // validToSlot converts back to, so the on-chain recomputation matches.
+        long validFromRaw = Math.max(fldtEntry.feed().validFrom(), usdmEntry.feed().validFrom()) + 2_000L;
+        long feedValidToMin = Math.min(fldtEntry.feed().validTo(), usdmEntry.feed().validTo());
+        long validToRaw = Math.min(feedValidToMin - ORACLE_WINDOW_MARGIN_MILLIS - 5_000L,
+                validFromRaw + VALIDITY_WINDOW_MILLIS);
+        assertTrue(validToRaw > validFromRaw,
+                "the fetched feeds' windows do not overlap enough to build a candidate right now — re-run. "
+                        + "FLDT [" + fldtEntry.feed().validFrom() + "," + fldtEntry.feed().validTo() + "] "
+                        + "USDM [" + usdmEntry.feed().validFrom() + "," + usdmEntry.feed().validTo() + "]");
+
+        long[] slots = validitySlots(converters, validFromRaw, validToRaw);
+        long validFromMillis = millisOf(converters.slot().slotToTime(slots[0]));
+        long validToMillis = millisOf(converters.slot().slotToTime(slots[1]));
+
+        // ⛔ The wallet: the REAL live UTxO set, so the token-aware selection from slice 3
+        // (WalletInputSelection.smallestSufficientToken) is exercised against the REAL wallet shape,
+        // not a synthetic one — this is the whole point of pinning the candidate to this wallet.
+        String realWallet = System.getenv().getOrDefault("REAL_BOT_WALLET", BOT_WALLET);
+        List<Utxo> walletUtxos = liveWalletUtxos(backend, realWallet);
+
+        LiquidateTransactionBuilder.ReferenceScripts scripts = referenceScripts();
+        List<TransactionInput> refScriptCoords = referenceScriptCoordinates(scripts);
+
+        // ⛔ BOTH oracle scripts, fetched by their OWN reference-script hashes — findings §59.6's wall.
+        // Plus lm_liquidate_and_pay_in_advance_action itself: mainnet publishes it as a reference
+        // script (application.yaml), so it travels by REFERENCE here rather than witness-attached —
+        // unlike every existing offline fixture of this builder, which leaves it inline. EvalFixtures'
+        // base scriptSupplier list does not carry it (no offline fixture ever needed it referenced),
+        // so it is handed in here as an extra rather than by editing that shared test helper.
+        PlutusScript fldtOracleScript = PlutusBlueprintUtil.getPlutusScriptFromCompiledCode(
+                oracleScriptCbor(backend, fldtEntry), PlutusVersion.v3);
+        PlutusScript usdmOracleScript = PlutusBlueprintUtil.getPlutusScriptFromCompiledCode(
+                oracleScriptCbor(backend, usdmEntry), PlutusVersion.v3);
+        List<PlutusScript> extraScripts = List.of(fldtOracleScript, usdmOracleScript,
+                registry.getLmLiquidateAndPayInAdvanceActionScript());
+
+        // ⛔ THE UNIVERSE FIRST — every reference-script UTxO this builder can name, both oracle legs'
+        // referenceInput/referenceScript(/provider), the loan/bond/config pair and the FULL wallet
+        // UTxO set (not just the one that ends up nominated — balancing may need another one).
+        List<Utxo> universe = new ArrayList<>(List.of(loanUtxo, bondUtxo, configUtxo, lmConfigUtxo));
+        universe.addAll(walletUtxos);
+        for (TransactionInput in : refScriptCoords) {
+            universe.add(output(backend, in.getTransactionId(), in.getIndex()));
+        }
+        entryReferenceInputs(backend, fldtEntry, universe);
+        entryReferenceInputs(backend, usdmEntry, universe);
+
+        var aiken = new AikenTransactionEvaluator(
+                LoanFixtures.utxoSupplier(universe),
+                new DefaultProtocolParamsSupplier(backend.getEpochService()),
+                EvalFixtures.scriptSupplier(registry, extraScripts),
+                SlotConfigs.mainnet());
+
+        // ⚑ CCL wraps a failed evaluation as TxBuildException and DROPS the evaluator's own message —
+        // decorated so the real reason (which redeemer, why) survives to the report.
+        TransactionEvaluator evaluator = (cbor, inputUtxos) -> {
+            try {
+                Result<List<EvaluationResult>> result = aiken.evaluateTx(cbor, inputUtxos);
+                if (!result.isSuccessful()) {
+                    lastEvaluatorMessage = String.valueOf(result.getResponse());
+                }
+                return result;
+            } catch (RuntimeException | com.bloxbean.cardano.client.api.exception.ApiException e) {
+                StringBuilder chain = new StringBuilder();
+                for (Throwable t = e; t != null && t != t.getCause(); t = t.getCause()) {
+                    chain.append(t.getClass().getSimpleName()).append(": ").append(t.getMessage()).append(" | ");
+                }
+                lastEvaluatorMessage = chain + describe(cbor) + resolved(inputUtxos);
+                throw e;
+            }
+        };
+
+        var builder = new LiquidatePayInAdvanceTransactionBuilder(registry, Networks.mainnet(), backend, evaluator);
+
+        // The five numbers, off the SAME builder that will build — never re-derived independently, so
+        // there is nothing here that could silently drift from what build() itself recomputes.
+        LiquidatePayInAdvanceTransactionBuilder.Numbers numbers =
+                builder.numbers(loan, bond, fldtEntry, usdmEntry, validFromMillis);
+        String candidateState = "collateral=" + collateralAmount + " " + FLDT.toUnit()
+                + " remainingDebt=" + numbers.remainingDebt() + " " + USDM.toUnit()
+                + " partialLiquidationPenaltyPerMille=" + liquidation.partialLiquidationPenaltyPerMille()
+                + " equity=" + numbers.equity() + " " + FLDT.toUnit()
+                + " at validFromMillis=" + validFromMillis
+                + " | FLDT price=" + fldtEntry.feed().priceInLovelaces() + "/"
+                + fldtEntry.feed().priceDenominator() + " lovelace"
+                + " | USDM price=" + usdmEntry.feed().priceInLovelaces() + "/"
+                + usdmEntry.feed().priceDenominator() + " lovelace";
+        System.out.println("candidate state: " + candidateState);
+        // Same precondition PayInAdvanceLiquidationRouter checks BEFORE ever touching the builder
+        // (and that the builder itself re-checks at build() as its own first guard) — mirrored here
+        // so a non-positive-equity candidate is refused before wasting a wallet-selection round trip,
+        // exactly as production would. This is a LIVE rig: the pinned candidate's equity is a fact
+        // about the CHAIN at query time, not something this test controls, and a thin-margin position
+        // can cross zero between the ticket's pin and this run (interest accrual + oracle drift).
+        assertTrue(numbers.equity().signum() > 0,
+                "the pinned candidate no longer has positive equity — " + candidateState);
+        BigInteger lenderPayout = numbers.convertedLoanCollateralToPrincipalAmount();
+
+        // T-052 / MarketGate's Part 2: the smallest wallet utxo carrying enough USDM plus enough ada
+        // for the fee ceiling and the min-ada rider — mirrors LiquidationExecutor.nominate()'s
+        // token-principal branch exactly, against the REAL live protocol params.
+        ProtocolParams liveParams = new DefaultProtocolParamsSupplier(backend.getEpochService()).getProtocolParams();
+        BigInteger requiredAda = LedgerCeilings.maxPossibleFee(liveParams).add(TOKEN_PRINCIPAL_MIN_ADA_CEILING);
+        Utxo walletUtxo = WalletInputSelection.smallestSufficientToken(walletUtxos, USDM, lenderPayout, requiredAda)
+                .orElseThrow(() -> new AssertionError(
+                        "no utxo at " + realWallet + " carries >= " + lenderPayout + " " + USDM.toUnit()
+                                + " alongside >= " + requiredAda + " lovelace (fee ceiling + min-ada rider) — "
+                                + "this is a wallet-funding gap, not a rig or validator defect"));
+
+        var request = new LiquidatePayInAdvanceTransactionBuilder.Request(loan, loanUtxo, bond, bondUtxo,
+                walletUtxo, configUtxo, lmConfigUtxo, fldtEntry, usdmEntry,
+                validFromMillis, validToMillis, slots[0], slots[1],
+                walletUtxo.getAddress(), scripts, ORACLE_WINDOW_MARGIN_MILLIS);
+
+        Transaction transaction = builder.build(request);
+        return new Built(transaction, universe, List.of(fldtOracleScript, usdmOracleScript), request, numbers,
+                registry, evaluator);
+    }
+
+    // ---- diagnostics, kept for a failing build ------------------------------------------------------
+
+    private static String describe(byte[] cbor) {
+        try {
+            Transaction tx = Transaction.deserialize(cbor);
+            StringBuilder out = new StringBuilder("\n--- the body the evaluator saw ---\n");
+            int i = 0;
+            out.append("reference inputs (body order):\n");
+            for (var ri : tx.getBody().getReferenceInputs()) {
+                out.append("  [").append(i++).append("] ").append(ri.getTransactionId())
+                        .append('#').append(ri.getIndex()).append('\n');
+            }
+            i = 0;
+            out.append("withdrawals (body order):\n");
+            for (var w : tx.getBody().getWithdrawals()) {
+                out.append("  [").append(i++).append("] ").append(w.getRewardAddress()).append('\n');
+            }
+            if (tx.getWitnessSet() != null && tx.getWitnessSet().getRedeemers() != null) {
+                out.append("redeemers:\n");
+                for (var r : tx.getWitnessSet().getRedeemers()) {
+                    out.append("  ").append(r.getTag()).append(':').append(r.getIndex()).append('\n');
+                }
+            }
+            out.append("cbor: ").append(HexUtil.encodeHexString(cbor)).append('\n');
+            return out.toString();
+        } catch (Exception e) {
+            return "\n(could not decode the body the evaluator saw: " + e + ")";
+        }
+    }
+
+    private static String resolved(Set<Utxo> inputs) {
+        StringBuilder out = new StringBuilder("\n--- what the evaluator can resolve ---\n");
+        for (Utxo u : inputs) {
+            String datum = u.getInlineDatum() == null ? "(no inline datum)"
+                    : u.getInlineDatum().substring(0, Math.min(72, u.getInlineDatum().length())) + "…";
+            out.append("  ").append(u.getTxHash(), 0, 12).append('#').append(u.getOutputIndex())
+                    .append("  ").append(u.getAddress(), 0, Math.min(20, u.getAddress().length()))
+                    .append("…  ").append(datum).append('\n');
+        }
+        return out.toString();
+    }
+
+    // ---- reading the built body ----------------------------------------------------------------------
+
+    private static String rewardAddress(String scriptHash) {
+        return AddressProvider.getRewardAddress(Credential.fromScript(scriptHash), Networks.mainnet()).getAddress();
+    }
+
+    private static String paymentCredentialOf(String address) {
+        return new com.bloxbean.cardano.client.address.Address(address)
+                .getPaymentCredentialHash().map(HexUtil::encodeHexString).orElse("");
+    }
+
+    private static List<TransactionOutput> assetManagerOutputs(Transaction tx, LoansContractRegistry registry) {
+        String assetManagerSpend = registry.getAssetManagerSpendScriptHash();
+        List<TransactionOutput> filtered = new ArrayList<>();
+        for (TransactionOutput output : tx.getBody().getOutputs()) {
+            if (assetManagerSpend.equals(paymentCredentialOf(output.getAddress()))) {
+                filtered.add(output);
+            }
+        }
+        return filtered;
+    }
+
+    private static BigInteger quantityOf(TransactionOutput output, AssetType asset) {
+        return output.getValue().getMultiAssets().stream()
+                .filter(multiAsset -> multiAsset.getPolicyId().equalsIgnoreCase(asset.policyId()))
+                .flatMap(multiAsset -> multiAsset.getAssets().stream())
+                .filter(a -> HexUtil.encodeHexString(a.getNameAsBytes()).equalsIgnoreCase(asset.assetName()))
+                .map(Asset::getValue)
+                .reduce(BigInteger.ZERO, BigInteger::add);
+    }
+
+    private static int flattenedCount(TransactionOutput output) {
+        int tokens = output.getValue().getMultiAssets().stream()
+                .mapToInt(multiAsset -> multiAsset.getAssets().size()).sum();
+        return tokens + (output.getValue().getCoin().signum() > 0 ? 1 : 0);
+    }
+
+    private static int withdrawalIndexOf(Transaction tx, String rewardAddress) {
+        List<Withdrawal> withdrawals = tx.getBody().getWithdrawals();
+        for (int i = 0; i < withdrawals.size(); i++) {
+            if (withdrawals.get(i).getRewardAddress().equals(rewardAddress)) {
+                return i;
+            }
+        }
+        throw new AssertionError("no withdrawal at " + rewardAddress);
+    }
+
+    /**
+     * {@code ClaimData.principalOracleRefInputIndex} (field 3, 0-indexed) out of the
+     * {@code loan_claim_action} withdraw redeemer — {@code LiquidationTxEncoder.claimData}'s layout:
+     * {@code Constr 0 [ liquidationMode, lenderBondOutputIndex, collateralOracleRefInputIndex,
+     * principalOracleRefInputIndex, lenderAuth, equity, loanId, remainingDebt ]}, itself field 1 of
+     * the redeemer's {@code Constr 0 [ configRefInputIndex, [claimData, ...] ]}.
+     */
+    private static int principalOracleRefInputIndex(Transaction tx, LoansContractRegistry registry) {
+        String rewardAddr = rewardAddress(registry.getLoanClaimActionScriptHash());
+        int widx = withdrawalIndexOf(tx, rewardAddr);
+        Redeemer redeemer = tx.getWitnessSet().getRedeemers().stream()
+                .filter(r -> r.getTag() == RedeemerTag.Reward && r.getIndex().intValue() == widx)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no reward redeemer for loan_claim_action"));
+        ConstrPlutusData top = (ConstrPlutusData) redeemer.getData();
+        ListPlutusData claims = (ListPlutusData) top.getData().getPlutusDataList().get(1);
+        ConstrPlutusData claim = (ConstrPlutusData) claims.getPlutusDataList().get(0);
+        BigIntPlutusData idx = (BigIntPlutusData) claim.getData().getPlutusDataList().get(3);
+        return idx.getValue().intValueExact();
+    }
+
+    /** Decrements the lender's paid-in-advance USDM quantity by exactly one base unit, in place. */
+    private static Transaction decrementLenderPayoutByOne(Transaction source,
+                                                           LoansContractRegistry registry) throws Exception {
+        Transaction mutated = Transaction.deserialize(source.serialize());
+        TransactionOutput lenderOutput = assetManagerOutputs(mutated, registry).stream()
+                .filter(o -> quantityOf(o, USDM).signum() > 0)
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException(
+                        "no asset-manager output carries USDM — cannot perturb the payout"));
+        boolean decremented = false;
+        for (MultiAsset ma : lenderOutput.getValue().getMultiAssets()) {
+            if (!ma.getPolicyId().equalsIgnoreCase(USDM.policyId())) {
+                continue;
+            }
+            for (Asset asset : ma.getAssets()) {
+                if (HexUtil.encodeHexString(asset.getNameAsBytes()).equalsIgnoreCase(USDM.assetName())) {
+                    asset.setValue(asset.getValue().subtract(BigInteger.ONE));
+                    decremented = true;
+                }
+            }
+        }
+        if (!decremented) {
+            throw new IllegalStateException("found the lender's asset-manager output but not its USDM entry");
+        }
+        return mutated;
+    }
+
+    // ---- the assertions -------------------------------------------------------------------------------
+
+    /**
+     * ⛔ THE ONE THIS RIG EXISTS FOR: a real token-principal pay-in-advance liquidation, assembled and
+     * evaluated against the deployed validators, with BOTH real oracle legs.
+     */
+    @Test
+    void theRealTokenPrincipalCandidateBuildsAndEveryScriptEvaluates() throws Exception {
+        Built built;
+        try {
+            built = build();
+        } catch (Exception e) {
+            throw new AssertionError("the token-principal pay-in-advance build failed. What the "
+                    + "evaluator said: " + lastEvaluatorMessage, e);
+        }
+
+        Transaction rebuilt = Transaction.deserialize(built.transaction().serialize());
+        assertNotNull(rebuilt.getWitnessSet(), "the built transaction has no witness set");
+        List<Redeemer> redeemers = rebuilt.getWitnessSet().getRedeemers();
+        assertNotNull(redeemers, "the built transaction has no redeemers");
+        assertFalse(redeemers.isEmpty());
+
+        // ⛔ Every redeemer this shape must carry, identified STRUCTURALLY (by reward address / tag),
+        // never by an assumed total — CCL trap 14: two redeemers can be byte-indistinguishable, and a
+        // total alone cannot tell "the right six" from "some six".
+        long spends = redeemers.stream().filter(r -> r.getTag() == RedeemerTag.Spend).count();
+        long mints = redeemers.stream().filter(r -> r.getTag() == RedeemerTag.Mint).count();
+        assertEquals(2, spends, "the loan and bond spends");
+        assertEquals(1, mints, "the loan-NFT burn");
+
+        Set<String> withdrawalAddrs = new LinkedHashSet<>();
+        rebuilt.getBody().getWithdrawals().forEach(w -> withdrawalAddrs.add(w.getRewardAddress()));
+        LoansContractRegistry registry = built.registry();
+        assertTrue(withdrawalAddrs.contains(rewardAddress(registry.getLoanPolicyId())), "loan withdraw-0 missing");
+        assertTrue(withdrawalAddrs.contains(rewardAddress(registry.getLoanClaimActionScriptHash())),
+                "loan_claim_action withdraw-0 missing");
+        assertTrue(withdrawalAddrs.contains(rewardAddress(registry.getLenderManagerWithdrawScriptHash())),
+                "lenderManager withdraw-0 missing");
+        assertTrue(withdrawalAddrs.contains(rewardAddress(registry.getLmLiquidateAndPayInAdvanceActionScriptHash())),
+                "lm_liquidate_and_pay_in_advance_action withdraw-0 missing");
+        assertTrue(withdrawalAddrs.contains(built.request().oracle().rewardAddress()),
+                "collateral (FLDT) oracle withdraw-0 missing");
+        assertTrue(withdrawalAddrs.contains(built.request().principalOracle().rewardAddress()),
+                "principal (USDM) oracle withdraw-0 missing — WALL 3's second withdraw-0 did not happen");
+        System.out.println("withdrawals (" + withdrawalAddrs.size() + "): " + withdrawalAddrs);
+
+        // ⛔ Ex-units off the BUILT, DESERIALISED transaction — never off an evaluator's report. A
+        // rig-supplied evaluator makes the report look right while production has none (CCL trap 8).
+        for (var r : redeemers) {
+            assertNotNull(r.getExUnits(), "redeemer " + r.getTag() + ":" + r.getIndex() + " is uncosted");
+            assertTrue(r.getExUnits().getSteps().longValue() > 1_000_000L,
+                    "redeemer " + r.getTag() + ":" + r.getIndex() + " carries "
+                            + r.getExUnits().getMem() + "/" + r.getExUnits().getSteps()
+                            + " — cardano-client-lib's placeholder budget, so no evaluator ran");
+        }
+
+        // WALL 4 — the lender's paid-in-advance output holds >= the payout, in USDM, flatten == 2.
+        TransactionOutput lenderOutput = assetManagerOutputs(rebuilt, registry).stream()
+                .filter(o -> quantityOf(o, USDM).signum() > 0)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no asset-manager output carries USDM"));
+        assertTrue(quantityOf(lenderOutput, USDM)
+                        .compareTo(built.numbers().convertedLoanCollateralToPrincipalAmount()) >= 0,
+                "the lender's output holds less USDM than the required payout");
+        assertEquals(2, flattenedCount(lenderOutput),
+                "the lender's output must be the USDM token plus its min-ada rider (flatten == 2)");
+
+        // The redeemer's principalOracleRefInputIndex points at the USDM oracle's referenceInput, in
+        // the body's own (canonically sorted) reference-input list.
+        int principalIdx = principalOracleRefInputIndex(rebuilt, registry);
+        TransactionInput atIndex = rebuilt.getBody().getReferenceInputs().get(principalIdx);
+        assertEquals(built.request().principalOracle().referenceInput(), atIndex,
+                "principalOracleRefInputIndex does not point at the USDM oracle's reference input in "
+                        + "the body's sorted reference inputs");
+
+        // The exact arithmetic, cross-checked against LoanFinance directly rather than hardcoded —
+        // the ticket's own instruction, because the number moves with the live oracle ratio and equity.
+        BigInteger recomputed = LoanFinance.convertFromAToBWithOracles(
+                built.request().oracle().feed(), built.request().principalOracle().feed(),
+                Rational.fromInt(built.numbers().collateralLenderShouldReceive()));
+        assertEquals(recomputed, built.numbers().convertedLoanCollateralToPrincipalAmount(),
+                "the builder's payout disagrees with LoanFinance.convertFromAToBWithOracles on the "
+                        + "same live feeds and instant");
+
+        System.out.println("equity " + built.numbers().equity() + " USDM payout "
+                + built.numbers().convertedLoanCollateralToPrincipalAmount()
+                + " fee " + rebuilt.getBody().getFee()
+                + " size " + rebuilt.serialize().length + " bytes");
+    }
+
+    /**
+     * ⛔ The coordinates the pinned candidate needs to STILL BE TRUE on chain — CCL trap 12: an
+     * existence check ({@code getTxOutput}) proves an output once existed, never that it is still
+     * unspent, so every coordinate here is re-verified against the LIVE UTxO set.
+     */
+    @Test
+    void thePinnedCoordinatesAreStillTheLiveOnes() throws Exception {
+        BFBackendService backend = backend();
+        LoansContractRegistry registry = registry();
+
+        assertLiveAndCarries(backend, "loan", new TransactionInput(LOAN_TX, LOAN_IX),
+                new AssetType(registry.getLoanPolicyId(), LOAN_ID));
+
+        FluidOracleClient oracles = new FluidOracleClient(ORACLE_REGISTRY_URL);
+        oracles.refresh();
+        OracleEntry fldt = oracles.findEntry(FLDT)
+                .orElseThrow(() -> new IllegalStateException("no mainnet oracle entry for FLDT"));
+        OracleEntry usdm = oracles.findEntry(USDM)
+                .orElseThrow(() -> new IllegalStateException("no mainnet oracle entry for USDM"));
+
+        // Cross-check against the coordinates the ticket named, read from the registry today.
+        assertEquals(FLDT_ORACLE, fldt.oracleToken(), "the live FLDT oracle NFT moved from what was pinned");
+        assertEquals(FLDT_ORACLE_REF_INPUT, fldt.referenceInput(), "the live FLDT oracle referenceInput moved");
+        assertEquals(FLDT_ORACLE_REF_SCRIPT, fldt.referenceScript(), "the live FLDT oracle referenceScript moved");
+        assertEquals(USDM_ORACLE, usdm.oracleToken(), "the live USDM oracle NFT moved from what was pinned");
+        assertEquals(USDM_ORACLE_REF_INPUT, usdm.referenceInput(), "the live USDM oracle referenceInput moved");
+        assertEquals(USDM_ORACLE_REF_SCRIPT, usdm.referenceScript(), "the live USDM oracle referenceScript moved");
+
+        assertLiveAndCarries(backend, "FLDT oracle", fldt.referenceInput(), fldt.oracleToken());
+        assertLiveAndCarries(backend, "USDM oracle", usdm.referenceInput(), usdm.oracleToken());
+
+        // The main/LM config — the SAME global config ConvertLiveDryEvalTest pins and verifies.
+        Utxo lmConfig = output(backend, LM_CONFIG_TX, LM_CONFIG_IX);
+        String lmNft = LM_CONFIG_POLICY + ASSET_NAME;
+        assertTrue(lmConfig.getAmount().stream().anyMatch(a -> lmNft.equals(a.getUnit())),
+                "the pinned LM config UTxO no longer carries the LM config NFT " + lmNft);
+        String derived = registry.getLmLiquidateAndPayInAdvanceActionScriptHash();
+        assertNotNull(lmConfig.getInlineDatum(), "the LM config UTxO carries no inline datum");
+        assertTrue(lmConfig.getInlineDatum().contains(derived),
+                "the live LM config does not name the lm_liquidate_and_pay_in_advance_action hash this "
+                        + "node derives (" + derived + ") — either the vendored blueprint or the pinned "
+                        + "LM config is stale");
+    }
+
+    /** CCL trap 12: query the LIVE UTxO set at the output's own address, never just its existence. */
+    private static void assertLiveAndCarries(BFBackendService backend, String what, TransactionInput ref,
+                                             AssetType nft) throws Exception {
+        Utxo out = output(backend, ref.getTransactionId(), ref.getIndex());
+        String unit = nft.toUnit();
+        assertTrue(out.getAmount().stream().anyMatch(a -> unit.equalsIgnoreCase(a.getUnit())),
+                what + " reference input " + ref + " does not carry " + unit);
+        Result<List<Utxo>> live = backend.getUtxoService().getUtxos(out.getAddress(), unit, 20, 1);
+        assertTrue(live.isSuccessful(), "could not list live utxos at " + out.getAddress() + ": "
+                + live.getResponse());
+        boolean stillThere = live.getValue().stream().anyMatch(u ->
+                u.getTxHash().equals(ref.getTransactionId()) && u.getOutputIndex() == ref.getIndex());
+        assertTrue(stillThere, what + " reference input " + ref + " no longer appears in the live UTxO "
+                + "set at " + out.getAddress() + " — it has been spent (CCL trap 12)");
+    }
+
+    /**
+     * ⛔ THE ADVERSARIAL CASE — the whole point of this rig. A lender payout one base unit short of
+     * {@code convertedLoanCollateralToPrincipalAmount} is a value the validator computes and checks
+     * for itself ({@code validate_repayment_output}: {@code quantity_of(output, principalAsset) >=
+     * convertedAmount}), so it MUST be refused by the VALIDATOR — not by this builder's own
+     * {@code assertStructure}, which would refuse it first if the wrong number were fed INTO a normal
+     * build. So this takes the REAL, successfully built (and already structurally-proven) transaction
+     * and perturbs the FINISHED body by byte-surgery — {@code assertStructure} never sees the mutated
+     * bytes, because it already ran and passed on the correct ones. Only the real UPLC machine gets to
+     * say no.
+     */
+    @Test
+    void aLenderPayoutOneUnitShortIsREJECTEDByTheValidator() throws Exception {
+        Built built;
+        try {
+            built = build();
+        } catch (Exception e) {
+            throw new AssertionError("the baseline build failed, so no adversarial case can be run. What "
+                    + "the evaluator said: " + lastEvaluatorMessage, e);
+        }
+
+        Transaction mutated = decrementLenderPayoutByOne(built.transaction(), built.registry());
+        byte[] mutatedCbor = mutated.serialize();
+        Set<Utxo> inputs = new LinkedHashSet<>(built.universe());
+
+        lastEvaluatorMessage = null;
+        Result<List<EvaluationResult>> result = null;
+        Exception thrown = null;
+        try {
+            result = built.evaluator().evaluateTx(mutatedCbor, inputs);
+        } catch (Exception e) {
+            thrown = e;
+        }
+
+        if (thrown == null) {
+            assertFalse(result.isSuccessful(),
+                    "a lender payout one unit short of "
+                            + built.numbers().convertedLoanCollateralToPrincipalAmount()
+                            + " USDM evaluated SUCCESSFULLY — the validator's own repayment check "
+                            + "(validate_repayment_output) did not run, or this rig perturbed the wrong "
+                            + "output");
+        }
+
+        // ⛔ Must come from EVALUATION, not from assembly or an empty, unattributed failure — an empty
+        // ScriptFailures-shaped result has meant "you are short" (i.e. an input-resolution problem, not
+        // a script denial) in this repo before (2026-08-24).
+        assertNotNull(lastEvaluatorMessage,
+                "the mutated transaction failed before the evaluator ever reported anything, so this "
+                        + "proves nothing about the validator");
+        assertFalse(lastEvaluatorMessage.isBlank(), "the evaluator reported an empty message");
+        assertTrue(lastEvaluatorMessage.contains("EvaluationFailure")
+                        || lastEvaluatorMessage.contains("RedeemerError"),
+                "the perturbed transaction failed for a reason other than script evaluation, so it does "
+                        + "not demonstrate that the validator rejects a short payout: " + lastEvaluatorMessage);
+    }
+}

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidatePayInAdvanceLiveDryEvalTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidatePayInAdvanceLiveDryEvalTest.java
@@ -435,14 +435,20 @@ class LiquidatePayInAdvanceLiveDryEvalTest {
                 + " | USDM price=" + usdmEntry.feed().priceInLovelaces() + "/"
                 + usdmEntry.feed().priceDenominator() + " lovelace";
         System.out.println("candidate state: " + candidateState);
-        // Same precondition PayInAdvanceLiquidationRouter checks BEFORE ever touching the builder
-        // (and that the builder itself re-checks at build() as its own first guard) — mirrored here
-        // so a non-positive-equity candidate is refused before wasting a wallet-selection round trip,
-        // exactly as production would. This is a LIVE rig: the pinned candidate's equity is a fact
-        // about the CHAIN at query time, not something this test controls, and a thin-margin position
-        // can cross zero between the ticket's pin and this run (interest accrual + oracle drift).
-        assertTrue(numbers.equity().signum() > 0,
-                "the pinned candidate no longer has positive equity — " + candidateState);
+        // F0 (round 2) — EQUITY 0 IS BUILDABLE, NOT A REFUSAL. This used to mirror the OLD precondition
+        // PayInAdvanceLiquidationRouter and the builder's own build() checked (equity > 0), refusing a
+        // non-positive-equity candidate before ever reaching the builder. That precondition was ours,
+        // not the validator's: loan_claim_action.ak:240-259 accepts equity == 0 outright — the
+        // underwater loan, the common liquidation, and (measured against this run) the live candidate's
+        // actual state today. Only a genuinely NEGATIVE equity is still refused — unreachable here,
+        // since LoanFinance.redeemerEquity floors it to zero, exactly as production's own builder does.
+        // This is a LIVE rig: the pinned candidate's equity is a fact about the CHAIN at query time,
+        // not something this test controls, and a thin-margin position can cross zero between the
+        // ticket's pin and this run (interest accrual + oracle drift) — which is exactly what happened:
+        // the candidate crossed from positive to zero, and F0 is what keeps this rig buildable through it.
+        assertTrue(numbers.equity().signum() >= 0,
+                "the pinned candidate has gone NEGATIVE equity — unreachable through LoanFinance's own "
+                        + "floor, so this would mean that floor itself broke — " + candidateState);
         BigInteger lenderPayout = numbers.convertedLoanCollateralToPrincipalAmount();
 
         // T-052 / MarketGate's Part 2: the smallest wallet utxo carrying enough USDM plus enough ada

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidatePayInAdvanceTransactionBuilderTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidatePayInAdvanceTransactionBuilderTest.java
@@ -1,0 +1,370 @@
+package com.fluidtokens.aquarium.offchain.service.loans;
+
+import com.bloxbean.cardano.client.api.model.Utxo;
+import com.bloxbean.cardano.client.plutus.spec.BigIntPlutusData;
+import com.bloxbean.cardano.client.plutus.spec.ConstrPlutusData;
+import com.bloxbean.cardano.client.plutus.spec.ListPlutusData;
+import com.bloxbean.cardano.client.plutus.spec.PlutusData;
+import com.bloxbean.cardano.client.plutus.spec.Redeemer;
+import com.bloxbean.cardano.client.plutus.spec.RedeemerTag;
+import com.bloxbean.cardano.client.transaction.spec.Transaction;
+import com.bloxbean.cardano.client.transaction.spec.TransactionInput;
+import com.bloxbean.cardano.client.transaction.spec.Withdrawal;
+import com.bloxbean.cardano.client.util.HexUtil;
+import com.fluidtokens.aquarium.offchain.model.AssetType;
+import com.fluidtokens.aquarium.offchain.model.loans.OracleEntry;
+import com.fluidtokens.aquarium.offchain.model.loans.OraclePriceFeed;
+import com.fluidtokens.aquarium.offchain.model.loans.OracleSignature;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * ⛔ <b>THE MULTISIG ORACLE LEGS</b> — {@link LiquidatePayInAdvanceTransactionBuilder} against feeds
+ * that carry <em>signatures</em> instead of a Charli3 provider reference input.
+ *
+ * <h2>Why this class exists (2026-09-10)</h2>
+ * Every offline fixture of this builder had been Charli3-backed, because preview's only live oracle
+ * feeds are the three Charli3 ones. <b>Mainnet publishes every FluidTokens feed as multisig</b>
+ * (findings §40), and the first-ever mainnet build — Giovanni's node, 07:41Z — died with a bare
+ * {@link NullPointerException} out of {@code referenceInputs}: {@code List.of} refuses a null
+ * element, and a multisig feed's {@code charlieProviderReferenceInput} is null by construction.
+ * <p>
+ * Behind the NPE sat the second defect, which these encoding assertions exist for: both legs called
+ * {@code oracleRedeemer(feed, providerRefIndex, List.of())} unconditionally — the Charli3 shape, a
+ * provider index and an <b>empty signature list</b>. Against a multisig validator branch that runs
+ * {@code verify_ed25519_signature} over the published signatures, an empty list fails the threshold,
+ * and such a transaction assembles, passes the mempool and dies in <b>phase 2</b> with the fee spent
+ * and the collateral consumed (CCL trap 8's failure tier). {@link ConvertTransactionBuilder} — the
+ * only builder that has ever built on mainnet — has encoded the signed shape since findings §40, and
+ * its comment there names this builder's old call as exactly that fatal one.
+ * <p>
+ * ⚠ <b>Measured, and worth recording because it is better news than the above:</b> on the unmodified
+ * builder a signed feed did not silently reach the chain in the Charli3 shape. It could not:
+ * {@code OracleFeedConverter.toPlutusData(feed, providerRefInputIndex)} type-checks its own variant
+ * and threw {@code "only encodes PRICE_DATA_CHARLIE, not AGGREGATED"} at build time. The encoder's
+ * guard was the backstop that kept the phase-2 transaction unreachable. So what the tests below pin
+ * is not the absence of a throw — that was already true — but that each leg is encoded in the shape
+ * its own variant requires.
+ *
+ * <h2>Every assertion reads the DESERIALISED transaction</h2>
+ * Never a builder field and never an intermediate: the redeemer is fetched by its withdrawal's
+ * position in the finished body (CCL trap 14 — a redeemer is identified by its script purpose's
+ * position, never by its data's shape) and its {@code PlutusData} is decoded from there. What ships
+ * is what is asserted.
+ *
+ * <h2>What this class does NOT prove</h2>
+ * It is a build-and-inspect rig with no evaluator, so ex-units are cardano-client-lib placeholders
+ * here and nothing below reads them. That the deployed mainnet validators <em>accept</em> the
+ * encoding — the phase-2 question — is proven by {@link LiquidatePayInAdvanceLiveDryEvalTest}
+ * against the real chain, with both real oracle legs and a {@code payout − 1} adversarial case.
+ */
+class LiquidatePayInAdvanceTransactionBuilderTest {
+
+    /**
+     * A second priced asset with its own oracle deployment, so the principal leg gets a
+     * <b>distinct</b> withdrawal credential from the collateral leg's. The builder only emits a
+     * second withdraw-0 when the two credentials differ — the ledger permits one withdrawal per
+     * reward address, and {@code retrieve_oracle_data} resolves its feed with
+     * {@code pairs.get_first(self.redeemers, Withdraw(oraclePaymentCredential))}, one redeemer per
+     * credential.
+     */
+    private static final AssetType PRINCIPAL_TOKEN =
+            new AssetType("11".repeat(28), "5052494e434950414c");
+    private static final AssetType PRINCIPAL_ORACLE_NFT =
+            new AssetType("22".repeat(28), "6f7261636c65");
+    private static final String PRINCIPAL_ORACLE_SCRIPT_HASH = "33".repeat(28);
+    private static final TransactionInput PRINCIPAL_ORACLE_REF_INPUT =
+            new TransactionInput("44".repeat(32), 0);
+    private static final TransactionInput PRINCIPAL_ORACLE_REF_SCRIPT =
+            new TransactionInput("44".repeat(32), 1);
+
+    private static final List<OracleSignature> COLLATERAL_SIGNATURES = List.of(
+            new OracleSignature(0, "aa".repeat(64)),
+            new OracleSignature(2, "bb".repeat(64)));
+    private static final List<OracleSignature> PRINCIPAL_SIGNATURES = List.of(
+            new OracleSignature(1, "cc".repeat(64)));
+
+    // ---- 1. the multisig COLLATERAL leg -------------------------------------------------------
+
+    /**
+     * ⛔ <b>THE FAIL-FIRST CASE.</b> On the unmodified builder this throws
+     * {@code NullPointerException} out of {@code referenceInputs} before a single byte is assembled.
+     */
+    @Test
+    void aMultisigCollateralLegBuildsAndCarriesItsSignaturesInTheOracleRedeemer() {
+        var base = LiquidatePayInAdvanceDryEvalTest.fixture();
+        OracleEntry multisig = multisigLike(base.request().oracle(), COLLATERAL_SIGNATURES);
+        var request = withOracles(base.request(), multisig, null);
+
+        Transaction built = deserialised(build(request));
+
+        // The signed encoding: OraclePriceFeed::Aggregated is constructor 0 — three fields
+        // (common, price, denominator) and NO leading provider index — and the signature list
+        // carries every published signature, in order.
+        PlutusData redeemer = oracleRedeemerAt(built, multisig.rewardAddress());
+        assertSignedFeed(redeemer, multisig.feed());
+        assertSignatures(redeemer, COLLATERAL_SIGNATURES);
+
+        // And no provider reference input was invented for a feed that has none: the body's
+        // reference inputs are exactly the two configs plus this oracle's own two.
+        assertEquals(4, built.getBody().getReferenceInputs().size(),
+                "a provider-less feed must add no provider reference input");
+        assertTrue(built.getBody().getReferenceInputs().contains(multisig.referenceInput()));
+        assertTrue(built.getBody().getReferenceInputs().contains(multisig.referenceScript()));
+    }
+
+    // ---- 2. the multisig PRINCIPAL leg --------------------------------------------------------
+
+    /**
+     * The principal leg is a SEPARATE withdraw-0 of the oracle validator at its own credential, and
+     * it is encoded by its own feed's variant — not by the collateral leg's. The collateral leg here
+     * is deliberately left <b>Charli3</b>, so this case isolates the ENCODING defect from the
+     * null-provider one: on the unmodified builder it assembles cleanly and ships the principal leg
+     * in the Charli3 shape, which is the phase-2-fatal transaction.
+     */
+    @Test
+    void aMultisigPrincipalLegGetsItsOwnWithdrawZeroCarryingItsOwnSignatures() {
+        var base = LiquidatePayInAdvanceDryEvalTest.fixture();
+        OracleEntry charli3Collateral = base.request().oracle();
+        OracleEntry multisigPrincipal = multisigPrincipal(charli3Collateral.feed());
+        var request = withOracles(base.request(), charli3Collateral, multisigPrincipal);
+
+        Transaction built = deserialised(build(request));
+
+        // Two DISTINCT oracle withdrawals — one per credential.
+        assertFalse(charli3Collateral.rewardAddress().equals(multisigPrincipal.rewardAddress()),
+                "the two legs must not share a credential, or the second withdraw-0 is skipped and "
+                        + "this test proves nothing about it");
+        assertTrue(rewardAddresses(built).contains(charli3Collateral.rewardAddress()),
+                "the collateral oracle withdraw-0 is missing");
+        assertTrue(rewardAddresses(built).contains(multisigPrincipal.rewardAddress()),
+                "the principal oracle withdraw-0 is missing");
+
+        PlutusData principalRedeemer = oracleRedeemerAt(built, multisigPrincipal.rewardAddress());
+        assertSignedFeed(principalRedeemer, multisigPrincipal.feed());
+        assertSignatures(principalRedeemer, PRINCIPAL_SIGNATURES);
+
+        // The collateral leg, on the same transaction, still takes the Charli3 shape — the variant
+        // decides each leg independently and one leg's shape never leaks into the other's.
+        PlutusData collateralRedeemer = oracleRedeemerAt(built, charli3Collateral.rewardAddress());
+        assertCharli3Feed(collateralRedeemer, built, charli3Collateral);
+        assertSignatures(collateralRedeemer, List.of());
+    }
+
+    // ---- 3. the Charli3 leg, unchanged --------------------------------------------------------
+
+    /**
+     * The regression guard: the preview shape this builder has always emitted is untouched — the
+     * provider IS a reference input, the redeemer names its real position among the body's
+     * canonically sorted reference inputs, and the signature list is legitimately EMPTY (a c3 feed
+     * carries no signature over its own bytes; the validator checks it structurally against the
+     * provider UTxO instead).
+     */
+    @Test
+    void theCharli3LegIsUnchanged() {
+        var base = LiquidatePayInAdvanceDryEvalTest.fixture();
+        OracleEntry charli3 = base.request().oracle();
+
+        Transaction built = deserialised(build(base.request()));
+
+        assertTrue(built.getBody().getReferenceInputs().contains(charli3.charlieProviderReferenceInput()),
+                "the Charli3 provider must still be a reference input");
+        PlutusData redeemer = oracleRedeemerAt(built, charli3.rewardAddress());
+        assertCharli3Feed(redeemer, built, charli3);
+        assertSignatures(redeemer, List.of());
+    }
+
+    // ---- 4. an unmodelled variant is refused BY NAME -------------------------------------------
+
+    /**
+     * {@code POOLED} carries pool reserves and fees, not a plain price, and
+     * {@link OracleFeedConverter} cannot encode it at all. The builder must say so about the
+     * CANDIDATE — a named refusal the executor records as {@code REFUSED} — rather than letting an
+     * {@code UnsupportedOperationException} escape the encoder mid-assembly, which reads as
+     * machinery breakage.
+     */
+    @Test
+    void aPooledFeedIsRefusedByNameBeforeAnythingIsBuilt() {
+        var base = LiquidatePayInAdvanceDryEvalTest.fixture();
+        OracleEntry pooled = pooledLike(base.request().oracle());
+        var request = withOracles(base.request(), pooled, null);
+
+        var refusal = assertThrows(
+                PayInAdvanceLiquidationRouter.PayInAdvanceNotModelledException.class,
+                () -> build(request));
+
+        assertTrue(refusal.getMessage().contains("POOLED"),
+                "the refusal must name the variant it cannot model: " + refusal.getMessage());
+        assertTrue(refusal.getMessage().contains("collateral"),
+                "the refusal must name the leg: " + refusal.getMessage());
+    }
+
+    // ---- fixtures ------------------------------------------------------------------------------
+
+    /** The same asset, the same deployment, the same window — published MULTISIG instead of c3. */
+    private static OracleEntry multisigLike(OracleEntry charli3, List<OracleSignature> signatures) {
+        OraclePriceFeed feed = charli3.feed();
+        return LoanFixtures.multisig(charli3.token(), charli3.oracleToken(),
+                charli3.withdrawCredentialHash(),
+                OraclePriceFeed.aggregated(feed.token(), feed.priceInLovelaces(), feed.priceDenominator(),
+                        feed.validFrom(), feed.validTo()),
+                charli3.referenceInput(), charli3.referenceScript(), signatures);
+    }
+
+    /**
+     * A second, multisig oracle for the principal leg.
+     * <p>
+     * ⚠ Its price is deliberately <b>1 lovelace / 1</b>, which is arithmetically identical to the
+     * unit feed {@code numbers()} substitutes for a null principal oracle — so every payout figure,
+     * every output and every index in this transaction is the ada-principal baseline's, and the ONLY
+     * thing that changes is that a second oracle credential is named. This test is about the
+     * REDEEMER, and pinning the arithmetic still means a failure here can only be the redeemer.
+     * (The genuine token-principal economics are proven live, against real USDM, by
+     * {@link LiquidatePayInAdvanceLiveDryEvalTest}.)
+     */
+    private static OracleEntry multisigPrincipal(OraclePriceFeed windowSource) {
+        return LoanFixtures.multisig(PRINCIPAL_TOKEN, PRINCIPAL_ORACLE_NFT, PRINCIPAL_ORACLE_SCRIPT_HASH,
+                OraclePriceFeed.aggregated(PRINCIPAL_TOKEN, BigInteger.ONE, BigInteger.ONE,
+                        windowSource.validFrom(), windowSource.validTo()),
+                PRINCIPAL_ORACLE_REF_INPUT, PRINCIPAL_ORACLE_REF_SCRIPT, PRINCIPAL_SIGNATURES);
+    }
+
+    /** The same entry with its feed re-labelled {@code POOLED} — nothing else moves. */
+    private static OracleEntry pooledLike(OracleEntry entry) {
+        OraclePriceFeed feed = entry.feed();
+        return new OracleEntry(entry.token(), entry.oracleToken(), entry.rewardAddress(),
+                entry.withdrawCredentialHash(), entry.referenceInput(), entry.referenceScript(),
+                entry.verificationKeys(), entry.threshold(),
+                new OraclePriceFeed(OraclePriceFeed.Variant.POOLED, feed.token(),
+                        feed.priceInLovelaces(), feed.priceDenominator(),
+                        feed.validFrom(), feed.validTo()),
+                entry.signatures(), entry.charlieProviderReferenceInput());
+    }
+
+    private static LiquidatePayInAdvanceTransactionBuilder.Request withOracles(
+            LiquidatePayInAdvanceTransactionBuilder.Request r, OracleEntry oracle, OracleEntry principal) {
+        return new LiquidatePayInAdvanceTransactionBuilder.Request(r.loan(), r.loanUtxo(), r.bond(),
+                r.bondUtxo(), r.walletUtxo(), r.configUtxo(), r.lmConfigUtxo(), oracle, principal,
+                r.validFromMillis(), r.validToMillis(), r.validFromSlot(), r.validToSlot(),
+                r.changeAddress(), r.referenceScripts(), r.oracleWindowMarginMillis());
+    }
+
+    /**
+     * The builder with no evaluator. Reference inputs are body coordinates, not resolvable UTxOs —
+     * {@code complete()} installs a no-op {@code ScriptSupplier} offline (CCL trap 2) — so only the
+     * spendable universe has to be served here.
+     */
+    private static Transaction build(LiquidatePayInAdvanceTransactionBuilder.Request request) {
+        List<Utxo> universe = new ArrayList<>(List.of(request.configUtxo(), request.lmConfigUtxo(),
+                request.walletUtxo(), request.loanUtxo(), request.bondUtxo()));
+        return new LiquidatePayInAdvanceTransactionBuilder(LoanFixtures.registry(), LoanFixtures.NETWORK,
+                LoanFixtures.utxoSupplier(universe), EvalFixtures.protocolParams())
+                .build(request);
+    }
+
+    // ---- reading the built body ------------------------------------------------------------------
+
+    private static Transaction deserialised(Transaction built) {
+        try {
+            return Transaction.deserialize(built.serialize());
+        } catch (Exception e) {
+            throw new AssertionError("the built transaction does not round-trip through CBOR", e);
+        }
+    }
+
+    private static List<String> rewardAddresses(Transaction tx) {
+        return tx.getBody().getWithdrawals().stream().map(Withdrawal::getRewardAddress).toList();
+    }
+
+    /**
+     * The oracle validator's withdraw-0 redeemer, located by the POSITION of its script purpose —
+     * the withdrawal's index in the body's own (canonically sorted) withdrawals list — and never by
+     * matching the redeemer's shape (CCL trap 14).
+     */
+    private static PlutusData oracleRedeemerAt(Transaction tx, String rewardAddress) {
+        int index = rewardAddresses(tx).indexOf(rewardAddress);
+        assertTrue(index >= 0, "no withdrawal at " + rewardAddress);
+        Redeemer redeemer = tx.getWitnessSet().getRedeemers().stream()
+                .filter(r -> r.getTag() == RedeemerTag.Reward && r.getIndex().intValue() == index)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no reward redeemer at withdrawal " + index));
+        return redeemer.getData();
+    }
+
+    /**
+     * {@code OracleRedeemer { data: OraclePriceFeed, signatures: List<Signature> }} — the feed is
+     * field 0, the signature list field 1.
+     */
+    private static ConstrPlutusData feedOf(PlutusData redeemer) {
+        return (ConstrPlutusData) ((ConstrPlutusData) redeemer).getData().getPlutusDataList().get(0);
+    }
+
+    private static ListPlutusData signaturesOf(PlutusData redeemer) {
+        return (ListPlutusData) ((ConstrPlutusData) redeemer).getData().getPlutusDataList().get(1);
+    }
+
+    /**
+     * {@code Aggregated { common, price_in_lovelaces, price_denominator }} — constructor 0, THREE
+     * fields, no provider index. The price is read back out to prove this is the feed handed in and
+     * not some other leg's.
+     */
+    private static void assertSignedFeed(PlutusData redeemer, OraclePriceFeed expected) {
+        ConstrPlutusData feed = feedOf(redeemer);
+        assertEquals(0L, feed.getAlternative(),
+                "a signed (AGGREGATED) feed is constructor 0; constructor 3 is the Charli3 shape, "
+                        + "which a multisig validator branch refuses in phase 2");
+        List<PlutusData> fields = feed.getData().getPlutusDataList();
+        assertEquals(3, fields.size(), "the signed feed has no provider_ref_input_index");
+        assertEquals(expected.priceInLovelaces(), ((BigIntPlutusData) fields.get(1)).getValue());
+        assertEquals(expected.priceDenominator(), ((BigIntPlutusData) fields.get(2)).getValue());
+    }
+
+    /**
+     * {@code PriceDataCharlie { provider_ref_input_index, common, price_in_lovelaces,
+     * price_denominator }} — constructor 3, and the index must point at the provider's real position
+     * in the FINISHED body's reference inputs.
+     */
+    private static void assertCharli3Feed(PlutusData redeemer, Transaction tx, OracleEntry entry) {
+        ConstrPlutusData feed = feedOf(redeemer);
+        assertEquals(3L, feed.getAlternative(), "a Charli3 feed is constructor 3");
+        List<PlutusData> fields = feed.getData().getPlutusDataList();
+        assertEquals(4, fields.size(), "the Charli3 feed carries a leading provider_ref_input_index");
+        int providerIndex = ((BigIntPlutusData) fields.get(0)).getValue().intValueExact();
+        assertEquals(entry.charlieProviderReferenceInput(),
+                tx.getBody().getReferenceInputs().get(providerIndex),
+                "provider_ref_input_index does not point at the Charli3 provider in the body's own "
+                        + "sorted reference inputs");
+    }
+
+    /**
+     * {@code Signature { signature: ByteArray, key_position: Int }} — signature BEFORE key_position,
+     * the opposite of {@link OracleSignature}'s own field order, which is exactly the kind of detail
+     * an assertion off the deserialised bytes catches and a builder-field assertion cannot.
+     */
+    private static void assertSignatures(PlutusData redeemer, List<OracleSignature> expected) {
+        List<PlutusData> actual = signaturesOf(redeemer).getPlutusDataList();
+        assertEquals(expected.size(), actual.size(),
+                "the oracle redeemer carries " + actual.size() + " signatures, expected "
+                        + expected.size() + " — an empty list on a multisig feed fails the "
+                        + "validator's threshold in PHASE 2");
+        for (int i = 0; i < expected.size(); i++) {
+            List<PlutusData> fields = ((ConstrPlutusData) actual.get(i)).getData().getPlutusDataList();
+            assertEquals(expected.get(i).signatureHex(),
+                    HexUtil.encodeHexString(
+                            ((com.bloxbean.cardano.client.plutus.spec.BytesPlutusData) fields.get(0))
+                                    .getValue()),
+                    "signature " + i + " is not the one published");
+            assertEquals(BigInteger.valueOf(expected.get(i).keyPosition()),
+                    ((BigIntPlutusData) fields.get(1)).getValue(),
+                    "key_position " + i + " is not the one published");
+        }
+    }
+}

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidatePayInAdvanceTransactionBuilderTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidatePayInAdvanceTransactionBuilderTest.java
@@ -207,6 +207,33 @@ class LiquidatePayInAdvanceTransactionBuilderTest {
                 "the refusal must name the leg: " + refusal.getMessage());
     }
 
+    /**
+     * FAB-83-1 audit F1. A SIGNED feed whose registry entry currently carries NO signatures is not
+     * usable, and must be refused by name before anything is assembled — otherwise the redeemer ships
+     * an empty signature list, the exact shape the deployed validator refuses (a real script denial,
+     * measured on mainnet 2026-09-10). Reachable when a 30-second registry refresh lands between the
+     * scanner's usableForLiquidation() check and the executor's oracle snapshot. The convert builder
+     * guards this in build(); this builder did not.
+     *
+     * <p>Mutant: delete the usableForLiquidation() guard — the build then SUCCEEDS with an empty
+     * signature list and this assertThrows fails.
+     */
+    @Test
+    void aSignedFeedWithNoSignaturesIsRefusedByNameBeforeAnythingIsBuilt() {
+        var base = LiquidatePayInAdvanceDryEvalTest.fixture();
+        OracleEntry unsigned = multisigLike(base.request().oracle(), List.of());
+        var request = withOracles(base.request(), unsigned, null);
+
+        var refusal = assertThrows(
+                PayInAdvanceLiquidationRouter.PayInAdvanceNotModelledException.class,
+                () -> build(request));
+
+        assertTrue(refusal.getMessage().contains("0 signature(s)"),
+                "the refusal must name the missing signatures: " + refusal.getMessage());
+        assertTrue(refusal.getMessage().contains("collateral"),
+                "the refusal must name the leg: " + refusal.getMessage());
+    }
+
     // ---- fixtures ------------------------------------------------------------------------------
 
     /** The same asset, the same deployment, the same window — published MULTISIG instead of c3. */

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutorTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutorTest.java
@@ -91,6 +91,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class LiquidationExecutorTest {
 
+    // ---- ECONOMICS GATE direction (token-principals slice) -----------------------------------------
+
+    /**
+     * ⛔ THE DIRECTION. {@code PricingService.toLovelace} floors, which flatters an OUTLAY (understates
+     * the cost); {@link LiquidationExecutor#outlayCeilBiased} corrects that toward the ceiling side. A
+     * mutant that drops the {@code +1} (reverting to the bare floor) must change this test's result —
+     * it does, because the floored price here is not already a "round" figure the +1 could hide
+     * behind.
+     */
+    @Test
+    void outlayCeilBiasedAddsOneToTheFlooredPrice() {
+        assertEquals(BigInteger.valueOf(1_033_850_766L),
+                LiquidationExecutor.outlayCeilBiased(BigInteger.valueOf(1_033_850_765L)),
+                "the outlay must be taken ONE ABOVE the floored price, never the bare floor");
+        assertNotEquals(BigInteger.valueOf(1_033_850_765L),
+                LiquidationExecutor.outlayCeilBiased(BigInteger.valueOf(1_033_850_765L)),
+                "a mutant reverting to the bare floor must be distinguishable from the fix");
+    }
+
     /** A fixed instant well inside preview's history, so slot conversion is deterministic. */
     private static final long NOW = 1_700_000_000_000L;
 
@@ -1810,16 +1829,14 @@ class LiquidationExecutorTest {
     }
 
     /**
-     * The OTHER trigger behind the same exception, and the one the remedy is actually for.
-     *
-     * <p>{@code PayInAdvanceLiquidationRouter:143} refuses a non-ada principal outright, before equity
-     * is looked at. Here the advice is sound — the convert router genuinely supports a non-ada
-     * principal (it resolves a {@code collateral/principal} pool and prices the principal leg through
-     * its own feed) — so the line must carry it, and must name the asset that makes it apply.
-     *
-     * <p>⚠ This pair exists because the two triggers share ONE exception type. A single test can only
-     * ever prove the message fits the trigger it happened to fire; it takes both to prove the message
-     * fits <em>each</em>.
+     * ⛔ REPURPOSED, token-principals slice: {@code PayInAdvanceLiquidationRouter:143} — the outright
+     * "non-ada principal" refusal this test used to pin — is GONE (Part 1 of that slice; a non-ada
+     * principal is now modelled). The remaining {@code PayInAdvanceNotModelledException} trigger a
+     * non-ada principal can still hit is "no oracle entry for principal oracle asset X" (WALL 3): the
+     * executor's {@code oraclesByUnit} snapshot has nothing for the loan's own
+     * {@code principalOracleAsset}. The remedy logic this test exists to pin ({@code action: CONVERT}
+     * is sound advice for ANY non-ada-principal trigger, never for a non-positive-equity one) is
+     * unchanged and still keyed on the principal asset alone, so it still fires here.
      */
     @Test
     void aNonAdaPrincipalNotModelledRefusalCarriesTheConvertRemedy() {
@@ -1847,7 +1864,7 @@ class LiquidationExecutorTest {
         assertEquals(1, infos.size(), "expected exactly one INFO line for the not-modelled refusal: "
                 + appender.list);
         String message = infos.getFirst().getFormattedMessage();
-        assertTrue(message.contains("non-ada principal"),
+        assertTrue(message.contains("no oracle entry for principal oracle asset"),
                 "must carry the router's own message, which is what names this trigger: " + message);
         assertTrue(message.contains(COLLATERAL_TOKEN.toUnit()),
                 "must name the principal unit that makes the remedy apply: " + message);
@@ -1857,8 +1874,10 @@ class LiquidationExecutorTest {
     }
 
     /**
-     * A convert-flagged loan whose PRINCIPAL is a token. Nothing past
-     * {@code PayInAdvanceLiquidationRouter:143} is reached, so the feeds here need only be present.
+     * A convert-flagged loan whose PRINCIPAL is a token, with equity forced strictly positive so the
+     * router's equity precondition clears and the NEXT gate — WALL 3's missing-principal-oracle
+     * refusal — is what actually fires (no oracle entry is wired for {@code COLLATERAL_TOKEN} as a
+     * PRINCIPAL in this fixture's {@code oraclesByUnit}, only, where applicable, as a collateral).
      */
     private static Scenario tokenPrincipalConvertScenario() {
         LoanDatum datum = LoanFixtures.loanDatum(COLLATERAL_TOKEN, BigInteger.valueOf(100_000_000),
@@ -1874,7 +1893,9 @@ class LiquidationExecutorTest {
 
         LiquidationAssessment assessment = LoanFixtures.assess(bond.bond(), loan.loan(),
                 OraclePriceFeed.unit(), OraclePriceFeed.unit(), VALID_FROM);
-        return new Scenario(loan, bond, assessment);
+        LiquidationAssessment positiveEquity = LoanFixtures.withNumbers(assessment,
+                assessment.remainingDebt(), BigInteger.ONE, assessment.liquidationFee());
+        return new Scenario(loan, bond, positiveEquity);
     }
 
     /**

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutorTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutorTest.java
@@ -291,6 +291,16 @@ class LiquidationExecutorTest {
         public Collection<OracleEntry> entries() {
             return entries;
         }
+
+        // F1 (round 2) — findEntry is what PricingService actually calls (never entries()); it is
+        // keyed by the PRICED asset (entry.token()), never the oracle NFT (entry.oracleToken(), which
+        // is the OTHER lookup, findEntryByOracleToken's). No existing test before this round drove a
+        // convert candidate's economics far enough to need this — see
+        // LiquidationExecutorTest#tokenPrincipalConvertEconomicsWiring, the first to.
+        @Override
+        public Optional<OracleEntry> findEntry(AssetType token) {
+            return entries.stream().filter(e -> e.token().equals(token)).findFirst();
+        }
     }
 
     /**
@@ -829,6 +839,42 @@ class LiquidationExecutorTest {
                     BigInteger.valueOf(REMAINING_DEBT), BigInteger.valueOf(EQUITY), false,
                     BigInteger.valueOf(LIQUIDATION_FEE));
         }
+
+        /**
+         * F0 (round 2) — the frozen loan with a custom datum, and an assessment whose {@code equity}
+         * field is set to {@code assessedEquity} for the router's PRECONDITION check only. The router
+         * recomputes the REAL equity fresh from {@code loan(datum).datum()} + the oracle feed via
+         * {@code builder.numbers()} — {@code assessedEquity} never reaches the built transaction, so a
+         * caller proving a specific built shape must ALSO make {@code datum} compute to the same figure.
+         */
+        static LiquidationAssessment assessment(LoanDatum datum, BigInteger assessedEquity) {
+            return LiquidationAssessment.buildable(bond(), loan(datum), "f855 convert fixture (custom)",
+                    BigInteger.valueOf(REMAINING_DEBT), assessedEquity, false,
+                    BigInteger.valueOf(LIQUIDATION_FEE));
+        }
+
+        static Loan loan(LoanDatum datum) {
+            return new Loan(LOAN_TX, LOAN_INDEX, LOAN_ADDRESS, LOAN_ID,
+                    BigInteger.valueOf(COLLATERAL_AMOUNT), BigInteger.valueOf(LOAN_LOVELACE), datum);
+        }
+
+        /**
+         * F0 (round 2) — {@link #loanDatum()} with ONLY {@code principalAmount}/{@code interestRate}
+         * tuned so the REAL computed equity lands on exactly zero against the FIXED {@code
+         * COLLATERAL_AMOUNT} and the FIXED oracle {@code PRICE} — the identical derivation
+         * {@code PayInAdvanceLiquidationRouterTest.equityZeroLoanDatum()} pins, because it is the same
+         * collateral amount and the same oracle price: solving {@code collateralInLovelace - D -
+         * 0.05·D = 0} for the ada-denominated debt {@code D} gives {@code D = 32,206,000} exactly.
+         */
+        static LoanDatum equityZeroLoanDatum() {
+            LoanDatum ada = loanDatum();
+            return new LoanDatum(ada.doneRecasts(), BigInteger.valueOf(32_206_000L), ada.lendDate(),
+                    ada.repaidInstallments(), BigInteger.ZERO, ada.totalInstallments(),
+                    ada.principalAsset(), ada.principalOracleAsset(), ada.installmentPeriod(),
+                    ada.initialGracePeriod(), ada.liquidationMode(), ada.repaymentMode(),
+                    ada.repaymentTimeWindow(), ada.penaltyFeeForLateRepayment(), ada.repaymentReceipts(),
+                    ada.originId(), ada.collateral());
+        }
     }
 
     /**
@@ -851,6 +897,18 @@ class LiquidationExecutorTest {
      * by the fixture.
      */
     private static Wiring convertWiring(ProtocolParamsSupplier payInAdvanceParams) {
+        return convertWiring(payInAdvanceParams, F855.assessment());
+    }
+
+    /**
+     * As above, with the {@link LiquidationAssessment} made explicit too — F0 (round 2)'s
+     * {@code equityZeroIsBuildableAndRecorded} swaps in {@link F855#assessment(LoanDatum)} against a
+     * tuned datum whose REAL computed equity (through {@code builder.numbers()}, never {@code
+     * assessment.equity()} — the router recomputes fresh from the loan's own datum) lands on exactly
+     * zero, while keeping the SAME oracle/wallet/config universe F855's other tests already prove.
+     */
+    private static Wiring convertWiring(ProtocolParamsSupplier payInAdvanceParams,
+                                        LiquidationAssessment assessment) {
         AppConfig.LiquidationConfiguration configuration = shadow(SMALL_MARGIN);
 
         List<Utxo> universe = new ArrayList<>(List.of(CONFIG_UTXO, LM_CONFIG_UTXO, WALLET_UTXO,
@@ -864,7 +922,6 @@ class LiquidationExecutorTest {
         BlockEventListener blockEventListener = new BlockEventListener(null);
         blockEventListener.getIsSyncing().set(false);
 
-        LiquidationAssessment assessment = F855.assessment();
         FakeScanner scanner = new FakeScanner(List.of(assessment));
 
         Map<String, Utxo> unspent = new LinkedHashMap<>();
@@ -1756,25 +1813,35 @@ class LiquidationExecutorTest {
     }
 
     /**
-     * (b) A convert assessment the seam cannot model — here a non-positive equity — is mapped to a
-     * clean {@code REFUSED} row under the router's own message, <b>not</b> quarantined and with no
-     * transaction built. The ada/ada convert fixture is under water, so its equity is exactly zero: the
-     * shape {@code PayInAdvanceLiquidationRouter} refuses before it ever calls the builder.
+     * (b) F0 (round 2) — REPURPOSED. This used to pin the ada/ada convert fixture's naturally-zero
+     * equity as a clean REFUSED row; it is exactly backwards now. {@code loan_claim_action.ak:240-259}
+     * accepts equity 0 outright — it is the validator's normal case and the common liquidation, so the
+     * seam must build it, not refuse it (see {@code equityZeroNowBuildsAndIsRecordedRatherThanRefused}
+     * below, which is what this test used to disprove).
+     * <p>
+     * What is STILL refused cleanly (never quarantined) is a genuinely NEGATIVE equity — unreachable
+     * through a real assessment ({@code LoanFinance.redeemerEquity} floors it to zero), so this
+     * overrides the assessment's equity field directly via {@link Scenario#withAssessment}, defence in
+     * depth for the router's own precondition rather than a scenario the loan/oracle data produces.
      */
     @Test
-    void aConvertAssessmentWithNonPositiveEquityIsRefusedNotQuarantined() {
+    void aNegativeEquityAssessmentIsRefusedNotQuarantined() {
         Scenario convert = convertScenario(FAT_FEE_PER_MILLE);
         assertTrue(convert.bond().bond().datum().shouldLiquidationConvertToPrincipal(),
                 "the fixture must be a convert bond, or the executor would not route it");
-        assertEquals(BigInteger.ZERO, convert.assessment().equity(),
-                "the ada/ada fixture is under water: equity is zero, the non-positive shape the seam refuses");
+        LiquidationAssessment negativeEquity = LiquidationAssessment.buildable(
+                convert.assessment().bond(), convert.assessment().loan(),
+                "negative equity (defence in depth, unreachable through a real assessment)",
+                convert.assessment().remainingDebt(), BigInteger.valueOf(-1),
+                convert.assessment().late(), convert.assessment().liquidationFee());
+        convert = convert.withAssessment(negativeEquity);
 
         Wiring wiring = wiring(shadow(SMALL_MARGIN), convert, false);
         wiring.executor().cycle(NOW);
 
         LiquidationDecision decision = onlyDecision(wiring);
         assertEquals(LiquidationDecision.Outcome.REFUSED, decision.outcome(), decision.detail());
-        assertEquals("pay-in-advance not yet modelled for non-positive equity", decision.reason());
+        assertEquals("pay-in-advance not yet modelled for a negative equity", decision.reason());
         assertNull(decision.txHash(), "a clean not-modelled refusal builds no transaction");
         assertNull(decision.txCborHex());
         assertEquals(0, wiring.executor().quarantinedCount(),
@@ -1782,15 +1849,282 @@ class LiquidationExecutorTest {
     }
 
     /**
+     * F0 (round 2) — THE POSITIVE CASE, and the whole point of this round: an equity-0 convert loan
+     * (the live USDM loan's shape as of 2026-09-09) reaches {@code record()} and is priced, exactly
+     * like the positive-equity f855 loan {@code aBuildableConvertLoanIsRoutedAndRecordedButNeverSubmitted}
+     * already proves — never refused. {@link F855#equityZeroLoanDatum()} is tuned so
+     * {@code builder.numbers()} (which the router calls fresh, never trusting
+     * {@code assessment.equity()}) computes equity 0 against the SAME collateral amount and oracle
+     * price the rest of {@code F855}'s tests use.
+     * <p>
+     * Mutant: restoring the old equity {@code <= 0} refusal in the router makes this test fail (a
+     * REFUSED decision instead of a priced WOULD_SUBMIT/UNPROFITABLE one).
+     */
+    @Test
+    void equityZeroNowBuildsAndIsRecordedRatherThanRefused() {
+        LiquidationAssessment assessment = F855.assessment(F855.equityZeroLoanDatum(), BigInteger.ZERO);
+        Wiring wiring = convertWiring(LoanFixtures.protocolParams(), assessment);
+
+        wiring.executor().cycle(F855.NOW);
+
+        LiquidationDecision decision = onlyDecision(wiring);
+        assertNotNull(decision.txHash(), decision.detail());
+        assertTrue(decision.outcome() == LiquidationDecision.Outcome.WOULD_SUBMIT
+                        || decision.outcome() == LiquidationDecision.Outcome.UNPROFITABLE,
+                "an equity-0 convert tx is priced, not refused: " + decision.outcome() + " " + decision.detail());
+        assertEquals(0, wiring.executor().quarantinedCount(), "a clean build is not quarantined (equityZero)");
+    }
+
+    // ======================================================================================
+    // F3 (round 2) — THE EXECUTOR-LEVEL SCENARIO: nominate -> gate -> announce -> economics, with a
+    // USDM+ada wallet AND a NON-UNIT principal feed. A 1:1 principal feed cannot distinguish the
+    // two-feed WALL-1 composition from the old one-feed shortcut (M1b/M8's escape), and an ada-only
+    // wallet cannot even reach the token nomination branch (M18) — this fixture is built specifically
+    // so it cannot pass by taking either shortcut.
+    // ======================================================================================
+
+    private static final AssetType PRINCIPAL_TOKEN_2 = new AssetType("d0".repeat(28), "5553444d");
+    private static final AssetType PRINCIPAL_TOKEN_2_ORACLE_NFT = new AssetType("d1".repeat(28), "555344"
+            + "4d4f5241434c45");
+    private static final String PRINCIPAL_TOKEN_2_CREDENTIAL = "d2".repeat(28);
+    private static final String TX_PRINCIPAL_ORACLE_NFT = "d3".repeat(32);
+    private static final String TX_PRINCIPAL_ORACLE_SCRIPT = "d4".repeat(32);
+    private static final String TX_PRINCIPAL_C3_PROVIDER = "d5".repeat(32);
+    private static final String TX_TOKEN_WALLET = "d6".repeat(32);
+
+    /**
+     * The fixture arithmetic, pinned by hand (collateralFeed = 50 lovelace/unit, principalFeed = 5
+     * lovelace/unit — deliberately NOT 1:1, and deliberately DIFFERENT from the collateral's price, so
+     * neither feed's ratio could stand in for the other by coincidence):
+     * <pre>
+     *   collateralAmount 1,000,000 TOK   -> collateralInLovelace   = 1,000,000 * 50 = 50,000,000
+     *   remainingDebt    2,000,000 USDM  -> remainingDebtInLovelace = 2,000,000 * 5 = 10,000,000
+     *   penalty (5%)                     -> 500,000
+     *   equityInLovelace = 50,000,000 - 10,000,000 - 500,000 = 39,500,000
+     *   equity (collateral currency)     = floor(39,500,000 / 50) = 790,000 TOK
+     *   liquidationFee (5%, bond's OWN rate) = floor(1,000,000 * 50 / 1000) = 50,000 TOK
+     *   collateralLenderShouldReceive    = 1,000,000 - 790,000 - 50,000 = 160,000 TOK
+     *   converted (WALL 1, two-feed)     = ceil(160,000 * 50 / 5) = 1,600,000 USDM
+     *   [the OLD one-feed shortcut would instead pay toLovelace(160,000, collFeed).ceil() =
+     *    8,000,000 USDM — 5x too much; this is M1b/M8's escape route, closed by using a non-1:1 feed]
+     *   botCollateral (S-15 rider)       = collateralAmount - equity = 1,000,000 - 790,000 = 210,000 TOK
+     *   acquired (F1)  = value(210,000 TOK)   = 210,000 * 50 = 10,500,000 lovelace
+     *   outlay   (F1)  = value(1,600,000 USDM) = 1,600,000 * 5 = 8,000,000 lovelace (+1, ceil-biased)
+     *   net before tx fee / riders = 10,500,000 - 8,000,001 = 2,499,999 lovelace
+     * </pre>
+     */
+    private static Scenario tokenPrincipalConvertEconomicsScenario() {
+        LoanDatum datum = LoanFixtures.loanDatum(PRINCIPAL_TOKEN_2, PRINCIPAL_TOKEN_2_ORACLE_NFT,
+                BigInteger.valueOf(2_000_000L), BigInteger.ZERO,
+                LoanFixtures.tokenCollateral(COLLATERAL_TOKEN, ORACLE_TOKEN), LATE_LEND_DATE,
+                LoanFixtures.liquidation(), new RepaymentMode.PrincipalAndInterestOnInstallments(), false);
+
+        LoanFixtures.LoanUtxo loan = LoanFixtures.loanUtxo(TX_LOAN, 0, LOAN_ID, datum, 2_000_000L,
+                List.of(LoanFixtures.token(COLLATERAL_TOKEN, 1_000_000L)));
+        LoanFixtures.BondUtxo bond = LoanFixtures.bondUtxo(TX_BOND, 0, LOAN_ID,
+                LoanFixtures.convertToPrincipalBondDatum(BigInteger.valueOf(50),
+                        LoanFixtures.inlineKeyStakeCredential(STAKE_KEY), PRINCIPAL_TOKEN_2),
+                2_000_000L);
+
+        LiquidationAssessment assessment = LoanFixtures.assess(bond.bond(), loan.loan(),
+                principalFeed(), collateralFeed(), NOW);
+        return new Scenario(loan, bond, assessment);
+    }
+
+    private static OraclePriceFeed principalFeed() {
+        return OraclePriceFeed.priceDataCharlie(PRINCIPAL_TOKEN_2, BigInteger.valueOf(5), BigInteger.ONE,
+                NOW - 60_000L, NOW + 600_000L);
+    }
+
+    private static OracleEntry principalOracle() {
+        return LoanFixtures.charli3(PRINCIPAL_TOKEN_2, PRINCIPAL_TOKEN_2_ORACLE_NFT,
+                PRINCIPAL_TOKEN_2_CREDENTIAL, principalFeed(),
+                LoanFixtures.input(TX_PRINCIPAL_ORACLE_NFT, 0), LoanFixtures.input(TX_PRINCIPAL_ORACLE_SCRIPT, 0),
+                LoanFixtures.input(TX_PRINCIPAL_C3_PROVIDER, 0));
+    }
+
+    /**
+     * ⛔ F2's OWN scenario: 3,000,000 USDM in the wallet against a ~1,600,000 payout — the leftover
+     * ~1,400,000 comes back as the bot's own CHANGE, at the SAME address the S-15 collateral rider
+     * lands at, in a DIFFERENT asset (USDM, never the collateral token). A rider filter keyed on "any
+     * token at my address" cannot tell the two apart; one keyed on the COLLATERAL asset specifically
+     * can (F2).
+     */
+    private static final Utxo TOKEN_WALLET_UTXO = LoanFixtures.utxo(TX_TOKEN_WALLET, 0,
+            ACCOUNT.baseAddress(), List.of(
+                    Amount.lovelace(BigInteger.valueOf(60_000_000L)),
+                    Amount.asset(LoanFixtures.unit(PRINCIPAL_TOKEN_2), BigInteger.valueOf(3_000_000L))),
+            null);
+
+    private static Wiring tokenPrincipalConvertEconomicsWiring() {
+        return tokenPrincipalConvertEconomicsWiring(List.of(WALLET_UTXO, TOKEN_WALLET_UTXO));
+    }
+
+    /** As above, with the wallet contents made explicit — F7's own scenario overrides these. */
+    private static Wiring tokenPrincipalConvertEconomicsWiring(List<Utxo> walletUtxos) {
+        AppConfig.LiquidationConfiguration configuration = shadow(SMALL_MARGIN);
+        configuration.setMarkets(List.of(anticipateMarket(PRINCIPAL_TOKEN_2.toUnit(), 1_500_000_000L)));
+
+        // No evaluator is wired (offline, non-evaluating build — the same shape
+        // theBuildPricesWithTheOracleSnapshotTheScanWasTakenWith uses), so reference inputs are
+        // declared by COORDINATE only (from the OracleEntry objects the CountingOracleProvider below
+        // hands out) and never fetched through the UtxoSupplier — the universe needs no physical
+        // oracle utxos at all.
+        Scenario convert = tokenPrincipalConvertEconomicsScenario();
+        List<Utxo> universe = new ArrayList<>(List.of(CONFIG_UTXO, LM_CONFIG_UTXO,
+                convert.loan().utxo(), convert.bond().utxo()));
+        universe.addAll(walletUtxos);
+
+        LiquidateTransactionBuilder plainBuilder = new LiquidateTransactionBuilder(LoanFixtures.registry(),
+                LoanFixtures.NETWORK, LoanFixtures.converters(), LoanFixtures.utxoSupplier(universe),
+                LoanFixtures.protocolParams(), null);
+        BlockEventListener blockEventListener = new BlockEventListener(null);
+        blockEventListener.getIsSyncing().set(false);
+
+        FakeScanner scanner = new FakeScanner(List.of(convert.assessment()));
+        FakeResolver resolver = new FakeResolver(allUnspent(List.of(convert)));
+        LiquidationDecisionLog log = new LiquidationDecisionLog(configuration);
+        CountingOracleProvider oracles = new CountingOracleProvider(
+                new FakeOracleClient(List.of(collateralOracle(), principalOracle())),
+                new FakeOracleClient(List.of(collateralOracle(), principalOracle())));
+
+        PayInAdvanceLiquidationRouter router = new PayInAdvanceLiquidationRouter(
+                LoanFixtures.registry(), LoanFixtures.converters(), configuration,
+                new LiquidatePayInAdvanceTransactionBuilder(LoanFixtures.registry(), LoanFixtures.NETWORK,
+                        LoanFixtures.utxoSupplier(universe), LoanFixtures.protocolParams()));
+
+        LiquidationExecutor executor = new LiquidationExecutor(configuration, blockEventListener,
+                new FakeAppUtxoService(walletUtxos), ACCOUNT, scanner, resolver,
+                plainBuilder, router, LoanFixtures.registry(), log, oracles, previewNetwork(),
+                LoanFixtures.protocolParams(), LoanFixtures.converters(), EXPLODING_SUBMITTER);
+        return new Wiring(executor, log, scanner, resolver, oracles, blockEventListener);
+    }
+
+    /**
+     * ⛔ THE WHOLE SCENARIO, end to end: M18 (nominate must pick the USDM+ada utxo, not fail on an
+     * ada-only one), M12 (the announce line must name USDM, never "ada"), M1b/M8 (the two-feed
+     * composition, not the one-feed shortcut — provable only because the principal feed is non-1:1),
+     * F1 (acquired credited, outlay debited — a real positive net, not the always-negative old
+     * formula), F2 (the wallet's own leftover USDM change is not counted as a rider).
+     */
+    @Test
+    void theExecutorLevelTokenPrincipalScenarioNominatesGatesAnnouncesAndPricesCorrectly() {
+        Wiring wiring = tokenPrincipalConvertEconomicsWiring();
+
+        var logger = (Logger) LoggerFactory.getLogger(LiquidationExecutor.class);
+        var appender = new ListAppender<ILoggingEvent>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            wiring.executor().cycle(NOW);
+        } finally {
+            logger.detachAppender(appender);
+        }
+
+        LiquidationDecision decision = onlyDecision(wiring);
+        assertNotNull(decision.txHash(), "M18 — nominate() must pick the USDM+ada wallet utxo and "
+                + "actually build; got: " + decision.detail());
+
+        // ⛔ M18 — nominate() must ACTUALLY TAKE the token branch, named by its OWN nominated utxo and
+        // log shape. This is NOT provable by "the build succeeded" alone: cardano-client-lib's own
+        // balancer scans the whole wallet during balanceTx and will happily source the missing USDM
+        // from TOKEN_WALLET_UTXO even if nominate() itself picked the WRONG (ada-only) input — measured
+        // disabling the branch outright and finding every OTHER assertion in this test still passed.
+        // The nominate() log line is the only observable that actually pins WHICH utxo was chosen and
+        // by WHICH branch's logic (its message shape differs from the ada-only branch's).
+        boolean nominatedTheTokenUtxoByName = appender.list.stream()
+                .anyMatch(e -> e.getFormattedMessage().contains(TX_TOKEN_WALLET)
+                        && e.getFormattedMessage().contains("fee ceiling + min-ada rider"));
+        assertTrue(nominatedTheTokenUtxoByName, "nominate() must log choosing " + TX_TOKEN_WALLET
+                + " through its TOKEN branch (\"fee ceiling + min-ada rider\"), not fall through to the "
+                + "ada-only branch and rely on the balancer to paper over the wrong nomination: "
+                + appender.list.stream().map(ILoggingEvent::getFormattedMessage).toList());
+
+        // M12 — the announce line must name USDM, never "ada", for a token principal.
+        boolean announcedTheToken = appender.list.stream()
+                .anyMatch(e -> e.getFormattedMessage().contains(PRINCIPAL_TOKEN_2.toUnit())
+                        && e.getFormattedMessage().contains("PAY-IN-ADVANCE"));
+        assertTrue(announcedTheToken, "the PAY-IN-ADVANCE announce line must name " + PRINCIPAL_TOKEN_2.toUnit()
+                + ", never \"ada\": " + appender.list.stream().map(ILoggingEvent::getFormattedMessage).toList());
+
+        // F1/F2 — the economics detail carries the REPLACED bracket with the exact pinned figures.
+        String detail = decision.detail();
+        assertTrue(detail.contains("REPLACED (F1, token principal)"),
+                "a token-principal candidate must go through the REPLACED acquired/outlay economics: "
+                        + detail);
+        assertTrue(detail.contains("acquired 210000 " + COLLATERAL_TOKEN.toUnit() + " (10500000 lovelace)"),
+                "acquired must be the FULL botCollateral share (collateralAmount - equity), priced "
+                        + "through PricingService — M1b/M8 killed by this being the two-feed number: "
+                        + detail);
+        assertTrue(detail.contains("outlay 1600000 " + PRINCIPAL_TOKEN_2.toUnit() + " (8000001 lovelace"),
+                "outlay must be the two-feed WALL-1 payout (1,600,000 USDM, not the one-feed shortcut's "
+                        + "8,000,000), ceil-biased by exactly +1 (F1's second mutant, M7b): " + detail);
+
+        // ⛔ THE EXACT FLOOR, MEASURED AND PINNED — this is what makes F1's two mutants (dropping the
+        // acquired credit, or dropping the outlay's ceil-bias) and F2's (counting the USDM change as
+        // a rider) each change an OBSERVABLE number here, not just a bracket of text that could stay
+        // correct-looking while the real arithmetic drifted. Measured once (txFee 1,206,413, min-ada
+        // 2,245,350 — both protocol-param-derived and not hand-derivable), then pinned: floorProfit =
+        // 10,500,000 - 8,000,001 - 1,206,413 - 2,245,350 = -951,764. Note this is UNPROFITABLE at
+        // SMALL_MARGIN, which is itself informative: the OLD bug (subtracting the outlay alone against
+        // a puny fee slice) would have been far more negative still — this fixture does not need to
+        // clear a margin to prove the fix, only to prove the CORRECT number is being computed.
+        assertTrue(detail.contains("= floor -951764"),
+                "the exact pinned floorProfit — a mutant removing the acquired credit, weakening the "
+                        + "outlay's ceil-bias, or counting the USDM change as a rider each move this "
+                        + "number: " + detail);
+        assertEquals(LiquidationDecision.Outcome.UNPROFITABLE, decision.outcome(),
+                "pinned alongside the floor above — a routed convert tx is priced, not refused: " + detail);
+        assertEquals(0, wiring.executor().quarantinedCount(), "a clean build is not quarantined: " + detail);
+    }
+
+    /**
+     * F7 (round 2) — a token-carrying utxo with too little ada alongside it is NOT a candidate the
+     * selector could ever actually pick, so it must not count toward the balance {@link MarketGate}
+     * sees. 2,000 USDM base units against a bare 1.4 ADA — well short of {@code nominate()}'s own
+     * {@code requiredAda} (fee ceiling + {@code TOKEN_PRINCIPAL_MIN_ADA_CEILING}) — must be excluded
+     * entirely, so the gate sees balance ZERO, never 2,000. Kills M13 (balance summed over ALL
+     * nominable-for-token utxos, ignoring the ada-sufficiency filter).
+     */
+    @Test
+    void aTokenUtxoWithTooLittleAdaAlongsideItDoesNotCountTowardTheMarketBalance() {
+        Utxo tooLittleAda = LoanFixtures.utxo("d7".repeat(32), 0, ACCOUNT.baseAddress(), List.of(
+                Amount.lovelace(BigInteger.valueOf(1_400_000L)),
+                Amount.asset(LoanFixtures.unit(PRINCIPAL_TOKEN_2), BigInteger.valueOf(2_000L))), null);
+        Wiring wiring = tokenPrincipalConvertEconomicsWiring(List.of(WALLET_UTXO, tooLittleAda));
+
+        wiring.executor().cycle(NOW);
+
+        LiquidationDecision decision = onlyDecision(wiring);
+        assertEquals(LiquidationDecision.Outcome.REFUSED, decision.outcome(), decision.detail());
+        assertTrue(decision.detail().contains("holds 0 "),
+                "the 2,000-USDM-but-1.4-ADA utxo must not count at all — the gate must see zero, not "
+                        + "2000: " + decision.detail());
+        assertFalse(decision.detail().contains("holds 2000 "),
+                "M13's exact escape: summing balance over every nominable-for-token utxo regardless of "
+                        + "whether it carries enough ada to ever be selected: " + decision.detail());
+    }
+
+    /**
      * Slice 1, task 3. Exit 7 recorded REFUSED and logged NOTHING. The router's own message is
-     * generic ("… for non-positive equity" / "… for non-ada principal") and never says which asset —
-     * the log line must, because the operator's next question is always "which loan, which token".
-     * The message itself is what lets a reader tell the two triggers apart, so it must be carried
-     * verbatim.
+     * generic ("… for a negative equity" / "… no oracle entry for principal oracle asset") and never
+     * says which asset — the log line must, because the operator's next question is always "which
+     * loan, which token". The message itself is what lets a reader tell the two triggers apart, so it
+     * must be carried verbatim. (F0, round 2: the equity trigger is now a genuinely negative equity,
+     * not "non-positive" — equity 0 is buildable.)
      */
     @Test
     void aPayInAdvanceNotModelledRefusalLogsAtInfoNamingThePrincipalAsset() {
+        // F0 (round 2) — a genuinely negative equity, overridden directly on the assessment (defence
+        // in depth for the router's precondition; see aNegativeEquityAssessmentIsRefusedNotQuarantined
+        // for why the ada/ada fixture's naturally-zero equity no longer refuses at all).
         Scenario convert = convertScenario(FAT_FEE_PER_MILLE);
+        LiquidationAssessment negativeEquity = LiquidationAssessment.buildable(
+                convert.assessment().bond(), convert.assessment().loan(),
+                "negative equity (defence in depth, unreachable through a real assessment)",
+                convert.assessment().remainingDebt(), BigInteger.valueOf(-1),
+                convert.assessment().late(), convert.assessment().liquidationFee());
+        convert = convert.withAssessment(negativeEquity);
         Wiring wiring = wiring(shadow(SMALL_MARGIN), convert, false);
 
         var logger = (Logger) LoggerFactory.getLogger(LiquidationExecutor.class);
@@ -1805,7 +2139,7 @@ class LiquidationExecutorTest {
 
         LiquidationDecision decision = onlyDecision(wiring);
         assertEquals(LiquidationDecision.Outcome.REFUSED, decision.outcome(), decision.detail());
-        assertEquals("pay-in-advance not yet modelled for non-positive equity", decision.reason());
+        assertEquals("pay-in-advance not yet modelled for a negative equity", decision.reason());
 
         List<ILoggingEvent> infos = appender.list.stream()
                 .filter(event -> event.getLevel() == Level.INFO)
@@ -1815,7 +2149,7 @@ class LiquidationExecutorTest {
                 + appender.list);
         String message = infos.getFirst().getFormattedMessage();
         assertTrue(message.contains("lovelace"), "must name the principal asset (the unit): " + message);
-        assertTrue(message.contains("non-positive equity"),
+        assertTrue(message.contains("negative equity"),
                 "must carry the router's own message verbatim — it is what distinguishes the two "
                         + "triggers: " + message);
         // ⛔ AND THE REMEDY MUST BE ABSENT HERE. The principal IS ada, so "set this market to CONVERT"
@@ -1871,6 +2205,14 @@ class LiquidationExecutorTest {
         assertTrue(message.contains("action to CONVERT"),
                 "a non-ada-principal refusal MUST carry the remedy — it is the one trigger the advice "
                         + "is correct for: " + message);
+        // REMEDY WORDING (Machine Owner ruling, 2026-09-09) — "routable" is not "profitable": for the
+        // live USDM loan the FLDT/USDM pool returns ~827M against a 980M minimum_receive, so CONVERT
+        // would build, submit and REFUND rather than fill the debt. The remedy must carry that caveat
+        // until PR3's POOL_TOO_THIN pre-check exists, or it reads as an unconditional fix it is not.
+        assertTrue(message.contains("only if a Minswap pool can fill the debt")
+                        && message.contains("thin pool refunds rather than fills"),
+                "the CONVERT remedy must carry the pool-depth caveat, not read as unconditional advice: "
+                        + message);
     }
 
     /**

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutorTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutorTest.java
@@ -3224,4 +3224,70 @@ class LiquidationExecutorTest {
         m.setCap(java.math.BigInteger.valueOf(cap));
         return m;
     }
+
+    // ===== the CONVERT route must be handed a NOMINABLE wallet utxo, never the first raw one =====
+
+    /** Captures the wallet utxo the executor hands the convert router, then stops the build. */
+    private static final class CapturingConvertRouter extends ConvertLiquidationRouter {
+        Utxo captured;
+        CapturingConvertRouter() { super(null, null, null, null, null, null, null, null); }
+        @Override
+        public Transaction buildConvertLiquidation(LiquidationAssessment assessment, Utxo loanUtxo,
+                                                    Utxo bondUtxo, Utxo configUtxo, Utxo lmConfigUtxo,
+                                                    Utxo walletUtxo, Map<String, OracleEntry> oracles,
+                                                    String changeAddress, long validFromMillis, long validToMillis) {
+            captured = walletUtxo;
+            throw new RuntimeException("captured the wallet input; nothing past this point is under test");
+        }
+    }
+
+    /**
+     * ⛔ The regression the slice-3 round-2 audit caught, pinned. fbcf6b1 made the cycle's wallet list
+     * the UNFILTERED listing (so the token path could see multi-asset utxos), and the convert hand-off
+     * — {@code walletUtxos.get(0)}, untouched — silently became "the first utxo Blockfrost returns".
+     * Blockfrost lists ascending, so that is the OLDEST utxo at the bot's address: the published
+     * reference scripts. A convert would have spent {@code loan_claim_action}'s reference script.
+     *
+     * <p>The listing here puts a reference-script utxo FIRST on purpose; the captured input must be
+     * the ada-only one. Mutant: hand the router {@code walletUtxos.get(0)} again — this test fails with
+     * the reference-script hash in the message.
+     */
+    @Test
+    void theConvertRouteIsHandedANominableWalletUtxoNeverTheFirstRawOne() {
+        Utxo refScriptUtxo = Utxo.builder().txHash("f9".repeat(32)).outputIndex(0)
+                .address(ACCOUNT.baseAddress())
+                .amount(List.of(Amount.lovelace(BigInteger.valueOf(30_000_000L))))
+                .referenceScriptHash("9ae63b26c98d90024a45f9cdb57e4154f72144d44325f0a261b8bc1d").build();
+        AppConfig.LiquidationConfiguration configuration = new AppConfig.LiquidationConfiguration(
+                AppConfig.LiquidationConfiguration.Mode.SHADOW, 60, 120, 30, SMALL_MARGIN, 200, 30);
+        Scenario convert = convertScenario(FAT_FEE_PER_MILLE);
+        List<Utxo> universe = List.of(CONFIG_UTXO, LM_CONFIG_UTXO, WALLET_UTXO, refScriptUtxo,
+                convert.loan().utxo(), convert.bond().utxo());
+        LiquidateTransactionBuilder plainBuilder = new LiquidateTransactionBuilder(LoanFixtures.registry(),
+                LoanFixtures.NETWORK, LoanFixtures.converters(), LoanFixtures.utxoSupplier(universe),
+                LoanFixtures.protocolParams(), null);
+        BlockEventListener blockEventListener = new BlockEventListener(null);
+        blockEventListener.getIsSyncing().set(false);
+        FakeScanner scanner = new FakeScanner(List.of(convert.assessment()));
+        FakeResolver resolver = new FakeResolver(allUnspent(List.of(convert)));
+        LiquidationDecisionLog log = new LiquidationDecisionLog(configuration);
+        CountingOracleProvider oracles = noOracle();
+        PayInAdvanceLiquidationRouter payInAdvanceRouter = new PayInAdvanceLiquidationRouter(
+                LoanFixtures.registry(), LoanFixtures.converters(), configuration,
+                new LiquidatePayInAdvanceTransactionBuilder(LoanFixtures.registry(), LoanFixtures.NETWORK,
+                        LoanFixtures.utxoSupplier(universe), LoanFixtures.protocolParams()));
+        CapturingConvertRouter capturing = new CapturingConvertRouter();
+        LiquidationExecutor executor = new LiquidationExecutor(configuration, blockEventListener,
+                new FakeAppUtxoService(List.of(refScriptUtxo, WALLET_UTXO)), ACCOUNT, scanner, resolver, plainBuilder,
+                payInAdvanceRouter, capturing, LoanFixtures.registry(), log, oracles,
+                previewNetwork(), LoanFixtures.protocolParams(), LoanFixtures.converters(),
+                EXPLODING_SUBMITTER);
+        executor.cycle(NOW);
+        assertNotNull(capturing.captured, "the convert route was never reached");
+        assertNull(capturing.captured.getReferenceScriptHash(),
+                "the CONVERT route was handed the published REFERENCE-SCRIPT utxo as its wallet input: "
+                        + capturing.captured.getTxHash() + "#" + capturing.captured.getOutputIndex());
+        assertEquals(WALLET_UTXO.getTxHash(), capturing.captured.getTxHash(),
+                "the convert route must receive the first NOMINABLE utxo");
+    }
 }

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LoanFixtures.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LoanFixtures.java
@@ -30,6 +30,7 @@ import com.fluidtokens.aquarium.offchain.model.loans.Loan;
 import com.fluidtokens.aquarium.offchain.model.loans.LoanDatum;
 import com.fluidtokens.aquarium.offchain.model.loans.OracleEntry;
 import com.fluidtokens.aquarium.offchain.model.loans.OraclePriceFeed;
+import com.fluidtokens.aquarium.offchain.model.loans.OracleSignature;
 import com.fluidtokens.aquarium.offchain.model.loans.Rational;
 import com.fluidtokens.aquarium.offchain.model.loans.RepaymentMode;
 import com.fluidtokens.aquarium.offchain.service.LoansContractRegistry;
@@ -793,6 +794,24 @@ public final class LoanFixtures {
         return new OracleEntry(token, oracleToken, rewardAddress(withdrawCredentialHash),
                 withdrawCredentialHash, referenceInput, referenceScript, List.of(), 0, feed,
                 List.of(), provider);
+    }
+
+    /**
+     * A <b>MULTISIG</b> ({@code AGGREGATED}) oracle entry — the shape every FluidTokens mainnet feed
+     * is published in, and the one no offline fixture had until 2026-09-10.
+     * <p>
+     * Two things distinguish it from {@link #charli3} and both matter to the builder: there is
+     * <b>no Charli3 provider reference input</b> (so a builder that assembles one unconditionally
+     * meets a null), and the price is proven by <b>published signatures</b> rather than structurally
+     * against a provider UTxO (so the redeemer takes the signed encoding, and an empty signature list
+     * would fail the validator's threshold in phase 2).
+     */
+    public static OracleEntry multisig(AssetType token, AssetType oracleToken, String withdrawCredentialHash,
+                                       OraclePriceFeed feed, TransactionInput referenceInput,
+                                       TransactionInput referenceScript, List<OracleSignature> signatures) {
+        return new OracleEntry(token, oracleToken, rewardAddress(withdrawCredentialHash),
+                withdrawCredentialHash, referenceInput, referenceScript,
+                List.of("00".repeat(32)), 1, feed, signatures, null);
     }
 
     // ---- suppliers ---------------------------------------------------------------------------

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/MainnetCompoundEscrowTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/MainnetCompoundEscrowTest.java
@@ -7,6 +7,7 @@ import com.bloxbean.cardano.client.util.HexUtil;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fluidtokens.aquarium.offchain.config.AppConfig;
+import com.fluidtokens.aquarium.offchain.model.AssetType;
 import com.fluidtokens.aquarium.offchain.service.LoansContractRegistry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -152,13 +153,15 @@ class MainnetCompoundEscrowTest {
         ReflectionTestUtils.setField(configuration, "enabled", true);
         ReflectionTestUtils.setField(configuration, "profitMarginLovelace", BigInteger.ZERO);
 
-        var assessment = new CompoundEconomics(configuration, network).assess(
+        var pricingService = new PricingService(new FluidOracleClient("http://unused.invalid"));
+        var assessment = new CompoundEconomics(configuration, network, pricingService).assess(
                 true,                                   // the bond names a pool
                 true,                                   // pool and manager are both live
-                true,                                   // ada principal
+                AssetType.ada(),                        // ada principal
                 BigInteger.valueOf(ESCROW_LOVELACE),
                 0L,                                     // compoudingFeePerMille, read from chain
-                BigInteger.valueOf(300_000L));          // a representative tx fee
+                BigInteger.valueOf(300_000L),            // a representative tx fee
+                System.currentTimeMillis());
 
         assertFalse(assessment.approved(),
                 "a zero-fee pool must be refused at the shipped margin: the compound pays nothing and "

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/MainnetShadowRunTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/MainnetShadowRunTest.java
@@ -344,7 +344,11 @@ class MainnetShadowRunTest {
                             configuration(Mode.SHADOW, List.of(market(principal.toUnit(), Mode.SHADOW,
                                     Action.ANTICIPATE, BigInteger.valueOf(1_000_000_000L))))))) {
                 var gate = new MarketGate(posture.getValue());
-                var decision = gate.decide(principal, required);
+                // Diagnostic report only — this manual rig does not read a real wallet balance, so it
+                // passes `required` as the balance too, which is what `decide`'s old two-argument form
+                // always assumed. min(required, cap) is unchanged from before Part 3 of the
+                // token-principals slice.
+                var decision = gate.decide(principal, required, required);
                 System.out.println("  GATE " + posture.getKey());
                 System.out.println("       effectiveMode=" + gate.effectiveMode(principal)
                         + "  action=" + gate.actionFor(principal)

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/MarketGateTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/MarketGateTest.java
@@ -292,6 +292,29 @@ class MarketGateTest {
         assertEquals(n(500_000_000), d.anticipatable(), "min(balance, cap) with an ample balance is the cap");
     }
 
+    /**
+     * F6 (round 2) — THE ORDERING THAT ACTUALLY DISTINGUISHES THE TWO REFUSALS: {@code balance < cap
+     * < required}. The sibling test above ({@code aBalanceAboveTheCapStillRefusesAsAboveMarketCap...})
+     * has {@code balance >= cap}, so {@code balance.compareTo(cap) < 0} was already false there under
+     * the PRE-FIX code too — it could not have caught a mutant that checked the balance-vs-cap
+     * ordering instead of the cap-vs-required one. Here the balance is BELOW the cap (100M < 500M)
+     * AND the cap is itself below the requirement (500M < 600M): the cap is the binding constraint
+     * regardless of the balance, so the refusal must be {@code ABOVE_MARKET_CAP}, never {@code
+     * INSUFFICIENT_BALANCE} — "fund the wallet" would be true but useless advice when the cap itself
+     * could never have covered the requirement.
+     */
+    @Test
+    void aCapBelowTheRequirementRefusesAsAboveMarketCapEvenWhenTheBalanceIsAlsoBelowTheCap() {
+        MarketGate.Decision d = gate(Mode.LIVE, market(TOKEN.toUnit(), Mode.LIVE, Action.ANTICIPATE, 500_000_000L))
+                .decide(TOKEN, n(600_000_000), n(100_000_000));
+
+        assertFalse(d.allowed());
+        assertEquals(MarketGate.Refusal.ABOVE_MARKET_CAP, d.refusal(),
+                "the cap is below the requirement, so it is the binding constraint — the balance being "
+                        + "ALSO short must not relabel this as INSUFFICIENT_BALANCE");
+        assertEquals(n(100_000_000), d.anticipatable(), "min(balance, cap) with balance the smaller of the two");
+    }
+
     // ---- startup validation ------------------------------------------------------------------------
 
     /**

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/MarketGateTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/MarketGateTest.java
@@ -33,6 +33,15 @@ class MarketGateTest {
         return BigInteger.valueOf(v);
     }
 
+    /**
+     * An "unlimited" wallet balance — every test above the balance-check tests below exists to prove
+     * something about the CAP, not the balance, so it is given a balance that can never be the
+     * limiting term. {@code min(AMPLE, cap) == cap} for every cap these tests use (max 500,000,000),
+     * which is exactly what makes {@link MarketGate.Refusal#ABOVE_MARKET_CAP} (not
+     * {@link MarketGate.Refusal#INSUFFICIENT_BALANCE}) the refusal those tests still see.
+     */
+    private static final BigInteger AMPLE = BigInteger.valueOf(1_000_000_000_000L);
+
     private static Market market(String unit, Mode mode, Action action, Long cap) {
         Market m = new Market();
         m.setUnit(unit);
@@ -68,7 +77,7 @@ class MarketGateTest {
         assertEquals(Mode.LIVE, g.effectiveMode(ADA), "an unlisted market inherits the node's posture");
         assertEquals(Action.CONVERT, g.actionFor(ADA));
 
-        MarketGate.Decision d = g.decide(ADA, n(1_000_000));
+        MarketGate.Decision d = g.decide(ADA, n(1_000_000), AMPLE);
         assertFalse(d.allowed());
         assertEquals(MarketGate.Refusal.MARKET_ACTION_IS_CONVERT, d.refusal());
     }
@@ -114,7 +123,7 @@ class MarketGateTest {
     @Test
     void aDisabledMarketRefusesBeforeAnythingElse() {
         MarketGate.Decision d = gate(Mode.LIVE, market("lovelace", Mode.DISABLED, Action.ANTICIPATE, 1_000L))
-                .decide(ADA, n(1));
+                .decide(ADA, n(1), AMPLE);
 
         assertFalse(d.allowed());
         assertEquals(MarketGate.Refusal.MARKET_DISABLED, d.refusal());
@@ -134,10 +143,10 @@ class MarketGateTest {
     @Test
     void aShadowMarketBuildsAndIsHeldByTheExecutorVetoInstead() {
         assertTrue(gate(Mode.LIVE, market("lovelace", Mode.SHADOW, Action.ANTICIPATE, 1_000L))
-                        .decide(ADA, n(1)).allowed(),
+                        .decide(ADA, n(1), AMPLE).allowed(),
                 "a market-level shadow on a live node must reach the builder");
         assertTrue(gate(Mode.SHADOW, market("lovelace", null, Action.ANTICIPATE, 1_000L))
-                        .decide(ADA, n(1)).allowed(),
+                        .decide(ADA, n(1), AMPLE).allowed(),
                 "and so must a node-wide shadow, which always could");
 
         assertEquals(Mode.SHADOW, gate(Mode.LIVE, market("lovelace", Mode.SHADOW, Action.CONVERT, null))
@@ -152,12 +161,12 @@ class MarketGateTest {
     void payInAdvanceNeedsTheMarketToSayAnticipateExplicitly() {
         assertEquals(MarketGate.Refusal.MARKET_ACTION_IS_CONVERT,
                 gate(Mode.LIVE, market("lovelace", Mode.LIVE, Action.CONVERT, 1_000L))
-                        .decide(ADA, n(1)).refusal(),
+                        .decide(ADA, n(1), AMPLE).refusal(),
                 "a cap alone must NOT select anticipate — that is the positional inference the object "
                         + "shape exists to kill");
 
         assertTrue(gate(Mode.LIVE, market("lovelace", Mode.LIVE, Action.ANTICIPATE, 1_000L))
-                .decide(ADA, n(1)).allowed());
+                .decide(ADA, n(1), AMPLE).allowed());
     }
 
     // ---- the cap ----------------------------------------------------------------------------------
@@ -165,7 +174,7 @@ class MarketGateTest {
     @Test
     void aCapBelowTheRequirementRefusesRatherThanReducing() {
         MarketGate.Decision d = gate(Mode.LIVE, market("lovelace", Mode.LIVE, Action.ANTICIPATE, 500_000_000L))
-                .decide(ADA, n(500_000_001));
+                .decide(ADA, n(500_000_001), AMPLE);
 
         assertFalse(d.allowed());
         assertEquals(MarketGate.Refusal.ABOVE_MARKET_CAP, d.refusal());
@@ -193,19 +202,19 @@ class MarketGateTest {
     void theBoundaryIsInclusiveOnTheCap() {
         MarketGate g = gate(Mode.LIVE, market("lovelace", Mode.LIVE, Action.ANTICIPATE, 500_000_000L));
 
-        MarketGate.Decision exactly = g.decide(ADA, n(500_000_000));
+        MarketGate.Decision exactly = g.decide(ADA, n(500_000_000), AMPLE);
         assertTrue(exactly.allowed(), "required == cap must be ALLOWED; min() returns the requirement");
         assertEquals(n(500_000_000), exactly.anticipatable());
 
-        assertTrue(g.decide(ADA, n(499_999_999)).allowed(), "one under the cap");
-        assertFalse(g.decide(ADA, n(500_000_001)).allowed(), "one over the cap");
+        assertTrue(g.decide(ADA, n(499_999_999), AMPLE).allowed(), "one under the cap");
+        assertFalse(g.decide(ADA, n(500_000_001), AMPLE).allowed(), "one over the cap");
     }
 
     /** An explicit zero cap is a documented disable: min(required, 0) == 0. */
     @Test
     void anExplicitZeroCapIsADocumentedDisable() {
         MarketGate.Decision d = gate(Mode.LIVE, market("lovelace", Mode.LIVE, Action.ANTICIPATE, 0L))
-                .decide(ADA, n(1));
+                .decide(ADA, n(1), AMPLE);
 
         assertFalse(d.allowed());
         assertEquals(BigInteger.ZERO, d.anticipatable());
@@ -219,10 +228,68 @@ class MarketGateTest {
                 market("lovelace", Mode.LIVE, Action.ANTICIPATE, 1_000L),
                 market(TOKEN.toUnit(), Mode.LIVE, Action.ANTICIPATE, 900L));
 
-        assertTrue(g.decide(ADA, n(1_000)).allowed());
-        assertFalse(g.decide(ADA, n(1_001)).allowed());
-        assertTrue(g.decide(TOKEN, n(900)).allowed());
-        assertFalse(g.decide(TOKEN, n(901)).allowed(), "each market carries its own cap");
+        assertTrue(g.decide(ADA, n(1_000), AMPLE).allowed());
+        assertFalse(g.decide(ADA, n(1_001), AMPLE).allowed());
+        assertTrue(g.decide(TOKEN, n(900), AMPLE).allowed());
+        assertFalse(g.decide(TOKEN, n(901), AMPLE).allowed(), "each market carries its own cap");
+    }
+
+    // ---- the balance (Part 3, token-principals slice) ----------------------------------------------
+
+    /**
+     * ⛔ THE BUG THIS PART EXISTS TO FIX, pinned as a positive control before the fix is exercised
+     * below: a market with a generous cap and a bot holding ZERO of the principal must be REFUSED,
+     * naming the shortfall — "holds X, needs Y" — not silently allowed because {@code required} was
+     * being compared against the cap alone.
+     */
+    @Test
+    void aZeroBalanceIsRefusedByNameEvenUnderAGenerousCap() {
+        MarketGate.Decision d = gate(Mode.LIVE, market(TOKEN.toUnit(), Mode.LIVE, Action.ANTICIPATE, 1_500_000_000L))
+                .decide(TOKEN, n(1_033_850_765), BigInteger.ZERO);
+
+        assertFalse(d.allowed(), "zero balance must never be allowed, whatever the cap says");
+        assertEquals(MarketGate.Refusal.INSUFFICIENT_BALANCE, d.refusal());
+        assertEquals(BigInteger.ZERO, d.anticipatable(), "min(balance, cap) with balance 0 is 0");
+        assertTrue(d.detail().contains("holds 0") && d.detail().contains("needs 1033850765"),
+                "the refusal must name both the balance and the requirement: " + d.detail());
+    }
+
+    /** A balance strictly between zero and the requirement is refused the same way, still by name. */
+    @Test
+    void aPartialBalanceIsRefusedByName() {
+        MarketGate.Decision d = gate(Mode.LIVE, market(TOKEN.toUnit(), Mode.LIVE, Action.ANTICIPATE, 1_500_000_000L))
+                .decide(TOKEN, n(1_033_850_765), n(500_000_000));
+
+        assertFalse(d.allowed());
+        assertEquals(MarketGate.Refusal.INSUFFICIENT_BALANCE, d.refusal());
+        assertEquals(n(500_000_000), d.anticipatable());
+    }
+
+    /** A balance that covers the requirement (and sits under the cap) is allowed. */
+    @Test
+    void aSufficientBalanceUnderTheCapIsAllowed() {
+        MarketGate.Decision d = gate(Mode.LIVE, market(TOKEN.toUnit(), Mode.LIVE, Action.ANTICIPATE, 1_500_000_000L))
+                .decide(TOKEN, n(1_033_850_765), n(1_033_850_765));
+
+        assertTrue(d.allowed());
+        assertEquals(n(1_033_850_765), d.anticipatable());
+    }
+
+    /**
+     * ⛔ THE TWO REFUSALS ARE DISTINCT, and this is the boundary between them: a balance ABOVE the cap
+     * but a requirement above BOTH must still say {@code ABOVE_MARKET_CAP} — the operator's remedy is
+     * "raise the cap", not "fund the wallet", and a bot already holding more than the cap allows is
+     * proof the wallet is not the problem.
+     */
+    @Test
+    void aBalanceAboveTheCapStillRefusesAsAboveMarketCapNotInsufficientBalance() {
+        MarketGate.Decision d = gate(Mode.LIVE, market(TOKEN.toUnit(), Mode.LIVE, Action.ANTICIPATE, 500_000_000L))
+                .decide(TOKEN, n(600_000_000), n(2_000_000_000L));
+
+        assertFalse(d.allowed());
+        assertEquals(MarketGate.Refusal.ABOVE_MARKET_CAP, d.refusal(),
+                "the wallet holds plenty — the cap, not the balance, is what refuses this candidate");
+        assertEquals(n(500_000_000), d.anticipatable(), "min(balance, cap) with an ample balance is the cap");
     }
 
     // ---- startup validation ------------------------------------------------------------------------

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/PayInAdvanceLiquidationRouterTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/PayInAdvanceLiquidationRouterTest.java
@@ -21,6 +21,7 @@ import com.fluidtokens.aquarium.offchain.model.loans.Loan;
 import com.fluidtokens.aquarium.offchain.model.loans.LoanDatum;
 import com.fluidtokens.aquarium.offchain.model.loans.OracleEntry;
 import com.fluidtokens.aquarium.offchain.model.loans.OraclePriceFeed;
+import com.fluidtokens.aquarium.offchain.model.loans.Rational;
 import com.fluidtokens.aquarium.offchain.service.LoansContractRegistry;
 import org.cardanofoundation.conversions.CardanoConverters;
 import org.junit.jupiter.api.Test;
@@ -154,6 +155,13 @@ class PayInAdvanceLiquidationRouterTest {
     private static final Utxo WALLET_UTXO = LoanFixtures.adaUtxo(TX_WALLET, 0,
             LoanFixtures.botAddress(), 60_000_000L);
 
+    /**
+     * Part 3's {@code principalBalance} argument — "ample" for every test in this class that is not
+     * itself about the balance check, so MarketGate's cap (not its balance term) stays the thing under
+     * test, exactly as {@code anyWallet()} keeps the SELECTOR out of the way for tests not about T-052.
+     */
+    private static final BigInteger AMPLE_BALANCE = BigInteger.valueOf(1_000_000_000_000L);
+
     /** A selector that supplies the fixture wallet whatever the payout — for tests not about T-052. */
     private static Function<BigInteger, Optional<Utxo>> anyWallet() {
         return payout -> Optional.of(WALLET_UTXO);
@@ -174,7 +182,7 @@ class PayInAdvanceLiquidationRouterTest {
         LiquidationAssessment assessment = convertAssessment(BigInteger.valueOf(EQUITY));
 
         Transaction tx = router().buildConvertLiquidation(assessment, loanUtxo(), bondUtxo(),
-                CONFIG_UTXO, LM_CONFIG_UTXO, oraclesByUnit(), anyWallet(), NOW, VALID_TO_MILLIS);
+                CONFIG_UTXO, LM_CONFIG_UTXO, oraclesByUnit(), AMPLE_BALANCE, anyWallet(), NOW, VALID_TO_MILLIS);
 
         // The parent LenderManager redeemer carries LiquidateAndPayInAdvance (constructor index 3).
         String parentReward = LoanFixtures.rewardAddress(REGISTRY.getLenderManagerWithdrawScriptHash());
@@ -223,20 +231,185 @@ class PayInAdvanceLiquidationRouterTest {
         PayInAdvanceLiquidationRouter.PayInAdvanceNotModelledException refusal = assertThrows(
                 PayInAdvanceLiquidationRouter.PayInAdvanceNotModelledException.class,
                 () -> router().buildConvertLiquidation(assessment, loanUtxo(), bondUtxo(),
-                        CONFIG_UTXO, LM_CONFIG_UTXO, oraclesByUnit(), anyWallet(), NOW, VALID_TO_MILLIS));
+                        CONFIG_UTXO, LM_CONFIG_UTXO, oraclesByUnit(), AMPLE_BALANCE, anyWallet(), NOW, VALID_TO_MILLIS));
         assertEquals("pay-in-advance not yet modelled for non-positive equity", refusal.getMessage());
     }
 
-    /** A convert loan whose principal is not ada is refused cleanly, before the builder runs. */
+    /**
+     * ⛔ A non-ada principal is now MODELLED (the whole point of the token-principals slice) — it is
+     * refused only when the executor's {@code oraclesByUnit} snapshot has no entry for the loan's
+     * OWN {@code principalOracleAsset}, exactly as WALL 3 requires: looked up by the oracle NFT the
+     * datum names, not by the priced asset.
+     */
     @Test
-    void nonAdaPrincipalIsRefusedCleanly() {
+    void nonAdaPrincipalWithNoMatchingOracleIsRefusedCleanly() {
         LiquidationAssessment assessment = convertAssessment(BigInteger.valueOf(EQUITY),
                 nonAdaPrincipalLoanDatum());
         PayInAdvanceLiquidationRouter.PayInAdvanceNotModelledException refusal = assertThrows(
                 PayInAdvanceLiquidationRouter.PayInAdvanceNotModelledException.class,
                 () -> router().buildConvertLiquidation(assessment, loanUtxo(), bondUtxo(),
-                        CONFIG_UTXO, LM_CONFIG_UTXO, oraclesByUnit(), anyWallet(), NOW, VALID_TO_MILLIS));
-        assertEquals("pay-in-advance not yet modelled for non-ada principal", refusal.getMessage());
+                        CONFIG_UTXO, LM_CONFIG_UTXO, oraclesByUnit(), AMPLE_BALANCE, anyWallet(), NOW, VALID_TO_MILLIS));
+        assertTrue(refusal.getMessage().contains("no oracle entry for principal oracle asset"),
+                refusal.getMessage());
+    }
+
+    // ======================================================================================
+    // (4) a TOKEN PRINCIPAL, routed and built end to end — WALLS 1-4 exercised off the built body
+    // ======================================================================================
+    //
+    // ⚠ No real registered oracle asset besides tFLDT (the collateral one) is available offline —
+    // see docs/lending-v4-findings.md §59 on why a second REAL Charli3-recognised token cannot be
+    // fabricated (charlie_specs is a closed, deployment-time validator parameter). This principal
+    // oracle is therefore SYNTHETIC — its own fake script hash / reference input / reward address,
+    // the same style LiquidationSubmitVetoTest and LiquidationExecutorTest already use for their
+    // oracle fixtures. It is real enough to prove every piece of OFF-CHAIN wiring (WALLS 1-4, all
+    // Java-side), but this class evaluates no script (see its own class javadoc) — it never did, and
+    // still does not. The genuinely on-chain-validated proof is LoanFinanceTest's exact arithmetic
+    // vectors, which need no chain data at all.
+
+    private static final AssetType TOKEN_PRINCIPAL =
+            new AssetType("cc".repeat(28), "0014df105553444d");
+    private static final AssetType TOKEN_PRINCIPAL_ORACLE_NFT =
+            new AssetType("8a".repeat(28), "8a".repeat(10));
+    private static final String TOKEN_PRINCIPAL_ORACLE_CREDENTIAL = "8b".repeat(28);
+    // ⚠ "fe" — deliberately NOT the hex-lowest reference input in this fixture (see
+    // TransactionInputComparator), so its sorted position is provably non-zero. A hardcoded
+    // principalOracleRefIndex == 0 mutant must be DISTINGUISHABLE from the real derived position —
+    // choosing a coordinate that happens to sort first would let that mutant survive by coincidence.
+    private static final TransactionInput TOKEN_PRINCIPAL_ORACLE_REF_INPUT =
+            LoanFixtures.input("fe".repeat(32), 0);
+    private static final TransactionInput TOKEN_PRINCIPAL_ORACLE_REF_SCRIPT =
+            LoanFixtures.input("8d".repeat(32), 0);
+    private static final TransactionInput TOKEN_PRINCIPAL_C3_PROVIDER =
+            LoanFixtures.input("8e".repeat(32), 0);
+
+    private static LoanDatum tokenPrincipalLoanDatum() {
+        LoanDatum ada = loanDatum();
+        return new LoanDatum(ada.doneRecasts(), ada.principalAmount(), ada.lendDate(),
+                ada.repaidInstallments(), ada.interestRate(), ada.totalInstallments(), TOKEN_PRINCIPAL,
+                TOKEN_PRINCIPAL_ORACLE_NFT, ada.installmentPeriod(), ada.initialGracePeriod(),
+                ada.liquidationMode(), ada.repaymentMode(), ada.repaymentTimeWindow(),
+                ada.penaltyFeeForLateRepayment(), ada.repaymentReceipts(), ada.originId(),
+                ada.collateral());
+    }
+
+    /**
+     * ⚠ Priced 1:1 — the same numeric ratio {@link OraclePriceFeed#unit()} carries — DELIBERATELY, so
+     * this fixture's remaining debt and equity come out exactly as the frozen ada fixture's do
+     * ({@code EQUITY}, below) and the loan stays solvent. This test proves the WIRING (a distinct
+     * reference input, a distinct withdraw-0, the payout landing in the principal asset, the output
+     * shape) — the EXACT two-feed ARITHMETIC at a genuinely different price is
+     * {@code LoanFinanceTest.convertFromAToBWithOraclesMatchesThePinnedMainnetCandidate}, which needs
+     * no chain-shaped fixture at all.
+     */
+    private static OracleEntry tokenPrincipalOracle() {
+        return LoanFixtures.charli3(TOKEN_PRINCIPAL, TOKEN_PRINCIPAL_ORACLE_NFT,
+                TOKEN_PRINCIPAL_ORACLE_CREDENTIAL,
+                OraclePriceFeed.priceDataCharlie(TOKEN_PRINCIPAL,
+                        BigInteger.ONE, BigInteger.ONE,
+                        FEED_VALID_FROM, FEED_VALID_TO),
+                TOKEN_PRINCIPAL_ORACLE_REF_INPUT, TOKEN_PRINCIPAL_ORACLE_REF_SCRIPT,
+                TOKEN_PRINCIPAL_C3_PROVIDER);
+    }
+
+    private static Map<String, OracleEntry> oraclesByUnitWithTokenPrincipal() {
+        Map<String, OracleEntry> byUnit = new java.util.LinkedHashMap<>(oraclesByUnit());
+        OracleEntry principal = tokenPrincipalOracle();
+        byUnit.put(principal.oracleToken().toUnit(), principal);
+        return byUnit;
+    }
+
+    private static AppConfig.LiquidationConfiguration configurationWithTokenMarket() {
+        AppConfig.LiquidationConfiguration cfg = configuration();
+        List<AppConfig.LiquidationConfiguration.Market> markets = new ArrayList<>(cfg.getMarkets());
+        markets.add(anticipateMarket(TOKEN_PRINCIPAL.toUnit(), 1_500_000_000L));
+        cfg.setMarkets(markets);
+        return cfg;
+    }
+
+    private static PayInAdvanceLiquidationRouter tokenPrincipalRouter() {
+        // Reads the reference inputs it needs from a universe that ALSO carries the synthetic
+        // principal oracle's three coordinates — the same additive pattern universe(fixture) uses
+        // for the collateral leg's oracle in the dry-eval rig.
+        List<Utxo> universeWithPrincipalOracle = new ArrayList<>(universe());
+        universeWithPrincipalOracle.add(LoanFixtures.utxo(
+                TOKEN_PRINCIPAL_ORACLE_REF_INPUT.getTransactionId(), TOKEN_PRINCIPAL_ORACLE_REF_INPUT.getIndex(),
+                LoanFixtures.rewardAddress(TOKEN_PRINCIPAL_ORACLE_CREDENTIAL), List.of(
+                        Amount.lovelace(BigInteger.valueOf(1_038_710L)),
+                        Amount.asset(LoanFixtures.unit(TOKEN_PRINCIPAL_ORACLE_NFT), BigInteger.ONE)), null));
+        return new PayInAdvanceLiquidationRouter(REGISTRY, converters(), configurationWithTokenMarket(),
+                new LiquidatePayInAdvanceTransactionBuilder(REGISTRY, LoanFixtures.NETWORK,
+                        LoanFixtures.utxoSupplier(universeWithPrincipalOracle), EvalFixtures.protocolParams()));
+    }
+
+    /**
+     * WALL 1 — the built transaction pays the lender the two-feed composition, in the PRINCIPAL
+     * asset, never a one-feed lovelace shortcut. WALL 4 — that output is the token plus its min-ada
+     * rider (flatten == 2), not ada. Both measured off the BUILT body, the same discipline
+     * {@code LiquidatePayInAdvanceTransactionBuilder}'s own {@code assertStructure} uses — this test
+     * would fail if that internal assertion were ever weakened, because it re-derives the same figure
+     * independently via {@link LoanFinance#convertFromAToBWithOracles} rather than trusting the
+     * builder's own number.
+     */
+    @Test
+    void aTokenPrincipalLoanIsRoutedAndPaysTheLenderInTheTokenWithTheTwoFeedComposition() {
+        LiquidationAssessment assessment = convertAssessment(BigInteger.valueOf(EQUITY), tokenPrincipalLoanDatum());
+
+        Transaction tx = tokenPrincipalRouter().buildConvertLiquidation(assessment, loanUtxo(),
+                bondUtxo(), CONFIG_UTXO, LM_CONFIG_UTXO, oraclesByUnitWithTokenPrincipal(),
+                AMPLE_BALANCE, anyWallet(), NOW, VALID_TO_MILLIS);
+
+        BigInteger collateralLenderShouldReceive = BigInteger.valueOf(COLLATERAL_AMOUNT)
+                .subtract(BigInteger.valueOf(EQUITY)).subtract(BigInteger.valueOf(LIQUIDATION_FEE));
+        BigInteger expectedPayout = LoanFinance.convertFromAToBWithOracles(
+                oracle().feed(), tokenPrincipalOracle().feed(), Rational.fromInt(collateralLenderShouldReceive));
+
+        List<TransactionOutput> assetManagerOutputs = assetManagerOutputs(tx);
+        assertEquals(2, assetManagerOutputs.size());
+        TransactionOutput lenderOutput = assetManagerOutputs.stream()
+                .filter(o -> quantityOf(o, TOKEN_PRINCIPAL).signum() > 0)
+                .findFirst().orElseThrow(() -> new AssertionError("no output pays the principal token"));
+        assertEquals(expectedPayout, quantityOf(lenderOutput, TOKEN_PRINCIPAL),
+                "the lender must be paid EXACTLY the two-feed composition, not a one-feed shortcut");
+        assertEquals(0, lenderOutput.getValue().getMultiAssets().size() == 1
+                        ? 0 : lenderOutput.getValue().getMultiAssets().size() - 1,
+                "the lender output must carry exactly the principal token (plus its min-ada rider, "
+                        + "which is lovelace, not a second multi-asset entry)");
+
+        // WALL 3 — TWO distinct oracle withdrawals (collateral and principal are different oracle
+        // credentials here), and the principal oracle's own reference input is among the tx's.
+        String collateralOracleReward = oracle().rewardAddress();
+        String principalOracleReward = tokenPrincipalOracle().rewardAddress();
+        assertTrue(!collateralOracleReward.equals(principalOracleReward),
+                "fixture sanity: the two oracle legs must be distinct credentials for this to prove WALL 3");
+        List<Withdrawal> withdrawals = tx.getBody().getWithdrawals();
+        assertTrue(withdrawals.stream().anyMatch(w -> w.getRewardAddress().equals(collateralOracleReward)));
+        assertTrue(withdrawals.stream().anyMatch(w -> w.getRewardAddress().equals(principalOracleReward)),
+                "the principal oracle must get its OWN withdraw-0 invocation");
+        assertTrue(tx.getBody().getReferenceInputs().stream()
+                        .anyMatch(i -> i.getTransactionId().equals(TOKEN_PRINCIPAL_ORACLE_REF_INPUT.getTransactionId())
+                                && i.getIndex() == TOKEN_PRINCIPAL_ORACLE_REF_INPUT.getIndex()),
+                "the principal oracle's own reference input must be among the transaction's");
+
+        // WALL 3 — the redeemer's principalOracleRefInputIndex must be the REAL derived position of
+        // the principal oracle's reference input, never a hardcoded value: a hardcoded 0 would name
+        // whatever reference input happens to sort first, which is neither oracle here (config and
+        // lm-config sort ahead of both by TransactionInputComparator on this fixture's tx hashes).
+        String lmActionReward =
+                LoanFixtures.rewardAddress(REGISTRY.getLmLiquidateAndPayInAdvanceActionScriptHash());
+        ConstrPlutusData lmRedeemer = (ConstrPlutusData) rewardRedeemer(tx, lmActionReward).getData();
+        com.bloxbean.cardano.client.plutus.spec.ListPlutusData pairsListData =
+                (com.bloxbean.cardano.client.plutus.spec.ListPlutusData) lmRedeemer.getData().getPlutusDataList().get(3);
+        com.bloxbean.cardano.client.plutus.spec.ListPlutusData firstPair =
+                (com.bloxbean.cardano.client.plutus.spec.ListPlutusData) pairsListData.getPlutusDataList().get(0);
+        BigInteger encodedPrincipalOracleRefIndex =
+                ((com.bloxbean.cardano.client.plutus.spec.BigIntPlutusData) firstPair.getPlutusDataList().get(0))
+                        .getValue();
+        int actualPosition = tx.getBody().getReferenceInputs().indexOf(TOKEN_PRINCIPAL_ORACLE_REF_INPUT);
+        assertTrue(actualPosition >= 0, "the principal oracle reference input must be in the body");
+        assertEquals(BigInteger.valueOf(actualPosition), encodedPrincipalOracleRefIndex,
+                "the redeemer's principalOracleRefInputIndex must be the REAL sorted position (" + actualPosition
+                        + "), not hardcoded to 0 or any other fixed value");
     }
 
     // ======================================================================================
@@ -390,6 +563,18 @@ class PayInAdvanceLiquidationRouterTest {
                 .getPaymentCredentialHash().map(HexUtil::encodeHexString).orElse("");
     }
 
+    private static BigInteger quantityOf(TransactionOutput output, AssetType asset) {
+        if (output.getValue().getMultiAssets() == null) {
+            return BigInteger.ZERO;
+        }
+        return output.getValue().getMultiAssets().stream()
+                .filter(m -> m.getPolicyId().equalsIgnoreCase(asset.policyId()))
+                .flatMap(m -> m.getAssets().stream())
+                .filter(a -> HexUtil.encodeHexString(a.getNameAsBytes()).equalsIgnoreCase(asset.assetName()))
+                .map(com.bloxbean.cardano.client.transaction.spec.Asset::getValue)
+                .reduce(BigInteger.ZERO, BigInteger::add);
+    }
+
     // ======================================================================================
     // T-052 — the wallet input is selected to cover THIS liquidation's lender payout
     // ======================================================================================
@@ -408,7 +593,7 @@ class PayInAdvanceLiquidationRouterTest {
         List<BigInteger> asked = new ArrayList<>();
 
         Transaction tx = router().buildConvertLiquidation(assessment, loanUtxo(), bondUtxo(),
-                CONFIG_UTXO, LM_CONFIG_UTXO, oraclesByUnit(),
+                CONFIG_UTXO, LM_CONFIG_UTXO, oraclesByUnit(), AMPLE_BALANCE,
                 payout -> {
                     asked.add(payout);
                     return Optional.of(WALLET_UTXO);
@@ -443,7 +628,7 @@ class PayInAdvanceLiquidationRouterTest {
         PayInAdvanceLiquidationRouter.WalletInputTooSmallException refusal = assertThrows(
                 PayInAdvanceLiquidationRouter.WalletInputTooSmallException.class,
                 () -> router().buildConvertLiquidation(assessment, loanUtxo(), bondUtxo(),
-                        CONFIG_UTXO, LM_CONFIG_UTXO, oraclesByUnit(),
+                        CONFIG_UTXO, LM_CONFIG_UTXO, oraclesByUnit(), AMPLE_BALANCE,
                         payout -> Optional.empty(), NOW, VALID_TO_MILLIS));
 
         assertTrue(refusal.getMessage().contains("repays the lender"),
@@ -461,7 +646,7 @@ class PayInAdvanceLiquidationRouterTest {
         LiquidationAssessment assessment = convertAssessment(BigInteger.valueOf(EQUITY));
 
         Transaction tx = router().buildConvertLiquidation(assessment, loanUtxo(), bondUtxo(),
-                CONFIG_UTXO, LM_CONFIG_UTXO, oraclesByUnit(), anyWallet(), NOW, VALID_TO_MILLIS);
+                CONFIG_UTXO, LM_CONFIG_UTXO, oraclesByUnit(), AMPLE_BALANCE, anyWallet(), NOW, VALID_TO_MILLIS);
 
         assertTrue(tx.getBody().getInputs().stream()
                         .anyMatch(i -> i.getTransactionId().equals(WALLET_UTXO.getTxHash())

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/PayInAdvanceLiquidationRouterTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/PayInAdvanceLiquidationRouterTest.java
@@ -33,6 +33,7 @@ import java.util.function.Function;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -224,15 +225,57 @@ class PayInAdvanceLiquidationRouterTest {
     // (3) the clean refusals — never a crash, a quarantine or a transaction
     // ======================================================================================
 
-    /** A convert loan whose equity is not strictly positive is refused cleanly, before the builder runs. */
+    /**
+     * F0 (round 2) — EQUITY 0 IS THE VALIDATOR'S NORMAL CASE, NOT A REFUSAL. {@code
+     * loan_claim_action.ak:240-259} (deployed {@code ff005fb}) accepts {@code inputAction.equity == 0}
+     * outright and its {@code or { equity == 0, .. }} borrower-compensation gate (ak:273) never looks
+     * for a compensation output when it is zero. This is the underwater loan — the common
+     * liquidation, and the live USDM loan as of 2026-09-09 — so the seam must build it, not refuse it.
+     * <p>
+     * Mutant: restoring the old {@code equity.signum() <= 0} refusal makes this test fail (it would
+     * throw {@code PayInAdvanceNotModelledException} instead of returning a transaction).
+     */
     @Test
-    void nonPositiveEquityIsRefusedCleanly() {
-        LiquidationAssessment assessment = convertAssessment(BigInteger.ZERO);
+    void equityZeroIsTheValidatorsNormalCaseAndBuildsWithNoBorrowerCompensationOutput() {
+        // convertAssessment(ZERO) alone is NOT enough: the router recomputes equity fresh from the
+        // LOAN'S OWN datum + the real oracle feed (builder.numbers()), never from assessment.equity()
+        // (that field only gates the precondition). equityZeroLoanDatum() is tuned so the REAL
+        // computed equity lands on exactly zero against the frozen collateral amount and oracle price.
+        LiquidationAssessment assessment = convertAssessment(BigInteger.ZERO, equityZeroLoanDatum());
+
+        Transaction tx = router().buildConvertLiquidation(assessment, loanUtxo(), bondUtxo(),
+                CONFIG_UTXO, LM_CONFIG_UTXO, oraclesByUnit(), AMPLE_BALANCE, anyWallet(), NOW, VALID_TO_MILLIS);
+
+        // Exactly ONE asset-manager output at equity 0: the lender's paid-in-advance principal, and no
+        // borrower compensation output at all — loan_claim_action never reads one for this loan.
+        List<TransactionOutput> assetManagerOutputs = assetManagerOutputs(tx);
+        assertEquals(1, assetManagerOutputs.size(),
+                "at equity 0 the pay-in-advance layout emits ONLY the lender's converted output, no "
+                        + "borrower compensation");
+
+        // The bot keeps the WHOLE collateral share (collateralAmount - equity == collateralAmount at
+        // equity 0), so the ada dry-eval CBOR sha256 for the equity > 0 shape stays untouched — this is
+        // a genuinely separate code path, not a parameterisation of it.
+        String parentReward = LoanFixtures.rewardAddress(REGISTRY.getLenderManagerWithdrawScriptHash());
+        ConstrPlutusData parent = (ConstrPlutusData) rewardRedeemer(tx, parentReward).getData();
+        ConstrPlutusData action = (ConstrPlutusData) parent.getData().getPlutusDataList().get(1);
+        assertEquals(3, action.getAlternative(),
+                "the parent LenderManager must still carry LiquidateAndPayInAdvance (constructor index 3)");
+    }
+
+    /**
+     * Defence in depth only: {@code LoanFinance.redeemerEquity} floors a negative computed equity to
+     * ZERO, so this trigger is unreachable through a real assessment — but the seam still does not
+     * know how to model a genuinely negative equity, and the promoted builder still throws on one.
+     */
+    @Test
+    void aNegativeEquityIsRefusedCleanly() {
+        LiquidationAssessment assessment = convertAssessment(BigInteger.valueOf(-1));
         PayInAdvanceLiquidationRouter.PayInAdvanceNotModelledException refusal = assertThrows(
                 PayInAdvanceLiquidationRouter.PayInAdvanceNotModelledException.class,
                 () -> router().buildConvertLiquidation(assessment, loanUtxo(), bondUtxo(),
                         CONFIG_UTXO, LM_CONFIG_UTXO, oraclesByUnit(), AMPLE_BALANCE, anyWallet(), NOW, VALID_TO_MILLIS));
-        assertEquals("pay-in-advance not yet modelled for non-positive equity", refusal.getMessage());
+        assertEquals("pay-in-advance not yet modelled for a negative equity", refusal.getMessage());
     }
 
     /**
@@ -319,6 +362,109 @@ class PayInAdvanceLiquidationRouterTest {
         return byUnit;
     }
 
+    /**
+     * M9 (F4, round 2) — {@link #tokenPrincipalOracle()} with its window narrowed so it does NOT
+     * cover {@code VALID_TO_MILLIS}: {@code validTo == NOW + 10_000}, well short of {@code
+     * VALID_TO_MILLIS == NOW + 120_000}. Proves WALL 3's principal-feed window check
+     * (LiquidatePayInAdvanceTransactionBuilder.build(), mirroring the collateral leg's V3) is real —
+     * a mutant deleting that block would let this build succeed against a feed that has already
+     * expired by the time the transaction's own validity window ends.
+     */
+    private static OracleEntry tokenPrincipalOracleWithNarrowWindow() {
+        long narrowValidTo = NOW + 10_000L;
+        return LoanFixtures.charli3(TOKEN_PRINCIPAL, TOKEN_PRINCIPAL_ORACLE_NFT,
+                TOKEN_PRINCIPAL_ORACLE_CREDENTIAL,
+                OraclePriceFeed.priceDataCharlie(TOKEN_PRINCIPAL, BigInteger.ONE, BigInteger.ONE,
+                        FEED_VALID_FROM, narrowValidTo),
+                TOKEN_PRINCIPAL_ORACLE_REF_INPUT, TOKEN_PRINCIPAL_ORACLE_REF_SCRIPT,
+                TOKEN_PRINCIPAL_C3_PROVIDER);
+    }
+
+    private static Map<String, OracleEntry> oraclesByUnitWithNarrowWindowPrincipal() {
+        Map<String, OracleEntry> byUnit = new java.util.LinkedHashMap<>(oraclesByUnit());
+        OracleEntry principal = tokenPrincipalOracleWithNarrowWindow();
+        byUnit.put(principal.oracleToken().toUnit(), principal);
+        return byUnit;
+    }
+
+    /** M9 — the principal oracle's own window check, WALL 3's mirror of the collateral leg's V3. */
+    @Test
+    void aPrincipalOracleFeedThatDoesNotCoverTheTxWindowIsRefusedCleanly() {
+        LiquidationAssessment assessment = convertAssessment(BigInteger.valueOf(EQUITY), tokenPrincipalLoanDatum());
+
+        PayInAdvanceLiquidationRouter.PayInAdvanceNotModelledException refusal = assertThrows(
+                PayInAdvanceLiquidationRouter.PayInAdvanceNotModelledException.class,
+                () -> tokenPrincipalRouter().buildConvertLiquidation(assessment, loanUtxo(), bondUtxo(),
+                        CONFIG_UTXO, LM_CONFIG_UTXO, oraclesByUnitWithNarrowWindowPrincipal(),
+                        AMPLE_BALANCE, tokenWallet(), NOW, VALID_TO_MILLIS));
+        assertTrue(refusal.getMessage().contains("principal oracle feed window"), refusal.getMessage());
+    }
+
+    /**
+     * M19 (F4, round 2) — {@code assertStructure}'s WALL-4 check for a token principal must be
+     * {@code flatten == 2}, not weakened to {@code >= 1}. Every REAL build in this test class already
+     * produces flatten == 2 (min-ada top-up always adds a coin alongside the token), so the two
+     * comparisons are indistinguishable on any built body — a mutant weakening {@code ==2} to
+     * {@code >=1} passes every OTHER test in this file silently. This one hand-mutates the ALREADY
+     * BUILT, ALREADY-PROVEN-CORRECT body (stripping the lender output's own ada to zero, so flatten
+     * drops to 1) and re-invokes {@code assertStructure} directly — package-private for exactly this —
+     * proving the check is load-bearing rather than coincidentally always true.
+     */
+    @Test
+    void assertStructureRequiresFlattenExactlyTwoForATokenPrincipalLenderOutput() {
+        LoanDatum datum = tokenPrincipalLoanDatum();
+        LiquidationAssessment assessment = convertAssessment(BigInteger.valueOf(EQUITY), datum);
+        Transaction tx = tokenPrincipalRouter().buildConvertLiquidation(assessment, loanUtxo(), bondUtxo(),
+                CONFIG_UTXO, LM_CONFIG_UTXO, oraclesByUnitWithTokenPrincipal(), AMPLE_BALANCE, tokenWallet(),
+                NOW, VALID_TO_MILLIS);
+
+        LiquidatePayInAdvanceTransactionBuilder builder = new LiquidatePayInAdvanceTransactionBuilder(
+                REGISTRY, LoanFixtures.NETWORK, LoanFixtures.utxoSupplier(tokenPrincipalUniverse()),
+                EvalFixtures.protocolParams());
+        LiquidatePayInAdvanceTransactionBuilder.Numbers numbers = builder.numbers(loan(datum), bond(),
+                oracle(), tokenPrincipalOracle(), NOW);
+        LiquidatePayInAdvanceTransactionBuilder.Request request = new LiquidatePayInAdvanceTransactionBuilder.Request(
+                loan(datum), loanUtxo(), bond(), bondUtxo(), TOKEN_WALLET_UTXO, CONFIG_UTXO, LM_CONFIG_UTXO,
+                oracle(), tokenPrincipalOracle(), NOW, VALID_TO_MILLIS, 0L, 0L,
+                TOKEN_WALLET_UTXO.getAddress(), configuration().getReferenceScripts(), 30_000L);
+        long lenderBondOutputIndex = OutputLayout.CCL_PREPENDED_OUTPUTS;
+        long assetOutputIndex = numbers.equity().signum() > 0 ? 1L : 0L;
+
+        // Sanity: the REAL body passes as-is — this is what proves the mutation below is what flips it.
+        assertDoesNotThrow(() -> builder.assertStructure(tx, request, numbers, lenderBondOutputIndex, assetOutputIndex));
+
+        // Byte-surgery (officina CCL trap 4's discipline): strip the lender output's own ada to zero,
+        // so flatten drops from 2 to 1 — a shape that dosProtection's flatten == 2 must reject.
+        TransactionOutput lenderOutput = assetManagerOutputs(tx).get((int) assetOutputIndex);
+        lenderOutput.getValue().setCoin(BigInteger.ZERO);
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class,
+                () -> builder.assertStructure(tx, request, numbers, lenderBondOutputIndex, assetOutputIndex));
+        assertTrue(thrown.getMessage().contains("flatten == 2"), thrown.getMessage());
+    }
+
+    // ⛔ F3 (round 2) — A USDM+ADA WALLET UTXO, not an ada-only one.
+    //
+    // Before this fix the token-principal test funded its build from WALLET_UTXO — an ADA-ONLY 60 ADA
+    // utxo — even though this scenario's payout is denominated in TOKEN_PRINCIPAL. cardano-client-lib
+    // cannot conjure a token out of an ada-only input, so the balancer's change output for the wallet
+    // came back holding a NEGATIVE quantity of TOKEN_PRINCIPAL (measured: -29,109,347 on the real
+    // USDM audit) — an UNBALANCED transaction that this test never asserted balance on, so it passed
+    // anyway. This utxo carries both: ample TOKEN_PRINCIPAL to fund the lender's payout (~29.1M base
+    // units, per the pinned arithmetic below) and ample ada for the fee, the S-15 collateral rider and
+    // the lender output's own min-ada.
+    private static final String TX_TOKEN_WALLET = "e1".repeat(32);
+    private static final Utxo TOKEN_WALLET_UTXO = LoanFixtures.utxo(TX_TOKEN_WALLET, 0,
+            LoanFixtures.botAddress(), List.of(
+                    Amount.lovelace(BigInteger.valueOf(60_000_000L)),
+                    Amount.asset(LoanFixtures.unit(TOKEN_PRINCIPAL), BigInteger.valueOf(50_000_000L))),
+            null);
+
+    /** Supplies {@link #TOKEN_WALLET_UTXO} — the USDM+ada shape, for the token-principal test only. */
+    private static Function<BigInteger, Optional<Utxo>> tokenWallet() {
+        return payout -> Optional.of(TOKEN_WALLET_UTXO);
+    }
+
     private static AppConfig.LiquidationConfiguration configurationWithTokenMarket() {
         AppConfig.LiquidationConfiguration cfg = configuration();
         List<AppConfig.LiquidationConfiguration.Market> markets = new ArrayList<>(cfg.getMarkets());
@@ -327,19 +473,29 @@ class PayInAdvanceLiquidationRouterTest {
         return cfg;
     }
 
-    private static PayInAdvanceLiquidationRouter tokenPrincipalRouter() {
-        // Reads the reference inputs it needs from a universe that ALSO carries the synthetic
-        // principal oracle's three coordinates — the same additive pattern universe(fixture) uses
-        // for the collateral leg's oracle in the dry-eval rig.
+    /**
+     * The universe {@link #tokenPrincipalRouter()} builds against — carries the synthetic principal
+     * oracle's three coordinates (the same additive pattern {@code universe()} uses for the collateral
+     * leg's oracle in the dry-eval rig) and the USDM+ada wallet utxo (F3), alongside {@code
+     * WALLET_UTXO} (ada-only) so the balancer has a genuinely ada-only collateral candidate too —
+     * exactly the shape F8 documents as relied upon. Exposed (not inlined into the router factory) so
+     * {@link #assertBalanced} can resolve every spent input by the SAME set the router built against.
+     */
+    private static List<Utxo> tokenPrincipalUniverse() {
         List<Utxo> universeWithPrincipalOracle = new ArrayList<>(universe());
+        universeWithPrincipalOracle.add(TOKEN_WALLET_UTXO);
         universeWithPrincipalOracle.add(LoanFixtures.utxo(
                 TOKEN_PRINCIPAL_ORACLE_REF_INPUT.getTransactionId(), TOKEN_PRINCIPAL_ORACLE_REF_INPUT.getIndex(),
                 LoanFixtures.rewardAddress(TOKEN_PRINCIPAL_ORACLE_CREDENTIAL), List.of(
                         Amount.lovelace(BigInteger.valueOf(1_038_710L)),
                         Amount.asset(LoanFixtures.unit(TOKEN_PRINCIPAL_ORACLE_NFT), BigInteger.ONE)), null));
+        return universeWithPrincipalOracle;
+    }
+
+    private static PayInAdvanceLiquidationRouter tokenPrincipalRouter() {
         return new PayInAdvanceLiquidationRouter(REGISTRY, converters(), configurationWithTokenMarket(),
                 new LiquidatePayInAdvanceTransactionBuilder(REGISTRY, LoanFixtures.NETWORK,
-                        LoanFixtures.utxoSupplier(universeWithPrincipalOracle), EvalFixtures.protocolParams()));
+                        LoanFixtures.utxoSupplier(tokenPrincipalUniverse()), EvalFixtures.protocolParams()));
     }
 
     /**
@@ -355,9 +511,17 @@ class PayInAdvanceLiquidationRouterTest {
     void aTokenPrincipalLoanIsRoutedAndPaysTheLenderInTheTokenWithTheTwoFeedComposition() {
         LiquidationAssessment assessment = convertAssessment(BigInteger.valueOf(EQUITY), tokenPrincipalLoanDatum());
 
+        // F3 (round 2) — a USDM+ada wallet utxo, never the ada-only WALLET_UTXO/anyWallet() the OLD
+        // fixture used for a TOKEN-denominated payout (see TOKEN_WALLET_UTXO's own javadoc for the
+        // -29,109,347 USDM unbalanced-change bug this replaces).
         Transaction tx = tokenPrincipalRouter().buildConvertLiquidation(assessment, loanUtxo(),
                 bondUtxo(), CONFIG_UTXO, LM_CONFIG_UTXO, oraclesByUnitWithTokenPrincipal(),
-                AMPLE_BALANCE, anyWallet(), NOW, VALID_TO_MILLIS);
+                AMPLE_BALANCE, tokenWallet(), NOW, VALID_TO_MILLIS);
+
+        // F3 — BALANCE, on the built body: no negative quantity in any output, and inputs (+ mint)
+        // equal outputs (+ fee) for every asset unit. This is exactly the assertion the old fixture
+        // never made, and exactly what would have caught the unbalanced USDM change.
+        assertBalanced(tx, tokenPrincipalUniverse());
 
         BigInteger collateralLenderShouldReceive = BigInteger.valueOf(COLLATERAL_AMOUNT)
                 .subtract(BigInteger.valueOf(EQUITY)).subtract(BigInteger.valueOf(LIQUIDATION_FEE));
@@ -454,6 +618,29 @@ class PayInAdvanceLiquidationRouterTest {
                 ada.repaymentReceipts(), ada.originId(), ada.collateral());
     }
 
+    /**
+     * F0 (round 2) — the frozen loan's own datum, with ONLY {@code principalAmount}/{@code
+     * interestRate} tuned so the REAL computed equity (through {@code LoanFinance.redeemerEquity},
+     * against the FIXED {@code COLLATERAL_AMOUNT} and the FIXED oracle price {@code PRICE}) lands on
+     * EXACTLY zero. Collateral, oracle and bond are untouched, so this is genuinely the same shape as
+     * every other test in this class, just at the equity boundary loan_claim_action treats specially.
+     * <p>
+     * Arithmetic pinned by hand: collateralInLovelace = 100,000,000 · 338163/1,000,000 = 33,816,300;
+     * solving 33,816,300 - D - 0.05·D = 0 for the ada-denominated debt D gives D = 32,206,000 exactly
+     * (32,206,000 · 1.05 = 33,816,300). Zero interest and one installment make {@code
+     * PrincipalAndInterestOnInstallments}'s remainingDebt exactly {@code principalAmount}, so setting
+     * it to 32,206,000 is sufficient — lendDate/time do not enter this repayment mode's formula.
+     */
+    private static LoanDatum equityZeroLoanDatum() {
+        LoanDatum ada = loanDatum();
+        return new LoanDatum(ada.doneRecasts(), BigInteger.valueOf(32_206_000L), ada.lendDate(),
+                ada.repaidInstallments(), BigInteger.ZERO, ada.totalInstallments(), ada.principalAsset(),
+                ada.principalOracleAsset(), ada.installmentPeriod(), ada.initialGracePeriod(),
+                ada.liquidationMode(), ada.repaymentMode(), ada.repaymentTimeWindow(),
+                ada.penaltyFeeForLateRepayment(), ada.repaymentReceipts(), ada.originId(),
+                ada.collateral());
+    }
+
     private static LenderManagerDatum bondDatum() {
         return new LenderManagerDatumConverter().deserialize(BOND_DATUM_HEX);
     }
@@ -523,6 +710,77 @@ class PayInAdvanceLiquidationRouterTest {
                         Amount.asset(LoanFixtures.unit(C3_FEED_NFT), BigInteger.ONE)),
                 C3_PROVIDER_DATUM_HEX));
         return universe;
+    }
+
+    // ---- F3 (round 2) — balance, on the built body ------------------------------------------------
+
+    /**
+     * <b>No negative quantity in any output; inputs (+ mint) == outputs (+ fee), per asset unit.</b>
+     * The assertion the old token-principal fixture never made, and the one that would have caught its
+     * unbalanced USDM change (-29,109,347 on the real audit) — an ada-only wallet cannot fund a
+     * TOKEN-denominated payout, and cardano-client-lib does not refuse that at build time; it simply
+     * hands back a change output that owes more of the token than the wallet had.
+     * <p>
+     * Every spent {@code TransactionInput} is resolved against {@code universe} — the SAME set the
+     * router built against, deliberately, since cardano-client-lib's own coin selection can add MORE
+     * inputs than this builder's explicit {@code collectFrom} calls (e.g. an extra ada-only utxo picked
+     * during balancing) and a hardcoded input list would then diverge from what the body actually
+     * spent. A coordinate absent from {@code universe} is treated as a collateral-only reference
+     * (skipped) rather than failing the lookup — see {@code assertStructure}'s own S-15 discipline for
+     * why locating by identity rather than assuming is the discipline throughout this builder.
+     */
+    private static void assertBalanced(Transaction tx, List<Utxo> universe) {
+        Map<String, Utxo> byRef = new java.util.HashMap<>();
+        for (Utxo utxo : universe) {
+            byRef.put(utxo.getTxHash() + "#" + utxo.getOutputIndex(), utxo);
+        }
+        Map<String, BigInteger> supply = new java.util.HashMap<>();
+        for (TransactionInput input : tx.getBody().getInputs()) {
+            Utxo utxo = byRef.get(input.getTransactionId() + "#" + input.getIndex());
+            if (utxo == null) {
+                continue;
+            }
+            for (Amount amount : utxo.getAmount()) {
+                supply.merge(amount.getUnit(), amount.getQuantity(), BigInteger::add);
+            }
+        }
+        if (tx.getBody().getMint() != null) {
+            for (var multiAsset : tx.getBody().getMint()) {
+                for (var asset : multiAsset.getAssets()) {
+                    String unit = multiAsset.getPolicyId()
+                            + HexUtil.encodeHexString(asset.getNameAsBytes());
+                    supply.merge(unit, asset.getValue(), BigInteger::add);
+                }
+            }
+        }
+
+        Map<String, BigInteger> demand = new java.util.HashMap<>();
+        demand.merge(AssetType.LOVELACE, tx.getBody().getFee(), BigInteger::add);
+        for (TransactionOutput output : tx.getBody().getOutputs()) {
+            demand.merge(AssetType.LOVELACE, output.getValue().getCoin(), BigInteger::add);
+            assertTrue(output.getValue().getCoin().signum() >= 0,
+                    "an output holds negative ada: " + output.getValue().getCoin());
+            if (output.getValue().getMultiAssets() != null) {
+                for (var multiAsset : output.getValue().getMultiAssets()) {
+                    for (var asset : multiAsset.getAssets()) {
+                        String unit = multiAsset.getPolicyId()
+                                + HexUtil.encodeHexString(asset.getNameAsBytes());
+                        demand.merge(unit, asset.getValue(), BigInteger::add);
+                        assertTrue(asset.getValue().signum() >= 0,
+                                "an output holds a NEGATIVE quantity of " + unit + ": " + asset.getValue());
+                    }
+                }
+            }
+        }
+
+        // A unit that nets to exactly zero (e.g. the loan NFT: +1 spent, -1 minted/burned) is present
+        // in supply at 0 but absent from demand entirely — a missing key and a zero VALUE are not the
+        // same key set, so Map.equals would flag a false mismatch. Strip zero entries from both sides
+        // before comparing; a genuine imbalance never nets to exactly zero by accident.
+        supply.values().removeIf(v -> v.signum() == 0);
+        demand.values().removeIf(v -> v.signum() == 0);
+        assertEquals(supply, demand, "inputs (+ mint) must equal outputs (+ fee), per asset unit — an "
+                + "unbalanced body means a wallet utxo could not actually fund this transaction");
     }
 
     // ---- reading the built transaction back ------------------------------------------------------

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/PricingServiceTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/PricingServiceTest.java
@@ -1,0 +1,241 @@
+package com.fluidtokens.aquarium.offchain.service.loans;
+
+import com.fluidtokens.aquarium.offchain.model.AssetType;
+import com.fluidtokens.aquarium.offchain.model.loans.OraclePriceFeed;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link PricingService} — the one place a token quantity becomes lovelace, and it fails closed.
+ * <p>
+ * {@link StubOracleClient} is this codebase's established shape for testing against
+ * {@link FluidOracleClient} without the registry's JSON machinery (same pattern as
+ * {@code LiquidationSubmitVetoTest.FakeOracleClient}): it overrides the two public accessors
+ * {@code findFeed}/{@code findFeedIgnoringValidity} directly, so each test hands {@link PricingService}
+ * exactly the feed situation it wants to prove.
+ */
+class PricingServiceTest {
+
+    /** A test-only token — not a real mainnet asset, just something that is not ada. */
+    private static final AssetType TOKEN =
+            new AssetType("c0eaf6cea665d1b99647a9d24461984103de0492da93e7af29fe5d9", "5553444d");
+
+    private static final long AT_MILLIS = 1_700_000_000_000L;
+
+    /** Hands {@link PricingService} exactly the {@code findFeed}/{@code findFeedIgnoringValidity}
+     *  answers a test wants, bypassing the registry's JSON parsing entirely. */
+    private static final class StubOracleClient extends FluidOracleClient {
+        private OraclePriceFeed usable;
+        private OraclePriceFeed anyHeld;
+
+        StubOracleClient() {
+            super("http://unused.invalid");
+        }
+
+        @Override
+        public Optional<OraclePriceFeed> findFeed(AssetType asset, long atMillis) {
+            return Optional.ofNullable(usable);
+        }
+
+        @Override
+        public Optional<OraclePriceFeed> findFeedIgnoringValidity(AssetType asset) {
+            return Optional.ofNullable(anyHeld);
+        }
+    }
+
+    /** Always throws — proves a code path never touches the oracle at all. */
+    private static final class ThrowingOracleClient extends FluidOracleClient {
+        ThrowingOracleClient() {
+            super("http://unused.invalid");
+        }
+
+        @Override
+        public Optional<OraclePriceFeed> findFeed(AssetType asset, long atMillis) {
+            throw new AssertionError("must not consult the oracle for ada");
+        }
+
+        @Override
+        public Optional<OraclePriceFeed> findFeedIgnoringValidity(AssetType asset) {
+            throw new AssertionError("must not consult the oracle for ada");
+        }
+    }
+
+    // ---- ADA is the identity ------------------------------------------------------------------
+
+    @Test
+    void adaIsTheIdentityAndConsultsNoOracle() {
+        var service = new PricingService(new ThrowingOracleClient());
+
+        var priced = service.toLovelace(AssetType.ada(), BigInteger.valueOf(123_456_789L), AT_MILLIS);
+
+        assertTrue(priced.isPriced());
+        assertEquals(BigInteger.valueOf(123_456_789L), priced.lovelace(),
+                "ada must come back byte-for-byte the input amount");
+    }
+
+    // ---- correct pricing, arithmetic stated -----------------------------------------------------
+
+    /**
+     * 21,785,609 / 100,000,000 lovelace per base unit (live FLDT registry price, 2026-09-09) times
+     * 23,000,000,000 base units = 5,010,690,070 lovelace exactly (230 * 21,785,609, no remainder) —
+     * matching the value verified against live mainnet data.
+     */
+    @Test
+    void pricesAKnownTokenExactlyAgainstItsFeed() {
+        var client = new StubOracleClient();
+        client.usable = OraclePriceFeed.aggregated(TOKEN, BigInteger.valueOf(21_785_609L),
+                BigInteger.valueOf(100_000_000L), AT_MILLIS - 1_000, AT_MILLIS + 1_000);
+        var service = new PricingService(client);
+
+        var priced = service.toLovelace(TOKEN, BigInteger.valueOf(23_000_000_000L), AT_MILLIS);
+
+        assertTrue(priced.isPriced());
+        assertEquals(BigInteger.valueOf(5_010_690_070L), priced.lovelace());
+    }
+
+    /**
+     * ⛔ NO DECIMALS SCALING. 2 lovelace per base unit, 3 base units — the correct answer is 6, not
+     * 6,000,000 (a stray x1_000_000) and not 0 (a stray /1_000_000). A mutant introducing either
+     * multiplier dies here, cheaply and obviously.
+     */
+    @Test
+    void appliesNoDecimalsScaling() {
+        var client = new StubOracleClient();
+        client.usable = OraclePriceFeed.aggregated(TOKEN, BigInteger.TWO, BigInteger.ONE,
+                AT_MILLIS - 1_000, AT_MILLIS + 1_000);
+        var service = new PricingService(client);
+
+        var priced = service.toLovelace(TOKEN, BigInteger.valueOf(3L), AT_MILLIS);
+
+        assertTrue(priced.isPriced());
+        assertEquals(BigInteger.valueOf(6L), priced.lovelace());
+        assertNotEquals(BigInteger.valueOf(6_000_000L), priced.lovelace());
+        assertNotEquals(BigInteger.ZERO, priced.lovelace());
+    }
+
+    /**
+     * Rounds DOWN — the direction that does not flatter whatever profitability check reads the
+     * result. 10 base units at 1/3 lovelace each is 10/3 = 3.33…, floored to 3, never ceil'd to 4.
+     */
+    @Test
+    void roundsDown() {
+        var client = new StubOracleClient();
+        client.usable = OraclePriceFeed.aggregated(TOKEN, BigInteger.ONE, BigInteger.valueOf(3L),
+                AT_MILLIS - 1_000, AT_MILLIS + 1_000);
+        var service = new PricingService(client);
+
+        var priced = service.toLovelace(TOKEN, BigInteger.TEN, AT_MILLIS);
+
+        assertTrue(priced.isPriced());
+        assertEquals(BigInteger.valueOf(3L), priced.lovelace(), "10/3 must floor to 3, not ceil to 4");
+    }
+
+    // ---- fail-closed refusals, distinguishable from one another ---------------------------------
+
+    @Test
+    void aMissingFeedRefusesAsNoFeed() {
+        var client = new StubOracleClient();   // usable and anyHeld both left null
+        var service = new PricingService(client);
+
+        var priced = service.toLovelace(TOKEN, BigInteger.TEN, AT_MILLIS);
+
+        assertFalse(priced.isPriced());
+        assertNull(priced.lovelace(), "a refusal must never also carry a number");
+        assertEquals(PricingService.RefusalReason.NO_FEED, priced.refusal().reason());
+        assertEquals(TOKEN, priced.refusal().asset());
+        assertEquals(AT_MILLIS, priced.refusal().atMillis());
+        assertNull(priced.refusal().feedValidFrom(), "no feed means no window to report");
+        assertNull(priced.refusal().feedValidTo());
+        assertNull(priced.refusal().feedAgeMillis());
+    }
+
+    @Test
+    void aStaleFeedRefusesAsNotUsableAndCarriesItsWindowAndAge() {
+        var client = new StubOracleClient();
+        // usable left null: findFeed itself has already filtered this feed out as unusable.
+        client.anyHeld = OraclePriceFeed.aggregated(TOKEN, BigInteger.ONE, BigInteger.ONE,
+                1_000L, 2_000L);   // expired long before AT_MILLIS
+        var service = new PricingService(client);
+
+        var priced = service.toLovelace(TOKEN, BigInteger.TEN, AT_MILLIS);
+
+        assertFalse(priced.isPriced());
+        assertEquals(PricingService.RefusalReason.NOT_USABLE_AT_INSTANT, priced.refusal().reason());
+        assertEquals(1_000L, priced.refusal().feedValidFrom());
+        assertEquals(2_000L, priced.refusal().feedValidTo());
+        assertEquals(AT_MILLIS - 1_000L, priced.refusal().feedAgeMillis());
+    }
+
+    /** The missing and stale cases must be told apart — an operator's remedy differs for each. */
+    @Test
+    void aMissingFeedAndAStaleFeedAreDistinguishable() {
+        var missing = new PricingService(new StubOracleClient())
+                .toLovelace(TOKEN, BigInteger.TEN, AT_MILLIS);
+
+        var staleClient = new StubOracleClient();
+        staleClient.anyHeld = OraclePriceFeed.aggregated(TOKEN, BigInteger.ONE, BigInteger.ONE, 1_000L, 2_000L);
+        var stale = new PricingService(staleClient).toLovelace(TOKEN, BigInteger.TEN, AT_MILLIS);
+
+        assertNotEquals(missing.refusal().reason(), stale.refusal().reason());
+    }
+
+    /**
+     * ⛔ A POOLED feed must refuse by NAME rather than let {@code OraclePriceFeed.price()} escape as
+     * a generic exception — asserted by construction: {@code toLovelace} must not throw.
+     */
+    @Test
+    void aPooledFeedRefusesWithoutThrowing() {
+        var client = new StubOracleClient();
+        client.usable = new OraclePriceFeed(OraclePriceFeed.Variant.POOLED, TOKEN,
+                BigInteger.ONE, BigInteger.ONE, AT_MILLIS - 1_000, AT_MILLIS + 1_000);
+        var service = new PricingService(client);
+
+        var priced = assertDoesNotThrow(() -> service.toLovelace(TOKEN, BigInteger.TEN, AT_MILLIS));
+
+        assertFalse(priced.isPriced());
+        assertEquals(PricingService.RefusalReason.POOLED, priced.refusal().reason());
+    }
+
+    /** A pooled feed that is ALSO expired still reports POOLED — the more permanent, useful fact. */
+    @Test
+    void aPooledAndExpiredFeedStillReportsPooled() {
+        var client = new StubOracleClient();
+        client.anyHeld = new OraclePriceFeed(OraclePriceFeed.Variant.POOLED, TOKEN,
+                BigInteger.ONE, BigInteger.ONE, 1_000L, 2_000L);
+        var service = new PricingService(client);
+
+        var priced = assertDoesNotThrow(() -> service.toLovelace(TOKEN, BigInteger.TEN, AT_MILLIS));
+
+        assertFalse(priced.isPriced());
+        assertEquals(PricingService.RefusalReason.POOLED, priced.refusal().reason());
+    }
+
+    // ---- the fail-closed property itself, as its own mutant-killing assertion -------------------
+
+    /**
+     * ⛔ THE MUTANT THIS KILLS: a refusal path that falls through to returning the amount unchanged
+     * (a 1:1 assumption). Every refusal above already asserts {@code isPriced() == false}, but this
+     * test states the property on its own, once, unmissably: a refused {@link PricingService.Priced}
+     * NEVER carries a lovelace figure, whatever the amount asked for.
+     */
+    @Test
+    void aRefusalNeverCarriesAnAmountEvenWhenOneWouldLookPlausible() {
+        var client = new StubOracleClient();   // no feed at all
+        var service = new PricingService(client);
+
+        var priced = service.toLovelace(TOKEN, BigInteger.valueOf(999_999L), AT_MILLIS);
+
+        assertFalse(priced.isPriced());
+        assertNull(priced.lovelace(),
+                "a 1:1 fallback would return 999_999 here — fail-closed means it returns nothing");
+    }
+}

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/PricingServiceTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/PricingServiceTest.java
@@ -31,6 +31,26 @@ class PricingServiceTest {
 
     private static final long AT_MILLIS = 1_700_000_000_000L;
 
+    /**
+     * Overrides ONLY {@code findFeedIgnoringValidity}, so the REAL {@code findFeed} — and therefore
+     * the real {@code usableAt(atMillis)} window check — runs against the instant the service passes.
+     * The other stubs answer {@code findFeed} whatever the instant, which is exactly why a mutant
+     * pricing at {@code 0L} instead of {@code atMillis} survived the suite (slice-2 audit, M7).
+     */
+    private static final class WindowedOracleClient extends FluidOracleClient {
+        private final OraclePriceFeed held;
+
+        WindowedOracleClient(OraclePriceFeed held) {
+            super("http://unused.invalid");
+            this.held = held;
+        }
+
+        @Override
+        public Optional<OraclePriceFeed> findFeedIgnoringValidity(AssetType asset) {
+            return asset.isAda() ? Optional.of(OraclePriceFeed.unit()) : Optional.of(held);
+        }
+    }
+
     /** Hands {@link PricingService} exactly the {@code findFeed}/{@code findFeedIgnoringValidity}
      *  answers a test wants, bypassing the registry's JSON parsing entirely. */
     private static final class StubOracleClient extends FluidOracleClient {
@@ -237,5 +257,27 @@ class PricingServiceTest {
         assertFalse(priced.isPriced());
         assertNull(priced.lovelace(),
                 "a 1:1 fallback would return 999_999 here — fail-closed means it returns nothing");
+    }
+
+    /**
+     * ⛔ The INSTANT is part of the question. A feed valid only over a window must price inside it and
+     * refuse outside it — through the service's own call, with the real {@code findFeed} in play.
+     * Mutant: {@code oracleClient.findFeed(asset, 0L)} — pricing at a fixed instant instead of the
+     * one asked for — survived every other test here, because they stub {@code findFeed} to ignore
+     * its arguments. This one does not, so that mutant now refuses at 1_300_000 and dies.
+     */
+    @Test
+    void pricesAtTheInstantAskedNotAtSomeOtherInstant() {
+        OraclePriceFeed windowed = OraclePriceFeed.aggregated(TOKEN, BigInteger.TWO, BigInteger.ONE,
+                1_000_000L, 1_600_000L);
+        PricingService service = new PricingService(new WindowedOracleClient(windowed));
+
+        PricingService.Priced inside = service.toLovelace(TOKEN, BigInteger.valueOf(5L), 1_300_000L);
+        assertTrue(inside.isPriced(), "inside the feed's window the price must be available: " + inside);
+        assertEquals(BigInteger.TEN, inside.lovelace());
+
+        PricingService.Priced before = service.toLovelace(TOKEN, BigInteger.valueOf(5L), 0L);
+        assertFalse(before.isPriced(), "outside the window the same feed must refuse: " + before);
+        assertEquals(PricingService.RefusalReason.NOT_USABLE_AT_INSTANT, before.refusal().reason());
     }
 }

--- a/src/test/java/com/fluidtokens/aquarium/offchain/util/WalletInputSelectionTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/util/WalletInputSelectionTest.java
@@ -2,6 +2,7 @@ package com.fluidtokens.aquarium.offchain.util;
 
 import com.bloxbean.cardano.client.api.model.Amount;
 import com.bloxbean.cardano.client.api.model.Utxo;
+import com.fluidtokens.aquarium.offchain.model.AssetType;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
@@ -121,5 +122,89 @@ class WalletInputSelectionTest {
         String large = WalletInputSelection.smallestSufficient(wallet(), ada(45)).orElseThrow().getTxHash();
         assertFalse(small.equals(large),
                 "if the requirement does not change which utxo is chosen, it is not being applied");
+    }
+
+    // ---- token-principal nomination (Part 2, token-principals slice) -------------------------------
+
+    private static final AssetType USDM =
+            new AssetType("c48cbb3d000000000000000000000000000000000002da47ad", "0014df105553444d");
+
+    private static Utxo token(String hash, int ix, long usdmBaseUnits, long lovelace) {
+        Utxo utxo = new Utxo();
+        utxo.setTxHash(hash);
+        utxo.setOutputIndex(ix);
+        utxo.setAmount(List.of(Amount.lovelace(BigInteger.valueOf(lovelace)),
+                Amount.asset(USDM.policyId() + USDM.assetName(), BigInteger.valueOf(usdmBaseUnits))));
+        return utxo;
+    }
+
+    /**
+     * ⛔ THE FIXTURE GIOVANNI'S FUNDING TRANSACTION ACTUALLY PRODUCED — USDM sitting in a MULTI-ASSET
+     * UTxO alongside its min-ada. {@code nominable} (ada-only) filters this out by construction; a
+     * test built on a PURE-USDM UTxO (no such thing exists on a real ledger — every UTxO carries some
+     * ada) would pass today's bug and fail production. This is the positive control the contract
+     * names explicitly.
+     */
+    @Test
+    void aMultiAssetUsdmUtxoIsNominatedForATokenPrincipal() {
+        Utxo usdmAndAda = token("usdm1", 0, 1_100_000_000L, 1_400_000L);
+        List<Utxo> wallet = List.of(ada("plain", 0, 60_000_000L), usdmAndAda);
+
+        assertTrue(WalletInputSelection.nominableForToken(usdmAndAda, USDM),
+                "a token + min-ada utxo must be nominable for that token");
+        Optional<Utxo> chosen = WalletInputSelection.smallestSufficientToken(
+                wallet, USDM, BigInteger.valueOf(1_033_850_765L), BigInteger.valueOf(1_000_000L));
+        assertTrue(chosen.isPresent());
+        assertEquals("usdm1", chosen.get().getTxHash());
+    }
+
+    /**
+     * The ada-only rule is UNTOUCHED — a token-carrying utxo must never be selected by the plain
+     * ada-only path, exactly as {@link #ineligibleUtxosAreNotNominable} already pins. Restated here
+     * against a REAL token-and-min-ada shape (not a throwaway "policy"+"name" pair), so the two rules'
+     * independence is visible from this class alone.
+     */
+    @Test
+    void theMultiAssetUsdmUtxoIsNeverNominableOnThePlainAdaOnlyPath() {
+        Utxo usdmAndAda = token("usdm1", 0, 1_100_000_000L, 1_400_000L);
+        assertFalse(WalletInputSelection.nominable(usdmAndAda),
+                "the token rule is ADDITIVE — it must never loosen the ada-only rule");
+    }
+
+    /** A pure-ada wallet cannot fund a USDM payout, however large — nothing to nominate. */
+    @Test
+    void aPureAdaWalletIsRefusedForAUsdmPayout() {
+        List<Utxo> pureAda = List.of(ada("aa", 0, 5_000_000L), ada("bb", 1, 500_000_000L));
+        Optional<Utxo> chosen = WalletInputSelection.smallestSufficientToken(
+                pureAda, USDM, BigInteger.valueOf(1_033_850_765L), BigInteger.valueOf(1_000_000L));
+        assertTrue(chosen.isEmpty(), "a pure-ada wallet holds none of the principal token");
+        assertTrue(WalletInputSelection.largestNominableToken(pureAda, USDM).isEmpty());
+    }
+
+    /** The utxo must carry ADA alongside the token too — the fee ceiling and min-ada rider. */
+    @Test
+    void aTokenUtxoWithTooLittleAdaAlongsideItIsRefused() {
+        Utxo thinAda = token("thin", 0, 5_000_000_000L, 900_000L);
+        Optional<Utxo> chosen = WalletInputSelection.smallestSufficientToken(
+                List.of(thinAda), USDM, BigInteger.valueOf(1_033_850_765L), BigInteger.valueOf(1_000_000L));
+        assertTrue(chosen.isEmpty(), "1,000,000 required ada > 900,000 held, however much USDM sits alongside it");
+    }
+
+    /** Smallest-that-suffices applies to the PRINCIPAL quantity too, not just ada. */
+    @Test
+    void smallestSufficientTokenPicksTheSmallestTokenQuantityThatCoversTheRequirement() {
+        Utxo small = token("small", 0, 1_100_000_000L, 2_000_000L);
+        Utxo large = token("large", 0, 5_000_000_000L, 2_000_000L);
+        Optional<Utxo> chosen = WalletInputSelection.smallestSufficientToken(
+                List.of(large, small), USDM, BigInteger.valueOf(1_033_850_765L), BigInteger.valueOf(1_000_000L));
+        assertEquals("small", chosen.orElseThrow().getTxHash(),
+                "the smaller token-sufficient utxo must be preferred, leaving the larger for a candidate that needs it");
+    }
+
+    @Test
+    void tokenQuantityOfSumsMatchingUnitsAndIgnoresOthers() {
+        Utxo usdmAndAda = token("usdm1", 0, 1_100_000_000L, 1_400_000L);
+        assertEquals(BigInteger.valueOf(1_100_000_000L), WalletInputSelection.tokenQuantityOf(usdmAndAda, USDM));
+        assertEquals(BigInteger.ZERO, WalletInputSelection.tokenQuantityOf(ada("aa", 0, 5_000_000L), USDM));
     }
 }


### PR DESCRIPTION
Token principals: the economics can price them, and anticipate can pay them.

⛔ **Do not merge on my say-so — Giovanni's call.** Targets `main` (#22 was squash-merged as `6ad5e0f`); the commits are cherry-picks from the working branch `feat/lending-v4-token-principals`, which stays as it was and is **not** the branch to build from — this one is, once merged.

## Why now

Mainnet, 2026-09-09. Two of the seven live v4 loans carry a **USDM** principal. Giovanni configured the USDM market `ANTICIPATE` (cap 1,500,000,000) and funded the bot wallet with USDM. The bot then refused loan `279499ff…` every cycle — *"pay-in-advance not yet modelled for non-ada principal"* — and the USDM sat in the wallet, unreachable. The validators support token principals; our economics and our anticipate builder did not.

## What changed

**Slice 2 — `PricingService` (`8847579`, `ca61aa3`).** One place where a token quantity becomes lovelace, and it **fails closed**: no feed, feed not usable at the instant asked, or a pooled feed each come back as a *named* refusal carrying the asset, the instant, the feed window and its age. Never 1:1, never last-known. ADA is the identity and consults nothing. Wired into `CompoundEconomics`, which now prices a token fee slice instead of refusing it outright.

Two hazards the slice was built around, both measured:
- **No decimals scaling — ever.** The oracle price is lovelace *per base unit*; FLDT's registry price × 23,000,000,000 base units = 5,010.69 ADA, which is right. The registry's display-precision field belongs to the UI (FAB-76); applying it here would be a 10⁶ error that reads as correctness.
- **`OraclePriceFeed.price()` throws for a pooled feed.** Let escape, that becomes a generic exception — and on the convert path the generic handler quarantines for 30 minutes. It is now a named refusal; a test asserts no exception escapes.

⚠ **Compound economics for token principals: done. Compound builder: not yet — USDM escrows are still refused by the scanner.** `CompoundTransactionBuilder` still assumes an ada principal (`plusLovelace` applied to token counts, `:244-245`, `:362-363`, `:412`), so the scanner's non-ada gate was deliberately left in place; findings §58.1 records why. The builder is its own slice and its own PR (PR4, after this one and PR3), because it is where the bot starts being paid in the principal token — the inventory decision — and that must not ride on the anticipate PR. The live escrow `cea665d1…#0` (11,000,000 USDM) stays refused until then, for the honest reason.

**Slice 3 — anticipate for token principals (`6d8427f`, audited and fixed in `fbcf6b1`).** Four walls read from the validator and transcribed exactly: the lender payout is `ceil(fromLovelace(toLovelace(share, collateralFeed), principalFeed))` — one ceil at the end, `finance.ak:433-444` — where the old one-feed shortcut would have paid **4,789,432,923** USDM units for a true **1,033,850,765** (4.63×); the redeemer's equity uses the real principal feed; the principal oracle is a real, indexed reference input with its own withdraw-0 and window check; the lender output is paid in the principal asset with `flatten == 2`. The ADA path is byte-identical (CBOR sha256 unchanged). Around the walls: token-aware wallet selection (a USDM+min-ada UTxO — the shape a funding transfer actually produces — is now nominable; ada-only stays ada-only), a real `min(balance, cap)` in `MarketGate` (it had been a comment), the announce line naming asset and amount, and an economics gate that values what the bot **acquires** against what it **pays** — at today's figures the bot buys ~23,000 FLDT at a ~3.6% edge, which is a trade, not a fee.

**And the finding the live rig produced:** "positive equity" was *our* precondition, not the validator's. `loan_claim_action.ak:240-259` accepts `equity == 0` as its normal case — the underwater loan, which is what a liquidation candidate usually is. The plain builder already handled it; the anticipate path refused it, and the live USDM loan crossed to zero equity this evening. Lifted in `fbcf6b1`, mirroring the plain builder. **The round-2 fixes also found a production bug no unit test could:** `cycle()` threaded the ada-only-filtered wallet list into `nominate()` and the token balance sum, so every multi-asset UTxO was discarded before the token path saw it — a USDM-funded bot could never have fired. Found by the fully-wired executor scenario the audit demanded; fixed in `fbcf6b1`.

**And the last wall, found by Giovanni's own node (`1c50725` + the audit's follow-up `d553371`, FAB-83):** the first-ever pay-in-advance build on mainnet died with a bare `NullPointerException` — this builder had only ever run on preview, where every oracle feed is Charli3; mainnet's feeds are **multisig**, with no provider reference input, and `List.of(…, null)` throws. Behind it, the oracle redeemer was encoded in the Charli3 shape — provider index, empty signature list — which cannot serve a multisig feed at all; the converter's own variant check would have refused it at build time (so the failure class was loud, not phase 2), but the leg could never have *worked*. The convert builder's comment had predicted exactly this about its sibling. Now the encoding is chosen per feed variant on both legs, mirroring the convert builder, which is the only builder that had ever built on mainnet.

**Live-mainnet dry-eval against the real USDM loan and Giovanni's real wallet, read-only, no key, no submit — 2026-09-10 07:52Z, 3/3:** the candidate builds and **every redeemer is costed by the UPLC evaluator** (six withdrawals; the FLDT and USDM oracle credentials distinct, so the principal leg's own withdraw-0 ran against the deployed validators); the lender output carries the payout in USDM with `flatten == 2`; and **`payout − 1` is refused by a real script denial** — `RedeemerError { tag: "Withdraw", index: 4, err: Machine(EvaluationFailure, ExBudget { mem: 1121388, cpu: 420739863 }, []) }`. Live figures: payout 1,029,537,903 USDM units, fee 1,020,074 lovelace, 2,466 bytes. What this does not prove is phase 1 (fees, min-ada, witnesses, collateral) — CCL trap 11 — which the node's own SHADOW cycle proves before anything is submitted.

## Tests

**Audited three times on this branch** (slices 2, 3 and FAB-83-1; one REJECT round on slice 3, one Ticket-Owner regression fix, one MEDIUM follow-up after the FAB-83-1 approval — a `usableForLiquidation()` re-check before shipping a signed feed's signatures, `d553371`). **And rehearsed on Giovanni's own mainnet node in SHADOW** (2026-09-10 08:18Z, every cycle since): `WOULD_SUBMIT`, 2,466 bytes, fee 1,020,074, lender paid 1,030,877,143 USDM, total collateral 1,530,111 (150 % exact) with a collateral return protecting the USDM — phase 1 proven on the operator's wallet, which the offline rig cannot do.


**135 files, 1052 tests, 0 failures, 45 skipped** (the live-rig tests skip without a mainnet read key), measured from the XML and orphan-checked both directions. Every guard added here carries a test that fails when it is removed and one that fails when it is disconnected; every new assertion was mutation-checked in an isolated copy, with the mutant → test mapping in the commit messages and audit reports. Slice 2's audit ran ten mutants; the one that survived — pricing at a fixed instant instead of the one asked for — is what `ca61aa3` pins.

## Known limitations, stated rather than discovered later

- Compound builder for token principals: **not yet** (PR4). `PRICE_UNAVAILABLE` exists in the compound enum but is unreachable from the live cycle until it lands.
- The anticipate path nominates ONE wallet input that must carry both the principal and the ada for fee + rider; a USDM UTxO holding only its min-ada is refused by name ("no utxo carries ≥ X USDM alongside ≥ Y lovelace"). Fund the bot with USDM and ADA in the same output. The rider requirement covers the lender's rider only and relies on the balancer's extra-input selection for the collateral rider and change — logged when the wallet lacks headroom.
- The convert path still treats clean verdicts as machinery faults (30-minute quarantine on a `RefusedException` or a Blockfrost transient) and does not size its wallet input — scoped as PR3, deliberately separate.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AvYgGDeXA4iMw1MqHcMRt
