### PR TITLE
The convert route stops treating verdicts as faults, and refuses orders the pool cannot fill

### DIFF
--- a/src/main/java/com/fluidtokens/aquarium/offchain/model/loans/MinswapPoolDatum.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/model/loans/MinswapPoolDatum.java
@@ -5,25 +5,52 @@ import com.fluidtokens.aquarium.offchain.model.AssetType;
 import java.math.BigInteger;
 
 /**
- * Minswap V2's {@code PoolDatum}, reduced to what {@code lm_liquidate_and_convert_action} reads.
+ * Minswap V2's {@code PoolDatum}, reduced to what {@code lm_liquidate_and_convert_action} and the
+ * bot's own pre-trade quote read.
  *
  * <p>⚠ <b>The field order is the chain's, not a reading of a library we vendor</b> — the
  * {@code amm_dex_v2} package is an Aiken dependency and is absent from the upstream clone, so this was
  * decoded from the live ADA/FLDT pool on mainnet and cross-checked against Minswap's own declaration
- * (findings §32.3, §34). Ten fields; the four after {@link #reserveB} are read by Minswap's own
- * validators and not by ours, so they are kept only to prove the arity.
+ * (findings §32.3, §34). Ten fields on chain; this record carries eight of them, and the arity check in
+ * {@code MinswapPoolDatumConverter} is what keeps the positions honest.
  *
- * @param assetA   the pool's {@code asset_a} — <b>not</b> sorted by us; the pool declares the order
- * @param assetB   the pool's {@code asset_b}
- * @param reserveA current reserve of {@link #assetA}
- * @param reserveB current reserve of {@link #assetB}
+ * <h2>⛔ The two fee numerators are the pool's OWN price, and no constant substitutes for them</h2>
+ * Measured live on mainnet 2026-09-10 (height 13,922,040): the ADA/FLDT pool declares
+ * {@code base_fee_a = base_fee_b = 80} and the FLDT/USDM pool {@code = 70}. <b>Two pools, two different
+ * fees</b> — so a hardcoded numerator is wrong for at least one of them however it is calibrated, and
+ * the 24/10000 and 30/10000 figures the DEX literature quotes are wrong for both. Against the real
+ * mainnet batch {@code 5f0572b2…} the datum's 80 reproduces the payout to within 272 lovelace on
+ * 18,565,738 (−0.0015 %, the safe direction) where 24 and 30 over-quote by +0.56 % and +0.50 %.
+ * Over-quoting is the direction that matters: it lets a futile order through to be built, submitted and
+ * refunded at the operator's expense.
+ *
+ * @param assetA             the pool's {@code asset_a} — <b>not</b> sorted by us; the pool declares the order
+ * @param assetB             the pool's {@code asset_b}
+ * @param reserveA           current reserve of {@link #assetA}
+ * @param reserveB           current reserve of {@link #assetB}
+ * @param baseFeeANumerator  {@code base_fee_a_numerator}, parts of {@code 10000}, charged on the INPUT
+ *                           when selling {@link #assetA} for {@link #assetB} ({@code aToB})
+ * @param baseFeeBNumerator  {@code base_fee_b_numerator}, the same for the {@code bToA} direction. ⚠ It
+ *                           is a SEPARATE field and equal to {@link #baseFeeANumerator} on both live
+ *                           mainnet pools today — which is exactly why a direction mix-up here would be
+ *                           invisible on the pools the tests use, and why the quote is tested against a
+ *                           fixture with UNEQUAL numerators.
+ * @param allowDynamicFee    {@code allow_dynamic_fee}. When true the base numerators are not the whole
+ *                           fee, so a quote built from them would understate the cost; the convert plan
+ *                           refuses such a pool by name rather than quoting it.
  */
 public record MinswapPoolDatum(AssetType assetA,
                                AssetType assetB,
                                BigInteger totalLiquidity,
                                BigInteger reserveA,
-                               BigInteger reserveB) {
+                               BigInteger reserveB,
+                               BigInteger baseFeeANumerator,
+                               BigInteger baseFeeBNumerator,
+                               boolean allowDynamicFee) {
 
     /** Number of fields in the on-chain constructor; a mismatch means Minswap changed the type. */
     public static final int FIELD_COUNT = 10;
+
+    /** Minswap's fee denominator: both base numerators are parts of ten thousand. */
+    public static final BigInteger FEE_DENOMINATOR = BigInteger.valueOf(10_000L);
 }

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/ConvertLiquidationRouter.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/ConvertLiquidationRouter.java
@@ -27,6 +27,8 @@ import com.fluidtokens.aquarium.offchain.model.loans.OraclePriceFeed;
 import com.fluidtokens.aquarium.offchain.model.loans.Rational;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * Routes one convert-eligible candidate to {@link ConvertTransactionBuilder}, or refuses it cleanly.
@@ -64,6 +66,20 @@ public class ConvertLiquidationRouter {
 
         public ConvertAssessment assessment() {
             return assessment;
+        }
+    }
+
+    /**
+     * No single nominable wallet UTxO covers what this order takes from the bot's own wallet.
+     *
+     * <p>⚠ A fact about the WALLET, not about the candidate — the operator can top it up between
+     * cycles, so it is reported and reconsidered rather than held. Mirrors
+     * {@code PayInAdvanceLiquidationRouter.WalletInputTooSmallException}, which is the sibling that
+     * already had a sized nomination.
+     */
+    public static final class WalletInputTooSmallException extends RuntimeException {
+        public WalletInputTooSmallException(String message) {
+            super(message);
         }
     }
 
@@ -306,7 +322,7 @@ public class ConvertLiquidationRouter {
                                                Utxo bondUtxo,
                                                Utxo configUtxo,
                                                Utxo lmConfigUtxo,
-                                               Utxo walletUtxo,
+                                               Function<BigInteger, Optional<Utxo>> walletSelector,
                                                Map<String, OracleEntry> oraclesByOracleTokenUnit,
                                                String changeAddress,
                                                long validFromMillis,
@@ -397,6 +413,37 @@ public class ConvertLiquidationRouter {
                 assessment.bond().datum().lenderAuth(),
                 ConvertTxEncoder.plainScriptAddress(registry.getAssetManagerSpendScriptHash()),
                 loanUtxo.getTxHash(), loanUtxo.getOutputIndex());
+
+        // ⛔ NOMINATE THE WALLET INPUT AGAINST WHAT THE ORDER ACTUALLY TAKES — sized, not "the first one".
+        //
+        // This used to be the executor's `nominableWalletUtxos(walletUtxos).get(0)`: the first
+        // NOMINABLE utxo, whatever its size. Two things were wrong with it. It funded an order whose
+        // ada requirement it never consulted — `orderLovelace` is the Minswap overhead alone for a
+        // token collateral but the whole swappable amount PLUS the overhead for an ada one, which can
+        // be arbitrarily large. And an unsized `get(0)` over a list is one list-semantics change away
+        // from selecting a published REFERENCE SCRIPT (CCL trap 9b/26a — this exact line already
+        // survived that once, when fbcf6b1 widened `walletUtxos` to the raw listing).
+        //
+        // ⚑ The selector is the sibling's shape (`PayInAdvanceLiquidationRouter`): the ROUTER knows
+        // what the order costs, the EXECUTOR knows the wallet and the fee ceiling, and neither has to
+        // learn the other's job. The selection it performs is nominable-filtered at source
+        // (`WalletInputSelection.smallestSufficient`), so the reference-script hazard is closed
+        // structurally rather than by this call site remembering to filter.
+        //
+        // ⚠ `plan.orderLovelace()` and not a re-derivation: the plan already computed it from the
+        // validator's own rule, and a second derivation here could disagree with the one the order is
+        // actually built from — the figures on this path are taken at the BODY's validFrom, not the
+        // assessment's, which is precisely how such a pair drifts apart.
+        Utxo walletUtxo = walletSelector.apply(plan.orderLovelace())
+                .orElseThrow(() -> new WalletInputTooSmallException(
+                        ("no nominable wallet utxo can fund this convert: the Minswap order carries %s "
+                                + "lovelace (%s), and no single ada-only utxo with no datum and no "
+                                + "reference script covers that plus the fee ceiling. Fund the wallet "
+                                + "with one such utxo of at least that amount plus fee headroom.")
+                                .formatted(plan.orderLovelace(),
+                                        collateral.isAda()
+                                                ? "the swappable ada plus the order overhead"
+                                                : "the order overhead; the collateral is a token")));
 
         ClaimData claim = new ClaimData((LiquidationMode.Liquidation) loan.liquidationMode(),
                 BigInteger.ZERO, BigInteger.ZERO, BigInteger.ZERO,

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/ConvertOrderPlan.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/ConvertOrderPlan.java
@@ -55,7 +55,24 @@ public record ConvertOrderPlan(boolean aToBDirection,
          * {@code collateral − equity − liquidationFee} is not positive, so there is nothing to swap.
          * Minswap would reject a zero-amount order and the validator's value check could not hold.
          */
-        NOTHING_LEFT_TO_SWAP
+        NOTHING_LEFT_TO_SWAP,
+        /**
+         * The pool sets {@code allow_dynamic_fee}, so its two base numerators are not the whole fee and
+         * a quote built from them would UNDERSTATE the cost — the direction that lets a futile order
+         * through. Refused rather than quoted at a price the pool does not charge.
+         */
+        POOL_HAS_DYNAMIC_FEE,
+        /**
+         * The pool cannot deliver the debt. {@code minimum_receive} is {@code remainingDebt} and the
+         * validator fixes it, so an order this pool cannot fill does not fill BADLY — it is batched,
+         * refunded, and the operator pays the batcher fee and the transaction fee for nothing
+         * (findings §25.2). Measured on the live FLDT/USDM pool 2026-09-09: 22,003,200,000 FLDT in
+         * would have returned ~824 M USDM against a 980,001,429 requirement, a 155 M shortfall.
+         *
+         * <p>⚠ This is arithmetic on the pool's own declared reserves and fee, not a policy or a
+         * slippage model — there is no knob, and there is nothing for an operator to tune.
+         */
+        POOL_TOO_THIN
     }
 
     /** Thrown rather than returned: a caller that ignored a refusal would build an invalid order. */
@@ -136,6 +153,42 @@ public record ConvertOrderPlan(boolean aToBDirection,
                             .formatted(collateralAmount, equity, liquidationFee, swappable));
         }
 
+        // ⛔ QUOTE THE SWAP BEFORE ANYTHING IS BUILT — a thin pool REFUNDS, it does not fill badly.
+        //
+        // `minimum_receive` is `remainingDebt` and the validator fixes it, so there is no price at
+        // which a pool too shallow to deliver the debt produces a partial fill: Minswap batches the
+        // order, fails the minimum, and returns the collateral. The bot pays the transaction fee and
+        // the batcher fee for a no-op, and the loan is still liquidatable next cycle — so the same
+        // futile order is built again, every cycle, until the pool moves. Refusing here costs nothing
+        // and is reproducible; the alternative is billed to the operator.
+        //
+        // ⚠ The fee is the POOL's, read from its own datum, and it is direction-dependent. No constant
+        // works: the two live mainnet pools declare 80 and 70, and both differ from the 24/10000 and
+        // 30/10000 the DEX literature quotes. Over-quoting is the failure that matters — it is what
+        // lets the futile order through — and a constant over-quotes the real batch by ~0.5%.
+        if (pool.allowDynamicFee()) {
+            throw new RefusedException(Refusal.POOL_HAS_DYNAMIC_FEE,
+                    ("pool %s/%s sets allow_dynamic_fee, so its base numerators (a %s, b %s) are not "
+                            + "the whole fee; refusing to quote a price the pool does not charge")
+                            .formatted(pool.assetA().toUnit(), pool.assetB().toUnit(),
+                                    pool.baseFeeANumerator(), pool.baseFeeBNumerator()));
+        }
+        BigInteger reserveIn = aToB ? pool.reserveA() : pool.reserveB();
+        BigInteger reserveOut = aToB ? pool.reserveB() : pool.reserveA();
+        BigInteger feeNumerator = feeNumeratorFor(pool, aToB);
+        BigInteger quotedOut = constantProductOut(swappable, reserveIn, reserveOut, feeNumerator);
+        if (quotedOut.compareTo(remainingDebt) < 0) {
+            throw new RefusedException(Refusal.POOL_TOO_THIN,
+                    ("swapping %s %s would return about %s %s, but minimum_receive is the debt, %s — "
+                            + "a shortfall of %s. The order would be batched and REFUNDED, at the "
+                            + "operator's expense. Pool reserves %s in / %s out, fee %s/%s (%s)")
+                            .formatted(swappable, collateral.toUnit(), quotedOut,
+                                    principal.toUnit(), remainingDebt,
+                                    remainingDebt.subtract(quotedOut), reserveIn, reserveOut,
+                                    feeNumerator, MinswapPoolDatum.FEE_DENOMINATOR,
+                                    aToB ? "base_fee_a, aToB" : "base_fee_b, bToA"));
+        }
+
         // The lp asset name is computed from the POOL's declared order, not from ours: the pair is
         // the same set either way, and the hash is not.
         String lpAssetName = ConvertTxEncoder.computeLpAssetName(pool.assetA(), pool.assetB());
@@ -159,5 +212,44 @@ public record ConvertOrderPlan(boolean aToBDirection,
 
         return new ConvertOrderPlan(aToB, lpAssetName, liquidationFee, swappable, orderLovelace,
                 remainingDebt, successDatum, refundDatum, successHash, refundHash, order);
+    }
+
+    /**
+     * The pool's fee numerator <b>for this swap's direction</b>: {@code aToB} sells {@code asset_a} and
+     * pays {@code base_fee_a_numerator} on the input, {@code bToA} pays {@code base_fee_b_numerator}.
+     *
+     * <p>⚠ <b>They are equal on both live mainnet pools</b> (ADA/FLDT 80/80, FLDT/USDM 70/70, measured
+     * 2026-09-10) — <b>which is precisely why picking the wrong one would be invisible</b> on every pool
+     * this node actually trades against, and why the test for this uses a fixture with UNEQUAL
+     * numerators. A direction bug here does not fail; it quotes a price at the other side's fee.
+     */
+    static BigInteger feeNumeratorFor(MinswapPoolDatum pool, boolean aToB) {
+        return aToB ? pool.baseFeeANumerator() : pool.baseFeeBNumerator();
+    }
+
+    /**
+     * Minswap V2's constant-product output, fee taken on the INPUT — the same arithmetic its batcher
+     * runs, so this answers "what would this order actually receive" rather than "what would be fair".
+     *
+     * <pre>
+     * effectiveIn = amountIn × (10000 − feeNumerator)
+     * out         = reserveOut × effectiveIn ÷ (reserveIn × 10000 + effectiveIn)
+     * </pre>
+     *
+     * <p>⛔ <b>Integer division truncates DOWNWARD, and that is the direction to keep.</b> The quote is
+     * a pre-check that refuses; under-stating the output can only make it refuse an order that would
+     * marginally have filled, while over-stating lets one through to be batched and refunded at the
+     * operator's expense. Calibrated against the real mainnet batch {@code 5f0572b2…} (2026-09-08):
+     * 86,279,718 FLDT against reserves 1,667,895,724,071 / 7,689,154,296,039 at the datum's fee of 80
+     * quotes <b>18,565,466</b> where the batch paid <b>18,565,738</b> — 272 lovelace under, on the safe
+     * side. The residual is consistent with that batch carrying several orders, so the pool input it
+     * settled against predates them all.
+     */
+    static BigInteger constantProductOut(BigInteger amountIn, BigInteger reserveIn,
+                                         BigInteger reserveOut, BigInteger feeNumerator) {
+        BigInteger effectiveIn = amountIn.multiply(
+                MinswapPoolDatum.FEE_DENOMINATOR.subtract(feeNumerator));
+        return reserveOut.multiply(effectiveIn)
+                .divide(reserveIn.multiply(MinswapPoolDatum.FEE_DENOMINATOR).add(effectiveIn));
     }
 }

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutor.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutor.java
@@ -2450,16 +2450,6 @@ public class LiquidationExecutor {
     }
 
     /**
-     * Quarantines one <b>loan UTxO ref</b> — {@code txHash#index}, never a loan id. The distinction
-     * is load-bearing: a loan id outlives the UTxO that carries it (it is minted once and burned at
-     * the end), so keying on it would exclude a borrower's loan across every re-creation of its
-     * UTxO, while keying on the ref means a quarantine dies naturally the moment the output is
-     * spent by anyone.
-     * <p>
-     * Package-private so the eviction and expiry rules can be driven directly from a test; nothing
-     * outside this package quarantines anything.
-     */
-    /**
      * How many scheduling cycles a TRANSPORT failure on the Minswap pool lookup is held for.
      *
      * <p>⛔ <b>Neither of the other two holds, deliberately.</b> A {@code LOOKUP_FAILED} is not a
@@ -2474,6 +2464,16 @@ public class LiquidationExecutor {
      */
     private static final long LOOKUP_FAILED_HOLD_CYCLES = 2L;
 
+    /**
+     * Quarantines one <b>loan UTxO ref</b> — {@code txHash#index}, never a loan id. The distinction
+     * is load-bearing: a loan id outlives the UTxO that carries it (it is minted once and burned at
+     * the end), so keying on it would exclude a borrower's loan across every re-creation of its
+     * UTxO, while keying on the ref means a quarantine dies naturally the moment the output is
+     * spent by anyone.
+     * <p>
+     * Package-private so the eviction and expiry rules can be driven directly from a test; nothing
+     * outside this package quarantines anything.
+     */
     void quarantineUntil(String loanUtxoRef, long until) {
         if (quarantine.size() >= MAX_QUARANTINED && !quarantine.containsKey(loanUtxoRef)) {
             List<Map.Entry<String, Long>> soonest = new ArrayList<>(quarantine.entrySet());

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutor.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutor.java
@@ -948,17 +948,26 @@ public class LiquidationExecutor {
                 try {
                     transaction = convertRouter.buildConvertLiquidation(assessment, loanUtxo.get(),
                             bondUtxo.get(), configUtxo, lmConfigUtxo,
-                            // ⛔ NOMINABLE, not raw. Round 2 of the token-principals slice (fbcf6b1)
-                            // made `walletUtxos` the UNFILTERED listing so the token path could see
-                            // multi-asset utxos — and this line, unchanged, silently went from "first
-                            // ada-only utxo" to "first utxo Blockfrost returns": the OLDEST one at the
-                            // bot's address, which is where the published reference scripts sit. A
-                            // convert would have SPENT the loan_claim_action reference script (the
-                            // 2026-08-24 incident class WalletInputSelection.nominable exists to
-                            // prevent). Sizing this input properly is PR3's job; until then it is the
-                            // first NOMINABLE utxo, exactly what it was before fbcf6b1.
-                            nominableWalletUtxos(walletUtxos).isEmpty()
-                                    ? null : nominableWalletUtxos(walletUtxos).get(0),
+                            // ⛔ SIZED, via the sibling's selector shape — PR3's job, now done.
+                            //
+                            // This was `nominableWalletUtxos(walletUtxos).get(0)`: the first nominable
+                            // utxo, whatever its size, funding an order whose ada requirement it never
+                            // consulted. Two defects in one line. It could under-fund an ADA-collateral
+                            // convert, whose order carries the whole swappable amount plus the Minswap
+                            // overhead rather than the overhead alone. And an unsized `get(0)` over a
+                            // list is one list-semantics change away from selecting a published
+                            // REFERENCE SCRIPT — which this exact line already survived once, when
+                            // fbcf6b1 widened `walletUtxos` to the raw Blockfrost listing and turned
+                            // "first ada-only utxo" into "oldest utxo at the address" (CCL trap
+                            // 9b/26a, the 2026-08-24 incident class).
+                            //
+                            // The router now asks for what the order actually costs and this supplies
+                            // the SMALLEST nominable utxo covering that plus the fee ceiling —
+                            // `nominate()`'s ada-only branch, which filters to nominable at source. The
+                            // reference-script hazard is closed structurally, not by this call site
+                            // remembering to filter.
+                            orderLovelace -> nominate(walletUtxos, feeCeiling, null, orderLovelace,
+                                    loanUtxoRef),
                             oraclesByUnit,
                             account.baseAddress(), validFromMillis, validToMillis);
                 } catch (ConvertLiquidationRouter.NoPoolException e) {
@@ -974,7 +983,80 @@ public class LiquidationExecutor {
                     log.info("the convert liquidation of {} is not worth doing: {}", loanUtxoRef,
                             e.getMessage());
                     return;
+                } catch (ConvertOrderPlan.RefusedException e) {
+                    // ⛔ A VERDICT ABOUT THE CANDIDATE, NOT A FAULT — so it is recorded and NOT held.
+                    //
+                    // The five ConvertOrderPlan refusals (the bond forbids conversion, equity is in the
+                    // principal currency, the pool is for a different pair, nothing is left to swap,
+                    // the pool is too thin) are all statements about this loan against this pool. Each
+                    // is reproducible next cycle, each costs one plan and no transaction, and none of
+                    // them is evidence that anything is broken. Quarantining them for thirty minutes
+                    // would suppress a candidate that a single Minswap swap can make viable again.
+                    //
+                    // ⚑ This is the plain path's RefusedException treatment, arrived at for the same
+                    // reason: before this catch existed EVERY one of these fell to the generic branch
+                    // below and was recorded as machinery failure at ERROR.
+                    decisionLog.record(decision(assessment, now, LiquidationDecision.Outcome.REFUSED,
+                            e.refusal().name(), e.getMessage()));
+                    log.info("the convert liquidation of {} was refused as {}: {}",
+                            loanUtxoRef, e.refusal(), e.getMessage());
+                    return;
+                } catch (MinswapPoolResolver.RefusedException e) {
+                    // ⛔ THE POOL LOOKUP REFUSED — and WHICH refusal decides whether this is a verdict
+                    // or a transport problem. They are not the same fact and must not share a hold.
+                    //
+                    // Measured on mainnet 2026-09-09: ONE Blockfrost hiccup on the pool lookup put a
+                    // live loan into the 30-minute machinery quarantine — 39 QUARANTINED records on
+                    // loan 279499ff, from a single transport error. A provider that cannot be reached
+                    // says NOTHING about the candidate; holding it as though the bot were broken is
+                    // how one bad second becomes half an hour of not liquidating.
+                    if (e.refusal() == MinswapPoolResolver.Refusal.LOOKUP_FAILED) {
+                        // ⚠ A SHORT hold, and it is deliberately neither of the other two.
+                        //   · the verdict path holds NOTHING — but a candidate retried every cycle
+                        //     against a provider that is down is exactly what the quarantine is for;
+                        //   · the machinery path holds THIRTY MINUTES — far too long for a transient
+                        //     that typically clears within one cycle.
+                        // Two cycles is enough for a blip to pass and short enough that a recovered
+                        // provider is noticed almost immediately. It is a code constant with its reason
+                        // beside it, not a knob: an operator asked to tune this would be being asked to
+                        // guess how long their provider stays down.
+                        long holdMillis = LOOKUP_FAILED_HOLD_CYCLES * configuration.getDelaySeconds()
+                                * 1000L;
+                        quarantineUntil(loanUtxoRef, now + holdMillis);
+                        decisionLog.record(decision(assessment, now,
+                                LiquidationDecision.Outcome.REFUSED, e.refusal().name(),
+                                e.getMessage() + " \u21d2 held for " + LOOKUP_FAILED_HOLD_CYCLES
+                                        + " cycles (" + holdMillis / 1000L + "s). This is a TRANSPORT "
+                                        + "failure, not a verdict: it says nothing about whether a "
+                                        + "pool exists, which is what NO_MINSWAP_POOL reports."));
+                        log.warn("the pool lookup for {} failed in transport ({}); held for {} cycles "
+                                        + "({}s) rather than the {}-minute machinery quarantine — the "
+                                        + "candidate itself was never assessed",
+                                loanUtxoRef, e.getMessage(), LOOKUP_FAILED_HOLD_CYCLES,
+                                holdMillis / 1000L, configuration.getQuarantineMinutes());
+                        return;
+                    }
+                    // AMBIGUOUS_POOL and POOL_DATUM_UNREADABLE are facts about the CHAIN, reproducible
+                    // next cycle and unaffected by waiting — a verdict, held no longer than any other.
+                    decisionLog.record(decision(assessment, now, LiquidationDecision.Outcome.REFUSED,
+                            e.refusal().name(), e.getMessage()));
+                    log.info("the convert liquidation of {} was refused as {}: {}",
+                            loanUtxoRef, e.refusal(), e.getMessage());
+                    return;
+                } catch (ConvertLiquidationRouter.WalletInputTooSmallException e) {
+                    // A fact about the WALLET, not the candidate — and the operator can top it up
+                    // between cycles, so holding it would keep refusing a convert that had become
+                    // fundable. Same treatment the pay-in-advance path already gives its own.
+                    decisionLog.record(decision(assessment, now, LiquidationDecision.Outcome.REFUSED,
+                            "WALLET_INPUT_TOO_SMALL", e.getMessage()));
+                    log.warn("the convert liquidation of {} was refused: {}", loanUtxoRef,
+                            e.getMessage());
+                    return;
                 } catch (Exception e) {
+                    // ⚠ WHAT IS LEFT HERE IS A GENUINE MACHINERY FAULT, and that is the point of the
+                    // four catches above: this branch used to swallow every verdict on the convert
+                    // route as well, so "the pool cannot fill the debt" and "the bot is broken" reached
+                    // the operator identically, both at ERROR, both held for thirty minutes.
                     quarantineUntil(loanUtxoRef, now + configuration.getQuarantineMinutes() * 60_000L);
                     decisionLog.record(decision(assessment, now, LiquidationDecision.Outcome.REFUSED,
                             rootReason(e), causeChain(e)));
@@ -2377,6 +2459,21 @@ public class LiquidationExecutor {
      * Package-private so the eviction and expiry rules can be driven directly from a test; nothing
      * outside this package quarantines anything.
      */
+    /**
+     * How many scheduling cycles a TRANSPORT failure on the Minswap pool lookup is held for.
+     *
+     * <p>⛔ <b>Neither of the other two holds, deliberately.</b> A {@code LOOKUP_FAILED} is not a
+     * verdict (those are recorded and reconsidered immediately) and not a machinery fault (those get
+     * {@code quarantine-minutes}, thirty by default). Measured on mainnet 2026-09-09: one Blockfrost
+     * hiccup on the pool lookup produced <b>39 {@code QUARANTINED} records</b> on a single live loan,
+     * because a transport error was being priced as though the bot were broken.
+     *
+     * <p>⚠ A code constant and not a configuration key: the hold exists so a candidate does not retry
+     * every cycle against a provider that is down, and an operator asked to tune it would be being
+     * asked to guess how long their own provider stays down.
+     */
+    private static final long LOOKUP_FAILED_HOLD_CYCLES = 2L;
+
     void quarantineUntil(String loanUtxoRef, long until) {
         if (quarantine.size() >= MAX_QUARANTINED && !quarantine.containsKey(loanUtxoRef)) {
             List<Map.Entry<String, Long>> soonest = new ArrayList<>(quarantine.entrySet());

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/MinswapPoolDatumConverter.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/MinswapPoolDatumConverter.java
@@ -27,6 +27,16 @@ import java.util.List;
  * <p>⚠ <b>The arity check is the load-bearing part.</b> Every field this converter reads is at a fixed
  * position, so a Minswap type change that inserted a field would otherwise be read as a pool with
  * different assets — a well-formed order for the wrong pair.
+ *
+ * <p>⛔ <b>Indices 6, 7 and 9 are the pool's own fee, and they are read HERE or nowhere.</b> They used
+ * to be decoded away, which left the convert quote with no honest fee to use — and the only way to
+ * reach them from elsewhere would be a second positional decoder over the same ten-field type, outside
+ * this arity guard. Two decoders of one positional type is how a field insertion gets caught in one
+ * place and silently mis-read in the other, so the fee is modelled here instead.
+ *
+ * <p>Index 8 ({@code fee_sharing_numerator_opt}) is deliberately left undecoded: it splits the fee
+ * between Minswap and a fee recipient <em>after</em> the swap arithmetic and does not change the output
+ * a swap produces, which is the only thing this node quotes. It is still COUNTED by the arity check.
  */
 public class MinswapPoolDatumConverter {
 
@@ -62,7 +72,11 @@ public class MinswapPoolDatumConverter {
                 asset(f.get(2)),
                 integer(f.get(3)),
                 integer(f.get(4)),
-                integer(f.get(5)));
+                integer(f.get(5)),
+                integer(f.get(6)),
+                integer(f.get(7)),
+                // index 8 is fee_sharing_numerator_opt — counted by the arity check, not read
+                bool(f.get(9)));
     }
 
     /** {@code Asset { policy_id, asset_name }} — constructor 0. ADA is the empty/empty pair. */
@@ -81,5 +95,18 @@ public class MinswapPoolDatumConverter {
             throw new CborRuntimeException("expected an Int, got " + d);
         }
         return i.getValue();
+    }
+
+    /**
+     * Aiken's {@code Bool}: {@code False} is constructor 0 and {@code True} constructor 1, both
+     * fieldless. Refused rather than defaulted — {@code allow_dynamic_fee} decides whether this pool's
+     * base numerators are the whole fee, so guessing it wrong quotes a price the pool does not charge.
+     */
+    private static boolean bool(PlutusData d) {
+        if (!(d instanceof ConstrPlutusData c) || !c.getData().getPlutusDataList().isEmpty()
+                || (c.getAlternative() != 0 && c.getAlternative() != 1)) {
+            throw new CborRuntimeException("expected a Bool constructor (0 or 1, fieldless), got " + d);
+        }
+        return c.getAlternative() == 1;
     }
 }

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/ConvertLiquidationRouterTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/ConvertLiquidationRouterTest.java
@@ -1,0 +1,196 @@
+package com.fluidtokens.aquarium.offchain.service.loans;
+
+import com.bloxbean.cardano.client.api.model.Utxo;
+import com.fluidtokens.aquarium.offchain.config.AppConfig;
+import com.fluidtokens.aquarium.offchain.model.AssetType;
+import com.fluidtokens.aquarium.offchain.model.loans.CollateralAsset;
+import com.fluidtokens.aquarium.offchain.model.loans.LenderBond;
+import com.fluidtokens.aquarium.offchain.model.loans.LiquidationAssessment;
+import com.fluidtokens.aquarium.offchain.model.loans.LiquidationMode;
+import com.fluidtokens.aquarium.offchain.model.loans.Loan;
+import com.fluidtokens.aquarium.offchain.model.loans.LoanDatum;
+import com.fluidtokens.aquarium.offchain.model.loans.MinswapPoolDatum;
+import com.fluidtokens.aquarium.offchain.model.loans.OracleEntry;
+import com.fluidtokens.aquarium.offchain.model.loans.OraclePriceFeed;
+import com.fluidtokens.aquarium.offchain.model.loans.RepaymentMode;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * ⛔ <b>The convert router's WALLET NOMINATION seam, driven at the router rather than through a fake.</b>
+ *
+ * <p>Audit finding F1: {@code WalletInputTooSmallException} was a decorative guard. The executor's
+ * catch for it was pinned by nothing (mutant M12 — neuter the catch so it falls to the 30-minute
+ * machinery quarantine — killed <b>0 of 1062</b> tests), and the THROW site was unreachable from the
+ * suite entirely, because this class did not exist and every executor test injects a fake router.
+ *
+ * <p>⚠ <b>A fake router cannot pin the router's own behaviour.</b> That is the whole reason this class
+ * is here and not another case in {@code LiquidationExecutorTest}: the executor tests prove what the
+ * executor does WITH the exception, and only a real {@link ConvertLiquidationRouter} proves that the
+ * exception is ever raised. Both halves are needed, and neither substitutes for the other.
+ */
+class ConvertLiquidationRouterTest {
+
+    private static final AssetType FLDT = new AssetType(
+            "577f0b1342f8f8f4aed3388b80a8535812950c7a892495c0ecdf0f1e", "0014df10464c4454");
+    private static final String MINSWAP_POOL_POLICY =
+            "f5808c2c990d86da54bfc97d89cee6efa20cd8461616359478d96b4c";
+
+    /** The live ADA/FLDT pool's shape: deep enough that {@code POOL_TOO_THIN} cannot be the refusal. */
+    private static MinswapPoolDatum deepPool() {
+        return new MinswapPoolDatum(AssetType.ada(), FLDT, BigInteger.TEN,
+                new BigInteger("1692342884761"), new BigInteger("7596442927398"),
+                BigInteger.valueOf(80L), BigInteger.valueOf(80L), false);
+    }
+
+    /**
+     * A resolver that answers with a pool without touching a provider — the {@code UtxoService} is
+     * {@code null}, so any real lookup would NPE and the test would say so.
+     */
+    private static final class FixedPoolResolver extends MinswapPoolResolver {
+        FixedPoolResolver() {
+            super(null, "addr_pool", MINSWAP_POOL_POLICY);
+        }
+
+        @Override
+        public Optional<ResolvedPool> resolveEitherOrder(AssetType one, AssetType other) {
+            Utxo poolUtxo = Utxo.builder().txHash("dd".repeat(32)).outputIndex(0)
+                    .address("addr_pool").build();
+            return Optional.of(new ResolvedPool(poolUtxo, deepPool(), "lp"));
+        }
+    }
+
+    /**
+     * ⚠ {@code AppConfig.LoansConfiguration} is {@code @Getter}-only — its fields are written by
+     * {@code @Value} in production and by nothing else — so the configured shape is expressed by
+     * overriding the getters rather than by adding setters to a production class this slice must not
+     * touch.
+     */
+    private static AppConfig.LoansConfiguration configuredForMinswap() {
+        return new AppConfig.LoansConfiguration() {
+            @Override
+            public String getMinswapPoolAddress() {
+                return "addr_pool";
+            }
+
+            @Override
+            public String getMinswapPoolPolicyId() {
+                return MINSWAP_POOL_POLICY;
+            }
+
+            @Override
+            public String getMinswapOrderSpendScriptHash() {
+                return "cc".repeat(28);
+            }
+        };
+    }
+
+    private static ConvertLiquidationRouter router() {
+        AppConfig.LoansConfiguration loans = configuredForMinswap();
+        return new ConvertLiquidationRouter(LoanFixtures.registry(), loans, null,
+                new FixedPoolResolver(), null, null, LoanFixtures.converters(), LoanFixtures.NETWORK);
+    }
+
+    /** An FLDT-collateral, ada-principal convert candidate — the shape the live mainnet loan has. */
+    private static LiquidationAssessment candidate() {
+        LoanDatum datum = LoanFixtures.loanDatum(
+                AssetType.ada(), BigInteger.valueOf(20_000_000L), BigInteger.valueOf(100L),
+                new CollateralAsset(FLDT.policyId(),
+                        Optional.of(FLDT.assetName()), LoanFixtures.NO_ORACLE),
+                1_700_000_000_000L,
+                new LiquidationMode.Liquidation(BigInteger.valueOf(500L), BigInteger.valueOf(1000L),
+                        BigInteger.ZERO, false),
+                new RepaymentMode.InterestOnRemainingPrincipal(BigInteger.ZERO), false);
+        Loan loan = new Loan("aa".repeat(32), 0, "addr_loan", "cafe",
+                BigInteger.valueOf(100_000_000L), BigInteger.valueOf(3_000_000L), datum);
+        LenderBond bond = new LenderBond("bb".repeat(32), 0, "addr_bond", "cafe", "d87980",
+                LoanFixtures.convertToPrincipalBondDatum(BigInteger.valueOf(50L),
+                        LoanFixtures.noStakeCredential(), AssetType.ada()));
+        return LiquidationAssessment.buildable(bond, loan, "convert fixture",
+                BigInteger.valueOf(20_000_000L), BigInteger.ZERO, false, BigInteger.valueOf(5_000_000L));
+    }
+
+    /**
+     * The collateral leg's feed. ⚠ It is REQUIRED, not optional: {@code LoanFinance.redeemerEquity}
+     * values the collateral through it, so a null here is an NPE rather than a degraded path — which
+     * is what a first draft of this test discovered.
+     */
+    private static Map<String, OracleEntry> collateralOracle() {
+        // ⚠ Priced BELOW the pool (0.15 vs the pool's ~0.2228 lovelace per FLDT unit) on purpose: the
+        // loan is then underwater, equity floors to zero, and the whole collateral less the
+        // liquidation fee is swappable — which is the shape a real liquidatable candidate has by the
+        // time it is liquidatable (CCL trap 20e). Priced AT the pool the fixture is marginal and the
+        // POOL_TOO_THIN pre-check fires first, masking the seam this class exists to test.
+        OraclePriceFeed feed = new OraclePriceFeed(OraclePriceFeed.Variant.AGGREGATED, FLDT,
+                BigInteger.valueOf(15_000_000L), BigInteger.valueOf(100_000_000L),
+                1_759_000_000_000L, 1_799_000_000_000L);
+        return Map.of(LoanFixtures.NO_ORACLE.toUnit(),
+                LoanFixtures.multisig(FLDT, LoanFixtures.NO_ORACLE, "dd".repeat(28), feed,
+                        null, null, java.util.List.of()));
+    }
+
+    private static Utxo loanUtxo() {
+        return Utxo.builder().txHash("aa".repeat(32)).outputIndex(0).address("addr_loan").build();
+    }
+
+    /**
+     * ⛔ <b>THE THROW SITE, and the requirement it must state.</b> When no single nominable wallet UTxO
+     * covers what the order takes, the router refuses BY NAME rather than handing the builder a null
+     * (which would surface as a bare {@code NullPointerException} through the executor's generic catch
+     * and be quarantined for thirty minutes as a machinery fault).
+     *
+     * <p>⚠ The selector returning {@code Optional.empty()} is the ONLY thing this fixture makes go
+     * wrong — the pool is deep, the bond permits conversion and the plan is computable — so the
+     * exception cannot be arriving for another reason.
+     *
+     * <p>Mutant M12 (neuter the executor's catch) is killed by the executor-side pair of this test;
+     * removing this throw and passing {@code null} through is killed HERE.
+     */
+    @Test
+    void aWalletWithNoSufficientUtxoIsRefusedByNameAndSaysWhatTheOrderNeeded() {
+        var e = assertThrows(ConvertLiquidationRouter.WalletInputTooSmallException.class,
+                () -> router().buildConvertLiquidation(candidate(), loanUtxo(), null, null, null,
+                        requirement -> Optional.empty(),
+                        collateralOracle(), "addr_change",
+                        1_760_000_000_000L, 1_760_000_120_000L));
+
+        assertTrue(e.getMessage().contains("4000000"),
+                "the operator must be told WHAT the order needed — the Minswap order overhead for a "
+                        + "token collateral: " + e.getMessage());
+        assertTrue(e.getMessage().contains("no nominable wallet utxo"),
+                "and that the shortfall is the wallet's, not the candidate's: " + e.getMessage());
+        assertTrue(e.getMessage().contains("reference script"),
+                "the remedy must name what makes a utxo nominable, which is the trap operators hit: "
+                        + e.getMessage());
+    }
+
+    /**
+     * ⚑ And the requirement handed to the selector is the ORDER's own figure, not a guess: for a TOKEN
+     * collateral it is exactly {@code MINSWAP_ORDER_OVERHEAD}. Captured off the real call so that a
+     * change to what the router asks for cannot pass unnoticed.
+     */
+    @Test
+    void theSelectorIsAskedForExactlyWhatTheOrderCarries() {
+        BigInteger[] asked = new BigInteger[1];
+
+        assertThrows(ConvertLiquidationRouter.WalletInputTooSmallException.class,
+                () -> router().buildConvertLiquidation(candidate(), loanUtxo(), null, null, null,
+                        requirement -> {
+                            asked[0] = requirement;
+                            return Optional.empty();
+                        },
+                        collateralOracle(), "addr_change",
+                        1_760_000_000_000L, 1_760_000_120_000L));
+
+        assertEquals(ConvertEconomics.MINSWAP_ORDER_OVERHEAD, asked[0],
+                "a token-collateral order carries the Minswap overhead and nothing else; the wallet "
+                        + "nomination must be sized to that, not to list position");
+    }
+}

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/ConvertOrderPlanTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/ConvertOrderPlanTest.java
@@ -131,6 +131,129 @@ class ConvertOrderPlanTest {
                 "the refusal must name the arity it saw and the one it expected: " + e.getMessage());
     }
 
+    /**
+     * ⛔ <b>F3 — THE FEE INDICES ARE NOT INTERCHANGEABLE, and only UNEQUAL numerators can say so.</b>
+     *
+     * <p>Round-1 audit: mutant M16 (swap the converter's index 6 and index 7 reads) killed <b>0 of
+     * 1062</b> tests, because the only converter-level fee assertion used the live fixture — where
+     * both numerators are 80. r2's own reasoning ("a direction bug is invisible on the pools the tests
+     * use") had been applied at {@code feeNumeratorFor} and not at the DECODE layer, one call earlier.
+     *
+     * <p>⚠ 80 and 70 are the two real mainnet fees, so this fixture is the two live pools' numerators
+     * put on ONE pool — the smallest change that makes the positions distinguishable.
+     */
+    @Test
+    void theTwoFeeNumeratorsAreDecodedIntoTheirOwnComponentsAndNotSwapped() {
+        MinswapPoolDatum decoded = new MinswapPoolDatumConverter().fromPlutusData(
+                poolDatum(BigIntPlutusData.of(80), BigIntPlutusData.of(70), bool(false)));
+
+        assertEquals(FEE_80, decoded.baseFeeANumerator(),
+                "on-chain index 6 is base_fee_a_numerator and must land in baseFeeANumerator");
+        assertEquals(FEE_70, decoded.baseFeeBNumerator(),
+                "on-chain index 7 is base_fee_b_numerator; swapping the two reads is invisible on "
+                        + "every live pool, because both real pools declare equal numerators");
+    }
+
+    /**
+     * ⛔ <b>F2 — THE {@code allow_dynamic_fee} DECODE MUST BE ABLE TO SAY TRUE.</b>
+     *
+     * <p>Round-1 audit: mutants M15/M19 ({@code bool()} stuck at {@code false}, or validating nothing)
+     * killed <b>0 of 1062</b>. The only assertion on this field used the live fixture and read
+     * {@code assertFalse(...)} — green whether the decoder works or is nailed shut — and the refusal
+     * test constructed the record directly, never touching the converter. <b>No path under test
+     * produced {@code true} from the decoder.</b>
+     *
+     * <p>The failure that leaves open: Minswap enables dynamic fees, the decoder reports false, the
+     * quote understates the fee and OVERSTATES the output, {@code POOL_TOO_THIN} does not fire, and
+     * the order is built, submitted and refunded at the operator's expense.
+     */
+    @Test
+    void aPoolThatSetsAllowDynamicFeeDecodesAsTrue() {
+        MinswapPoolDatum decoded = new MinswapPoolDatumConverter().fromPlutusData(
+                poolDatum(BigIntPlutusData.of(80), BigIntPlutusData.of(80), bool(true)));
+
+        assertTrue(decoded.allowDynamicFee(),
+                "constructor 1 at on-chain index 9 is True; a decoder that can only answer false "
+                        + "silently quotes a price the pool does not charge");
+
+        // …and the plan refuses it, so the decode is connected to the guard rather than merely correct.
+        var e = assertThrows(ConvertOrderPlan.RefusedException.class, () -> planAgainst(decoded));
+        assertEquals(ConvertOrderPlan.Refusal.POOL_HAS_DYNAMIC_FEE, e.refusal());
+    }
+
+    /**
+     * A {@code Bool} is constructor 0 or 1 and fieldless. Anything else is refused rather than
+     * defaulted — {@code allow_dynamic_fee} decides whether the base numerators are the whole fee, so
+     * a decoder that guesses it is a decoder that quotes a price nobody charges.
+     */
+    @Test
+    void aMalformedBoolAtTheDynamicFeeIndexIsRefusedRatherThanDefaulted() {
+        PlutusData constructorTwo = ConstrPlutusData.builder().alternative(2)
+                .data(com.bloxbean.cardano.client.plutus.spec.ListPlutusData.of()).build();
+        var e = assertThrows(RuntimeException.class,
+                () -> new MinswapPoolDatumConverter().fromPlutusData(
+                        poolDatum(BigIntPlutusData.of(80), BigIntPlutusData.of(80), constructorTwo)));
+        assertTrue(e.getMessage().contains("Bool"),
+                "the refusal must name what it expected: " + e.getMessage());
+
+        // A Bool constructor that CARRIES a field is the other malformation, and it is not the same
+        // mistake: the alternative is in range, so only the field check refuses it.
+        PlutusData trueWithAField = ConstrPlutusData.builder().alternative(1)
+                .data(com.bloxbean.cardano.client.plutus.spec.ListPlutusData.of(
+                        BigIntPlutusData.of(1))).build();
+        assertTrue(assertThrows(RuntimeException.class,
+                        () -> new MinswapPoolDatumConverter().fromPlutusData(
+                                poolDatum(BigIntPlutusData.of(80), BigIntPlutusData.of(80),
+                                        trueWithAField)))
+                .getMessage().contains("Bool"));
+    }
+
+    /**
+     * R2 — the arity guard's other side. A datum one field SHORT must refuse by name, not by an
+     * index-out-of-bounds from whichever read runs off the end.
+     */
+    @Test
+    void aPoolDatumWithONEFEWERFieldIsRefusedByTheArityGuard() {
+        var nineFields = ConstrPlutusData.builder().alternative(0)
+                .data(com.bloxbean.cardano.client.plutus.spec.ListPlutusData.of(
+                        BigIntPlutusData.of(0), asset("cc".repeat(28), "beef"),
+                        asset("dd".repeat(28), "cafe"), BigIntPlutusData.of(1),
+                        BigIntPlutusData.of(2), BigIntPlutusData.of(3), BigIntPlutusData.of(80),
+                        BigIntPlutusData.of(80), bool(false)))       // NINE fields
+                .build();
+
+        var e = assertThrows(RuntimeException.class,
+                () -> new MinswapPoolDatumConverter().fromPlutusData(nineFields));
+        assertTrue(e.getMessage().contains("9") && e.getMessage().contains("10"),
+                "the refusal must name the arity it saw and the one it expected: " + e.getMessage());
+    }
+
+    /**
+     * A well-formed ten-field Minswap {@code PoolDatum} with the fee fields under test at on-chain
+     * indices 6, 7 and 9. Index 8 (fee sharing) is present because the arity guard counts it.
+     */
+    private static ConstrPlutusData poolDatum(PlutusData feeA, PlutusData feeB, PlutusData dynamicFee) {
+        return ConstrPlutusData.builder().alternative(0)
+                .data(com.bloxbean.cardano.client.plutus.spec.ListPlutusData.of(
+                        BigIntPlutusData.of(0),                    // 0 pool_batching_stake_credential
+                        asset("", ""),                             // 1 asset_a — ADA
+                        asset(FLDT.policyId(), FLDT.assetName()),  // 2 asset_b
+                        BigIntPlutusData.of(1),                    // 3 total_liquidity
+                        BigIntPlutusData.of(2),                    // 4 reserve_a
+                        BigIntPlutusData.of(3),                    // 5 reserve_b
+                        feeA,                                      // 6 base_fee_a_numerator
+                        feeB,                                      // 7 base_fee_b_numerator
+                        BigIntPlutusData.of(1666),                 // 8 fee_sharing_numerator_opt
+                        dynamicFee))                               // 9 allow_dynamic_fee
+                .build();
+    }
+
+    /** Aiken's {@code Bool}: False is constructor 0, True is constructor 1, both fieldless. */
+    private static PlutusData bool(boolean value) {
+        return ConstrPlutusData.builder().alternative(value ? 1 : 0)
+                .data(com.bloxbean.cardano.client.plutus.spec.ListPlutusData.of()).build();
+    }
+
     private static PlutusData asset(String policyHex, String nameHex) {
         return ConstrPlutusData.builder().alternative(0)
                 .data(com.bloxbean.cardano.client.plutus.spec.ListPlutusData.of(
@@ -290,10 +413,17 @@ class ConvertOrderPlanTest {
      * have filled), quoting MORE is the failure this whole pre-check exists to prevent — it lets a
      * futile order through to be built, submitted and refunded at the operator's expense.
      *
-     * <p>⚠ <b>And this is the test that forbids a constant.</b> The 24/10000 and 30/10000 figures
-     * quoted for AMMs generally BOTH over-quote this batch by about half a percent — on the wrong side
-     * — while the pool's own declared 80 lands 272 lovelace under it. Two live mainnet pools declare
-     * two different fees (ADA/FLDT 80, FLDT/USDM 70), so no single constant is even available.
+     * <p>⚠ <b>What this test does NOT do, corrected after the round-1 audit (R1): it does not forbid a
+     * constant.</b> It calls {@code constantProductOut} with the fee passed EXPLICITLY, so replacing
+     * the production fee LOOKUP with a hardcoded 24 leaves it green (mutant M3). What it pins is the
+     * ARITHMETIC — that the formula, given the pool's real fee, reproduces a batch that really
+     * settled, and that the two constants a future reader might reach for would over-quote it.
+     *
+     * <p>The property "the fee is READ FROM THE DATUM, per direction" is defended by three other
+     * tests, and those are the ones a constant has to get past:
+     * {@link #aPoolThatCannotDeliverTheDebtIsRefusedByNameBeforeAnythingIsBuilt},
+     * {@link #aPoolOneUnitTooThinRefusesAndOneUnitDeeperProceeds} and
+     * {@link #eachSwapDirectionIsQuotedWithItsOwnFeeNumerator} — M3 kills all three.
      */
     @Test
     void theQuoteIsCalibratedAgainstTheRealMainnetBatchAndNeverOverQuotesIt() {

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/ConvertOrderPlanTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/ConvertOrderPlanTest.java
@@ -41,6 +41,19 @@ class ConvertOrderPlanTest {
             "1b6fda505ea9b739e42b5871d274344af37c196ddb70619541a7d06d");
     private static final String LOAN_TX = "d832b78e3d4a9ff99dfa8f238ae378b37dbd36b30efd24d68e5786f99786cf99";
 
+    /** USDM on mainnet — the other live pool's asset_b, for the thin-pool case below. */
+    private static final AssetType USDM =
+            new AssetType("c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad", "0014df105553444d");
+
+    /** The ADA/FLDT pool's declared fee, measured live 2026-09-10: 80/10000 on BOTH directions. */
+    private static final BigInteger FEE_80 = BigInteger.valueOf(80L);
+    /** The FLDT/USDM pool's, measured the same day — 70/10000. Two pools, two fees. */
+    private static final BigInteger FEE_70 = BigInteger.valueOf(70L);
+
+    /** The committed fixture pool's reserves, so a fixture that must SUCCEED is deep enough to. */
+    private static final BigInteger ADA_FLDT_RESERVE_ADA = new BigInteger("1692342884761");
+    private static final BigInteger ADA_FLDT_RESERVE_FLDT = new BigInteger("7596442927398");
+
     private static String fixture(String path) throws IOException {
         try (InputStream is = ConvertOrderPlanTest.class.getResourceAsStream(path)) {
             if (is == null) {
@@ -168,8 +181,12 @@ class ConvertOrderPlanTest {
         assertEquals(BigInteger.valueOf(4_000_000L), planTheRealCandidate(livePool()).orderLovelace());
 
         // The same loan with ADA collateral, against an ADA/FLDT-shaped pool with the roles swapped.
+        // ⚠ Reserves are the LIVE pool's, not BigInteger.TEN as they were before the POOL_TOO_THIN
+        // pre-check existed: a ten-unit pool cannot deliver a twenty-million debt, so the old fixture
+        // now refuses for a reason that has nothing to do with what this test is about.
         var adaCollateralPool = new MinswapPoolDatum(AssetType.ada(), FLDT,
-                BigInteger.TEN, BigInteger.TEN, BigInteger.TEN);
+                BigInteger.TEN, ADA_FLDT_RESERVE_ADA, ADA_FLDT_RESERVE_FLDT,
+                FEE_80, FEE_80, false);
         ConvertOrderPlan adaPlan = ConvertOrderPlan.plan(AssetType.ada(), FLDT,
                 BigInteger.valueOf(100_000_000L), BigInteger.ZERO, BigInteger.valueOf(20_000_000L),
                 50L, true, false, adaCollateralPool, MINSWAP_POOL_POLICY, LENDER_BOND,
@@ -202,8 +219,11 @@ class ConvertOrderPlanTest {
 
     @Test
     void aPoolForADifferentPairIsRefusedRatherThanPricedBadly() {
+        // Reserves stay nominal deliberately: the pair check refuses BEFORE the quote runs, and this
+        // test would still pass if it did not — which is why the ordering is pinned separately below.
         var wrongPool = new MinswapPoolDatum(AssetType.ada(),
-                new AssetType("cc".repeat(28), "beef"), BigInteger.TEN, BigInteger.TEN, BigInteger.TEN);
+                new AssetType("cc".repeat(28), "beef"), BigInteger.TEN, BigInteger.TEN,
+                BigInteger.TEN, FEE_80, FEE_80, false);
 
         var e = assertThrows(ConvertOrderPlan.RefusedException.class,
                 () -> planTheRealCandidate(wrongPool));
@@ -256,5 +276,198 @@ class ConvertOrderPlanTest {
         assertEquals(BigInteger.valueOf(50L), bond.liquidationFeePerMille());
         assertEquals(AssetType.ada(), loan.principalAsset());
         assertEquals(FLDT, loan.collateral().assetType());
+    }
+
+    // ---- the pre-trade quote: POOL_TOO_THIN, and the fee it is computed with ----------------------
+
+    /**
+     * ⛔ <b>THE CALIBRATION, against a batch that really settled.</b> Minswap batch
+     * {@code 5f0572b2…} (2026-09-08) took our order of 86,279,718 FLDT against reserves
+     * 1,667,895,724,071 ADA / 7,689,154,296,039 FLDT and paid <b>18,565,738 lovelace</b>.
+     *
+     * <p>The quote must be an <b>upper bound that does not exceed what the pool really paid</b>:
+     * quoting LESS than the batch is harmless (the pre-check refuses an order that would marginally
+     * have filled), quoting MORE is the failure this whole pre-check exists to prevent — it lets a
+     * futile order through to be built, submitted and refunded at the operator's expense.
+     *
+     * <p>⚠ <b>And this is the test that forbids a constant.</b> The 24/10000 and 30/10000 figures
+     * quoted for AMMs generally BOTH over-quote this batch by about half a percent — on the wrong side
+     * — while the pool's own declared 80 lands 272 lovelace under it. Two live mainnet pools declare
+     * two different fees (ADA/FLDT 80, FLDT/USDM 70), so no single constant is even available.
+     */
+    @Test
+    void theQuoteIsCalibratedAgainstTheRealMainnetBatchAndNeverOverQuotesIt() {
+        BigInteger in = new BigInteger("86279718");
+        BigInteger reserveFldt = new BigInteger("7689154296039");
+        BigInteger reserveAda = new BigInteger("1667895724071");
+        BigInteger realBatchPaid = new BigInteger("18565738");
+
+        BigInteger quoted = ConvertOrderPlan.constantProductOut(in, reserveFldt, reserveAda, FEE_80);
+
+        assertEquals(new BigInteger("18565466"), quoted,
+                "the pool's own fee of 80/10000 reproduces the settled batch to within 272 lovelace");
+        assertTrue(quoted.compareTo(realBatchPaid) <= 0,
+                "the quote must never promise more than the pool really paid: quoted " + quoted
+                        + " against a settled " + realBatchPaid);
+
+        // The two constants a future reader might reach for, pinned as the mistake they would be.
+        for (BigInteger wrong : new BigInteger[]{BigInteger.valueOf(24L), BigInteger.valueOf(30L)}) {
+            assertTrue(ConvertOrderPlan.constantProductOut(in, reserveFldt, reserveAda, wrong)
+                            .compareTo(realBatchPaid) > 0,
+                    "a hardcoded " + wrong + "/10000 OVER-quotes the real batch, which is the "
+                            + "direction that lets a futile order through — this is why the fee is "
+                            + "read from the pool datum");
+        }
+    }
+
+    /**
+     * ⛔ <b>The live FLDT/USDM candidate of 2026-09-09, which would have been built and refunded.</b>
+     * Pool 83,148,023,044 FLDT / 3,961,443,135 USDM, swapping 22,003,200,000 FLDT against a debt of
+     * 980,001,429 USDM: the pool returns about 824 M, a 155 M shortfall. {@code minimum_receive} is the
+     * debt and the validator fixes it, so this order does not fill badly — it is refunded, and the
+     * operator pays for the round trip.
+     */
+    @Test
+    void aPoolThatCannotDeliverTheDebtIsRefusedByNameBeforeAnythingIsBuilt() {
+        var thinPool = new MinswapPoolDatum(FLDT, USDM, BigInteger.TEN,
+                new BigInteger("83148023044"), new BigInteger("3961443135"),
+                FEE_70, FEE_70, false);
+
+        var e = assertThrows(ConvertOrderPlan.RefusedException.class,
+                () -> ConvertOrderPlan.plan(FLDT, USDM,
+                        new BigInteger("22003200000"), BigInteger.ZERO, new BigInteger("980001429"),
+                        0L, true, false, thinPool, MINSWAP_POOL_POLICY, LENDER_BOND,
+                        new AuthorizationMethod.CardanoSignature("aa".repeat(28)),
+                        receiver(), LOAN_TX, 1));
+
+        assertEquals(ConvertOrderPlan.Refusal.POOL_TOO_THIN, e.refusal());
+        // The operator reads these numbers on the endpoint; the refusal is only as good as its detail.
+        assertTrue(e.getMessage().contains("824348402"), "the quoted output: " + e.getMessage());
+        assertTrue(e.getMessage().contains("980001429"), "the required amount: " + e.getMessage());
+        assertTrue(e.getMessage().contains("155653027"), "the shortfall: " + e.getMessage());
+        assertTrue(e.getMessage().contains("83148023044") && e.getMessage().contains("3961443135"),
+                "the pool reserves it was quoted against: " + e.getMessage());
+        assertTrue(e.getMessage().contains("70/10000"), "the fee actually used: " + e.getMessage());
+    }
+
+    /**
+     * The off-by-one in the fee arithmetic is the likeliest defect here, so the boundary is pinned on
+     * both sides: a pool one unit too shallow refuses, and one unit deeper proceeds. Computed against
+     * the real candidate's own shape (95,000,000 FLDT swappable against a 20,000,000 lovelace debt).
+     */
+    @Test
+    void aPoolOneUnitTooThinRefusesAndOneUnitDeeperProceeds() {
+        BigInteger reserveFldt = ADA_FLDT_RESERVE_FLDT;
+        BigInteger exactlyEnough = new BigInteger("1612168329245");
+
+        assertEquals(BigInteger.valueOf(20_000_000L), ConvertOrderPlan.constantProductOut(
+                        BigInteger.valueOf(95_000_000L), reserveFldt, exactlyEnough, FEE_80),
+                "the boundary reserve returns the debt exactly");
+
+        assertEquals(BigInteger.valueOf(19_999_999L), ConvertOrderPlan.constantProductOut(
+                        BigInteger.valueOf(95_000_000L), reserveFldt,
+                        exactlyEnough.subtract(BigInteger.ONE), FEE_80),
+                "one unit shallower is one unit short");
+
+        // …and through plan(), because the arithmetic being right says nothing about it being wired.
+        // planTheRealCandidate sells FLDT (asset_b) for ada (asset_a), which is the bToA shape the two
+        // assertions above are computed for: reserve_b is the FLDT side we sell INTO the pool.
+        assertEquals(ConvertOrderPlan.Refusal.POOL_TOO_THIN,
+                assertThrows(ConvertOrderPlan.RefusedException.class,
+                        () -> planTheRealCandidate(new MinswapPoolDatum(AssetType.ada(), FLDT,
+                                BigInteger.TEN, exactlyEnough.subtract(BigInteger.ONE), reserveFldt,
+                                FEE_80, FEE_80, false))).refusal());
+
+        assertEquals(BigInteger.valueOf(20_000_000L),
+                planTheRealCandidate(new MinswapPoolDatum(AssetType.ada(), FLDT, BigInteger.TEN,
+                        exactlyEnough, reserveFldt, FEE_80, FEE_80, false)).minimumReceive(),
+                "one unit deeper and the plan is built");
+    }
+
+    /**
+     * ⛔ <b>EACH DIRECTION PAYS ITS OWN NUMERATOR — tested on UNEQUAL fees, because the live pools
+     * cannot test it.</b> ADA/FLDT declares 80/80 and FLDT/USDM 70/70, so on every pool this node
+     * actually trades against, reading the wrong numerator produces the identical answer and a
+     * direction bug is invisible. This fixture makes them 0 and 9000 so the two are impossible to
+     * confuse, and asserts the refusal FLIPS with the direction: selling asset_a is free and fills,
+     * selling asset_b costs 90 % and cannot.
+     *
+     * <p>Swapping the two numerators in {@code feeNumeratorFor} inverts both assertions.
+     */
+    @Test
+    void eachSwapDirectionIsQuotedWithItsOwnFeeNumerator() {
+        BigInteger reserve = new BigInteger("1000000000000");
+        BigInteger free = BigInteger.ZERO;
+        BigInteger punitive = BigInteger.valueOf(9_000L);
+        var lopsided = new MinswapPoolDatum(AssetType.ada(), FLDT, BigInteger.TEN,
+                reserve, reserve, free, punitive, false);
+
+        assertEquals(free, ConvertOrderPlan.feeNumeratorFor(lopsided, true),
+                "aToB sells asset_a and pays base_fee_a");
+        assertEquals(punitive, ConvertOrderPlan.feeNumeratorFor(lopsided, false),
+                "bToA sells asset_b and pays base_fee_b");
+
+        // aToB — collateral IS asset_a, so the free side applies and the debt is covered.
+        ConvertOrderPlan sellingAssetA = ConvertOrderPlan.plan(AssetType.ada(), FLDT,
+                BigInteger.valueOf(100_000_000L), BigInteger.ZERO, BigInteger.valueOf(20_000_000L),
+                50L, true, false, lopsided, MINSWAP_POOL_POLICY, LENDER_BOND,
+                new AuthorizationMethod.CardanoSignature("aa".repeat(28)), receiver(), LOAN_TX, 1);
+        assertTrue(sellingAssetA.aToBDirection());
+
+        // bToA — collateral IS asset_b, the 90 % side, and 95,000,000 in returns only ~9,499,909.
+        var e = assertThrows(ConvertOrderPlan.RefusedException.class,
+                () -> ConvertOrderPlan.plan(FLDT, AssetType.ada(),
+                        BigInteger.valueOf(100_000_000L), BigInteger.ZERO,
+                        BigInteger.valueOf(20_000_000L), 50L, true, false, lopsided,
+                        MINSWAP_POOL_POLICY, LENDER_BOND,
+                        new AuthorizationMethod.CardanoSignature("aa".repeat(28)),
+                        receiver(), LOAN_TX, 1));
+        assertEquals(ConvertOrderPlan.Refusal.POOL_TOO_THIN, e.refusal());
+        assertTrue(e.getMessage().contains("9499909") && e.getMessage().contains("9000/10000"),
+                "the refusal names the output and the numerator it used: " + e.getMessage());
+        assertTrue(e.getMessage().contains("base_fee_b"),
+                "and which side of the pool that numerator came from: " + e.getMessage());
+    }
+
+    /**
+     * {@code allow_dynamic_fee} means the two base numerators are not the whole fee, so a quote built
+     * from them would UNDERSTATE the cost — the direction that lets a futile order through. Refused by
+     * name rather than quoted at a price the pool does not charge. Both live pools have it false.
+     */
+    @Test
+    void aPoolWithDynamicFeesIsRefusedRatherThanQuotedFromItsBaseNumerators() {
+        var dynamicPool = new MinswapPoolDatum(AssetType.ada(), FLDT, BigInteger.TEN,
+                ADA_FLDT_RESERVE_ADA, ADA_FLDT_RESERVE_FLDT, FEE_80, FEE_80, true);
+
+        var e = assertThrows(ConvertOrderPlan.RefusedException.class,
+                () -> planAgainst(dynamicPool));
+        assertEquals(ConvertOrderPlan.Refusal.POOL_HAS_DYNAMIC_FEE, e.refusal());
+
+        // The identical pool with the flag clear is deep enough to plan — so the refusal is caused by
+        // the flag and by nothing else about this fixture.
+        assertEquals(BigInteger.valueOf(20_000_000L),
+                planAgainst(new MinswapPoolDatum(AssetType.ada(), FLDT, BigInteger.TEN,
+                        ADA_FLDT_RESERVE_ADA, ADA_FLDT_RESERVE_FLDT, FEE_80, FEE_80, false))
+                        .minimumReceive());
+    }
+
+    /** The real candidate's own numbers against an arbitrary pool — ada collateral, FLDT principal. */
+    private static ConvertOrderPlan planAgainst(MinswapPoolDatum pool) {
+        return ConvertOrderPlan.plan(AssetType.ada(), FLDT,
+                BigInteger.valueOf(100_000_000L), BigInteger.ZERO, BigInteger.valueOf(20_000_000L),
+                50L, true, false, pool, MINSWAP_POOL_POLICY, LENDER_BOND,
+                new AuthorizationMethod.CardanoSignature("aa".repeat(28)), receiver(), LOAN_TX, 1);
+    }
+
+    /**
+     * ⚑ The committed fixture is the LIVE pool, so its fee is evidence rather than a fixture choice —
+     * and the quote's whole calibration rests on this being 80, not on a number typed into a test.
+     */
+    @Test
+    void theCommittedPoolFixtureCarriesTheFeeTheChainDeclares() throws IOException {
+        MinswapPoolDatum pool = livePool();
+        assertEquals(FEE_80, pool.baseFeeANumerator());
+        assertEquals(FEE_80, pool.baseFeeBNumerator());
+        assertFalse(pool.allowDynamicFee(), "the live ADA/FLDT pool does not use dynamic fees");
     }
 }

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/ConvertTransactionBuilderGuardTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/ConvertTransactionBuilderGuardTest.java
@@ -104,8 +104,12 @@ class ConvertTransactionBuilderGuardTest {
     // ---- the post-assert, driven against hand-built bodies -----------------------------------------
 
     private static ConvertOrderPlan plan() {
-        var pool = new MinswapPoolDatum(AssetType.ada(), FLDT,
-                BigInteger.TEN, BigInteger.TEN, BigInteger.TEN);
+        // ⚠ Reserves and fee are the LIVE ADA/FLDT pool's. They were BigInteger.TEN, which the
+        // POOL_TOO_THIN pre-check now (correctly) refuses: a ten-unit pool cannot deliver a
+        // twenty-million debt, and this test is about the builder's post-assert, not the quote.
+        var pool = new MinswapPoolDatum(AssetType.ada(), FLDT, BigInteger.TEN,
+                new BigInteger("1692342884761"), new BigInteger("7596442927398"),
+                BigInteger.valueOf(80L), BigInteger.valueOf(80L), false);
         return ConvertOrderPlan.plan(FLDT, AssetType.ada(),
                 BigInteger.valueOf(100_000_000L), BigInteger.ZERO, BigInteger.valueOf(20_000_000L),
                 50L, true, false, pool,

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutorTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutorTest.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -323,7 +324,7 @@ class LiquidationExecutorTest {
         @Override
         public Transaction buildConvertLiquidation(LiquidationAssessment assessment, Utxo loanUtxo,
                                                     Utxo bondUtxo, Utxo configUtxo, Utxo lmConfigUtxo,
-                                                    Utxo walletUtxo,
+                                                    Function<BigInteger, Optional<Utxo>> walletSelector,
                                                     Map<String, OracleEntry> oraclesByOracleTokenUnit,
                                                     String changeAddress, long validFromMillis,
                                                     long validToMillis) {
@@ -3227,16 +3228,27 @@ class LiquidationExecutorTest {
 
     // ===== the CONVERT route must be handed a NOMINABLE wallet utxo, never the first raw one =====
 
-    /** Captures the wallet utxo the executor hands the convert router, then stops the build. */
+    /**
+     * Captures the wallet utxo the executor's SELECTOR nominates, then stops the build.
+     *
+     * <p>⚠ It applies the selector itself, exactly as the real router does — the executor no longer
+     * hands over a utxo, it hands over the means to choose one against a stated requirement. Asking
+     * for {@code requiredLovelace} is what makes the SIZE observable as well as the nominability.
+     */
     private static final class CapturingConvertRouter extends ConvertLiquidationRouter {
         Utxo captured;
-        CapturingConvertRouter() { super(null, null, null, null, null, null, null, null); }
+        private final BigInteger requiredLovelace;
+        CapturingConvertRouter(long requiredLovelace) {
+            super(null, null, null, null, null, null, null, null);
+            this.requiredLovelace = BigInteger.valueOf(requiredLovelace);
+        }
         @Override
         public Transaction buildConvertLiquidation(LiquidationAssessment assessment, Utxo loanUtxo,
                                                     Utxo bondUtxo, Utxo configUtxo, Utxo lmConfigUtxo,
-                                                    Utxo walletUtxo, Map<String, OracleEntry> oracles,
+                                                    Function<BigInteger, Optional<Utxo>> walletSelector,
+                                                    Map<String, OracleEntry> oracles,
                                                     String changeAddress, long validFromMillis, long validToMillis) {
-            captured = walletUtxo;
+            captured = walletSelector.apply(requiredLovelace).orElse(null);
             throw new RuntimeException("captured the wallet input; nothing past this point is under test");
         }
     }
@@ -3276,7 +3288,8 @@ class LiquidationExecutorTest {
                 LoanFixtures.registry(), LoanFixtures.converters(), configuration,
                 new LiquidatePayInAdvanceTransactionBuilder(LoanFixtures.registry(), LoanFixtures.NETWORK,
                         LoanFixtures.utxoSupplier(universe), LoanFixtures.protocolParams()));
-        CapturingConvertRouter capturing = new CapturingConvertRouter();
+        // The order overhead a token-collateral convert carries — what the real router asks for.
+        CapturingConvertRouter capturing = new CapturingConvertRouter(4_000_000L);
         LiquidationExecutor executor = new LiquidationExecutor(configuration, blockEventListener,
                 new FakeAppUtxoService(List.of(refScriptUtxo, WALLET_UTXO)), ACCOUNT, scanner, resolver, plainBuilder,
                 payInAdvanceRouter, capturing, LoanFixtures.registry(), log, oracles,
@@ -3288,6 +3301,199 @@ class LiquidationExecutorTest {
                 "the CONVERT route was handed the published REFERENCE-SCRIPT utxo as its wallet input: "
                         + capturing.captured.getTxHash() + "#" + capturing.captured.getOutputIndex());
         assertEquals(WALLET_UTXO.getTxHash(), capturing.captured.getTxHash(),
-                "the convert route must receive the first NOMINABLE utxo");
+                "the convert route must receive a NOMINABLE utxo");
+    }
+
+    /**
+     * ⛔ <b>NOMINABLE IS NOT ENOUGH — the input must also be big enough for the order.</b>
+     *
+     * <p>The previous test would pass against "the first nominable utxo", which is what the hand-off
+     * was before this slice. This one cannot: the first nominable utxo in the listing holds 5 ADA and
+     * the convert order needs 60, so a first-match selection returns the small one and a SIZED
+     * selection returns the large one. Together the two tests pin both halves — nominability and size —
+     * and the mutant that reverts either is failed by one of them.
+     *
+     * <p>⚠ An ADA-collateral convert is what makes this matter: its {@code orderLovelace} is the whole
+     * swappable amount PLUS the Minswap overhead, not the overhead alone, so it can be arbitrarily
+     * larger than any fixed headroom the old hand-off happened to have.
+     */
+    @Test
+    void theConvertRouteNominatesAWalletUtxoLargeEnoughForTheOrderNotMerelyTheFirstNominableOne() {
+        Utxo tooSmall = LoanFixtures.adaUtxo("ab".repeat(32), 0, ACCOUNT.baseAddress(), 5_000_000L);
+        AppConfig.LiquidationConfiguration configuration = new AppConfig.LiquidationConfiguration(
+                AppConfig.LiquidationConfiguration.Mode.SHADOW, 60, 120, 30, SMALL_MARGIN, 200, 30);
+        Scenario convert = convertScenario(FAT_FEE_PER_MILLE);
+        List<Utxo> universe = List.of(CONFIG_UTXO, LM_CONFIG_UTXO, tooSmall, WALLET_UTXO,
+                convert.loan().utxo(), convert.bond().utxo());
+        LiquidateTransactionBuilder plainBuilder = new LiquidateTransactionBuilder(LoanFixtures.registry(),
+                LoanFixtures.NETWORK, LoanFixtures.converters(), LoanFixtures.utxoSupplier(universe),
+                LoanFixtures.protocolParams(), null);
+        BlockEventListener blockEventListener = new BlockEventListener(null);
+        blockEventListener.getIsSyncing().set(false);
+        FakeScanner scanner = new FakeScanner(List.of(convert.assessment()));
+        FakeResolver resolver = new FakeResolver(allUnspent(List.of(convert)));
+        LiquidationDecisionLog log = new LiquidationDecisionLog(configuration);
+        PayInAdvanceLiquidationRouter payInAdvanceRouter = new PayInAdvanceLiquidationRouter(
+                LoanFixtures.registry(), LoanFixtures.converters(), configuration,
+                new LiquidatePayInAdvanceTransactionBuilder(LoanFixtures.registry(), LoanFixtures.NETWORK,
+                        LoanFixtures.utxoSupplier(universe), LoanFixtures.protocolParams()));
+        // 60 ADA: more than the 5 ADA utxo listed FIRST, less than the 200 ADA one listed second.
+        CapturingConvertRouter capturing = new CapturingConvertRouter(60_000_000L);
+        LiquidationExecutor executor = new LiquidationExecutor(configuration, blockEventListener,
+                new FakeAppUtxoService(List.of(tooSmall, WALLET_UTXO)), ACCOUNT, scanner, resolver,
+                plainBuilder, payInAdvanceRouter, capturing, LoanFixtures.registry(), log, noOracle(),
+                previewNetwork(), LoanFixtures.protocolParams(), LoanFixtures.converters(),
+                EXPLODING_SUBMITTER);
+        executor.cycle(NOW);
+
+        assertNotNull(capturing.captured, "the convert route was never reached");
+        assertEquals(WALLET_UTXO.getTxHash(), capturing.captured.getTxHash(),
+                "the convert route nominated the FIRST nominable utxo (5 ADA) for an order needing "
+                        + "60 ADA; the nomination must be sized to the order, not to list position");
+    }
+
+    // ===== a VERDICT on the convert route is recorded, never quarantined as machinery =====
+
+    /** Throws whatever it is given, and counts how often the executor actually reached it. */
+    private static final class ThrowingConvertRouter extends ConvertLiquidationRouter {
+        private final RuntimeException toThrow;
+        int calls;
+        ThrowingConvertRouter(RuntimeException toThrow) {
+            super(null, null, null, null, null, null, null, null);
+            this.toThrow = toThrow;
+        }
+        @Override
+        public Transaction buildConvertLiquidation(LiquidationAssessment assessment, Utxo loanUtxo,
+                                                    Utxo bondUtxo, Utxo configUtxo, Utxo lmConfigUtxo,
+                                                    Function<BigInteger, Optional<Utxo>> walletSelector,
+                                                    Map<String, OracleEntry> oracles,
+                                                    String changeAddress, long validFromMillis, long validToMillis) {
+            calls++;
+            throw toThrow;
+        }
+    }
+
+    /** Wires a shadow executor whose convert router throws, sharing the fixtures of the tests above. */
+    private static ConvertWiring convertWiringThrowing(RuntimeException toThrow) {
+        AppConfig.LiquidationConfiguration configuration = new AppConfig.LiquidationConfiguration(
+                AppConfig.LiquidationConfiguration.Mode.SHADOW, 60, 120, 30, SMALL_MARGIN, 200, 30);
+        Scenario convert = convertScenario(FAT_FEE_PER_MILLE);
+        List<Utxo> universe = List.of(CONFIG_UTXO, LM_CONFIG_UTXO, WALLET_UTXO,
+                convert.loan().utxo(), convert.bond().utxo());
+        LiquidateTransactionBuilder plainBuilder = new LiquidateTransactionBuilder(LoanFixtures.registry(),
+                LoanFixtures.NETWORK, LoanFixtures.converters(), LoanFixtures.utxoSupplier(universe),
+                LoanFixtures.protocolParams(), null);
+        BlockEventListener blockEventListener = new BlockEventListener(null);
+        blockEventListener.getIsSyncing().set(false);
+        LiquidationDecisionLog log = new LiquidationDecisionLog(configuration);
+        PayInAdvanceLiquidationRouter payInAdvanceRouter = new PayInAdvanceLiquidationRouter(
+                LoanFixtures.registry(), LoanFixtures.converters(), configuration,
+                new LiquidatePayInAdvanceTransactionBuilder(LoanFixtures.registry(), LoanFixtures.NETWORK,
+                        LoanFixtures.utxoSupplier(universe), LoanFixtures.protocolParams()));
+        ThrowingConvertRouter router = new ThrowingConvertRouter(toThrow);
+        LiquidationExecutor executor = new LiquidationExecutor(configuration, blockEventListener,
+                new FakeAppUtxoService(List.of(WALLET_UTXO)), ACCOUNT,
+                new FakeScanner(List.of(convert.assessment())),
+                new FakeResolver(allUnspent(List.of(convert))), plainBuilder, payInAdvanceRouter,
+                router, LoanFixtures.registry(), log, noOracle(), previewNetwork(),
+                LoanFixtures.protocolParams(), LoanFixtures.converters(), EXPLODING_SUBMITTER);
+        return new ConvertWiring(executor, log, router);
+    }
+
+    private record ConvertWiring(LiquidationExecutor executor, LiquidationDecisionLog log,
+                                 ThrowingConvertRouter router) {
+    }
+
+    /**
+     * ⛔ <b>A CLEAN VERDICT IS NOT A MACHINERY FAULT.</b> {@code POOL_TOO_THIN} — like the other four
+     * {@code ConvertOrderPlan} refusals — is a statement about this loan against this pool: no
+     * transaction was built, nothing broke, and one Minswap swap can make it viable again. It must be
+     * recorded under its own name and NOT held.
+     *
+     * <p>Before this slice every one of these fell to the executor's generic {@code catch (Exception)}
+     * and was quarantined for thirty minutes at ERROR, indistinguishable from a broken bot.
+     *
+     * <p>Mutant: remove the {@code ConvertOrderPlan.RefusedException} catch so it falls through again —
+     * the reason becomes the exception class and the quarantine count becomes 1.
+     */
+    @Test
+    void aConvertPlanRefusalIsRecordedUnderItsOwnNameAndNeverQuarantined() {
+        ConvertWiring wiring = convertWiringThrowing(new ConvertOrderPlan.RefusedException(
+                ConvertOrderPlan.Refusal.POOL_TOO_THIN,
+                "swapping 22003200000 would return about 824348402, but minimum_receive is 980001429"));
+
+        wiring.executor().cycle(NOW);
+
+        LiquidationDecision decision = wiring.log().newestFirst(10).getFirst();
+        assertEquals(LiquidationDecision.Outcome.REFUSED, decision.outcome());
+        assertEquals("POOL_TOO_THIN", decision.reason(),
+                "the refusal's own name, not the exception class the generic catch would have used");
+        assertTrue(decision.detail().contains("824348402"),
+                "the operator needs the numbers, not just the verdict: " + decision.detail());
+        assertEquals(0, wiring.executor().quarantinedCount(),
+                "a verdict about the candidate must not be held as though the bot were broken");
+
+        // …and it is genuinely reconsidered on the very next cycle, which is what "not held" means.
+        wiring.executor().cycle(NOW + 1_000L);
+        assertEquals(2, wiring.router().calls,
+                "the candidate must be reconsidered immediately, not suppressed");
+    }
+
+    /**
+     * ⛔ <b>A TRANSPORT FAILURE GETS A SHORT HOLD — NOT NOTHING, AND NOT THIRTY MINUTES.</b>
+     *
+     * <p>Measured on mainnet 2026-09-09: one Blockfrost hiccup on the pool lookup produced <b>39
+     * {@code QUARANTINED} records</b> on a single live loan, because {@code LOOKUP_FAILED} was reaching
+     * the machinery quarantine. A provider that cannot be reached says nothing about the candidate —
+     * but retrying every cycle against a provider that is down is what the quarantine exists for, so
+     * the answer is a SHORT hold: two cycles.
+     *
+     * <p>Both bounds are asserted, because each is a different mutant. Inside one cycle it must still
+     * be held (removing the hold entirely fails here); past two cycles it must be reconsidered (setting
+     * the hold to {@code quarantine-minutes} fails there).
+     */
+    @Test
+    void aTransportFailureOnThePoolLookupIsHeldForTwoCyclesNotTheThirtyMinuteQuarantine() {
+        ConvertWiring wiring = convertWiringThrowing(new MinswapPoolResolver.RefusedException(
+                MinswapPoolResolver.Refusal.LOOKUP_FAILED, "the pool lookup failed: java.net.SocketTimeoutException"));
+
+        wiring.executor().cycle(NOW);
+
+        LiquidationDecision decision = wiring.log().newestFirst(10).getFirst();
+        assertEquals(LiquidationDecision.Outcome.REFUSED, decision.outcome());
+        assertEquals("LOOKUP_FAILED", decision.reason(),
+                "a transport failure must be distinguishable from NO_MINSWAP_POOL, which is a verdict");
+        assertEquals(1, wiring.executor().quarantinedCount(),
+                "SOME hold is required: a candidate retried every cycle against a provider that is "
+                        + "down is exactly what the quarantine was built for");
+        assertEquals(1, wiring.router().calls);
+
+        // One cycle later (60s), still inside the two-cycle hold.
+        wiring.executor().cycle(NOW + 60_000L);
+        assertEquals(1, wiring.router().calls, "still held after one cycle");
+        assertEquals(LiquidationDecision.Outcome.QUARANTINED,
+                wiring.log().newestFirst(10).getFirst().outcome());
+
+        // Past two cycles (121s) it must be reconsidered — the whole point of not using 30 minutes.
+        wiring.executor().cycle(NOW + 121_000L);
+        assertEquals(2, wiring.router().calls,
+                "a transport blip must clear in two cycles, not in the 30-minute machinery quarantine");
+    }
+
+    /**
+     * The resolver's OTHER refusals are facts about the chain — reproducible next cycle and unaffected
+     * by waiting — so they are verdicts, held no longer than any other verdict. Only
+     * {@code LOOKUP_FAILED} is transport.
+     */
+    @Test
+    void anAmbiguousPoolIsAVerdictAboutTheChainAndIsNotHeld() {
+        ConvertWiring wiring = convertWiringThrowing(new MinswapPoolResolver.RefusedException(
+                MinswapPoolResolver.Refusal.AMBIGUOUS_POOL, "2 UTxOs hold the LP asset"));
+
+        wiring.executor().cycle(NOW);
+
+        assertEquals("AMBIGUOUS_POOL", wiring.log().newestFirst(10).getFirst().reason());
+        assertEquals(0, wiring.executor().quarantinedCount(),
+                "waiting cannot change how many pool UTxOs hold the LP asset");
     }
 }

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutorTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutorTest.java
@@ -3481,6 +3481,48 @@ class LiquidationExecutorTest {
     }
 
     /**
+     * ⛔ <b>F1 — A WALLET TOO SMALL IS A VERDICT ABOUT THE WALLET, NOT A BROKEN BOT.</b>
+     *
+     * <p>Round-1 audit: mutant M12 — neuter this catch so the exception falls to the generic
+     * {@code catch (Exception)} and its 30-minute machinery quarantine — killed <b>0 of 1062</b>
+     * tests. The catch existed, behaved correctly, and nothing held it there; reordering the ladder
+     * (the refactor r1 flags as "tempting, separate slice") would have silently restored pre-slice
+     * behaviour.
+     *
+     * <p>⚠ The operator can top the wallet up between cycles, so holding this for thirty minutes
+     * keeps refusing a convert that has already become fundable. Same treatment the pay-in-advance
+     * path gives its own {@code WalletInputTooSmallException}.
+     *
+     * <p>The THROW side is pinned separately, in {@code ConvertLiquidationRouterTest} — a fake router
+     * can prove what the executor does with the exception and nothing about whether it is ever raised.
+     */
+    @Test
+    void aWalletTooSmallForTheConvertOrderIsRecordedAndNeverQuarantined() {
+        ConvertWiring wiring = convertWiringThrowing(
+                new ConvertLiquidationRouter.WalletInputTooSmallException(
+                        "no nominable wallet utxo can fund this convert: the Minswap order carries "
+                                + "4000000 lovelace (the order overhead; the collateral is a token)"));
+
+        wiring.executor().cycle(NOW);
+
+        LiquidationDecision decision = wiring.log().newestFirst(10).getFirst();
+        assertEquals(LiquidationDecision.Outcome.REFUSED, decision.outcome());
+        assertEquals("WALLET_INPUT_TOO_SMALL", decision.reason(),
+                "recorded under its own name, not under the exception class the generic catch uses");
+        assertTrue(decision.detail().contains("4000000"),
+                "the operator needs the figure to fund against: " + decision.detail());
+        assertEquals(0, wiring.executor().quarantinedCount(),
+                "a wallet the operator can top up between cycles must not be held for 30 minutes");
+        assertTrue(wiring.executor().quarantinedRefs().isEmpty(),
+                "and the quarantine map must be untouched, not merely small");
+
+        // Reconsidered on the very next cycle — which is what "not held" has to mean to be worth it.
+        wiring.executor().cycle(NOW + 1_000L);
+        assertEquals(2, wiring.router().calls,
+                "a topped-up wallet must be retried immediately, not after a machinery quarantine");
+    }
+
+    /**
      * The resolver's OTHER refusals are facts about the chain — reproducible next cycle and unaffected
      * by waiting — so they are verdicts, held no longer than any other verdict. Only
      * {@code LOOKUP_FAILED} is transport.


### PR DESCRIPTION
The convert route stops treating verdicts as faults — and stops paying to build orders that cannot fill.

⛔ **Do not merge on my say-so — Giovanni's call.** Two commits, cherry-picked onto the new `main` (#23 was squashed, so the slice history is not an ancestor). Nothing about what is **submitted** changes.

## Why

Two things measured on mainnet on 2026-09-09, both on the convert path:

- **One Blockfrost transport error put a live loan into a 30-minute hold, 39 times over.** The pool lookup failed in transport; `LOOKUP_FAILED` reached the executor's generic `catch (Exception)`, which quarantines for 30 minutes and logs ERROR. The decision log carries 39 consecutive `QUARANTINED` records for loan `279499ff` from that one cause. A transport failure says nothing about the candidate.
- **The FLDT/USDM pool cannot deliver that loan's debt**, and nothing checked. `minimum_receive` is fixed by the validator at the remaining debt, so a shallow pool **refunds rather than fills**: the order is built, submitted, batched, returned — and the operator pays the transaction and batcher fees for nothing.

## What changed

**A `POOL_TOO_THIN` pre-check, from the quote, before anything is built.** The constant-product output for the swappable collateral against the resolved pool's reserves, refused by name when it falls short of the validator's `minimum_receive`, carrying input, quoted output, requirement, shortfall, reserves and the fee used.

⚑ **The fee comes from the pool's own datum, per pool and per direction — no constant is correct.** Measured live: **ADA/FLDT charges 80/10000, FLDT/USDM charges 70/10000**, and `base_fee_a`/`base_fee_b` are separate fields selected by swap direction. Calibrated against the real batch that filled our own order (`5f0572b2…`, 2026-09-08): at the datum's fee the quote reproduces the actual payout to **−272 lovelace** — under-quoting, the safe direction — where `24/10000` **over-quotes by +0.56 %** and `30/10000` by +0.50 %. An over-quoting pre-check is worse than none: it lets the futile order through. This required modelling three fields the Java `MinswapPoolDatum` had been discarding (on-chain indices 6, 7, 9); the ten-field arity guard is unchanged.

**Verdicts are caught by name and never quarantined.** `ConvertOrderPlan.RefusedException` (bond forbids conversion, equity in principal currency, wrong pair, nothing left to swap, and the new `POOL_TOO_THIN` / `POOL_HAS_DYNAMIC_FEE`), the resolver's refusals split by kind, and a new `WalletInputTooSmallException` — each recorded under its own name, logged at INFO, reconsidered next cycle. This mirrors what the plain path already did.

**A transport error gets a short hold, not thirty minutes.** `LOOKUP_FAILED` holds for two cycles (`2 × delay-seconds`, the same property driving the scheduler, so it is two cycles at any operator setting), distinct from `NO_MINSWAP_POOL` — which is a real 404 on both asset orders and says something about the candidate — and from the 30-minute machinery quarantine, which is unchanged.

**The convert route sizes its wallet input.** It took the first nominable UTxO; it now nominates the smallest that covers the order's own ada, as the plain and anticipate paths already did.

## Evidence

- **Nothing submitted changes** — the emitted order datum hex, `orderLovelace`, both datum hashes and the swappable amount are byte-identical base vs head, and the pay-in-advance ada dry-eval CBOR sha256 is unchanged. The audit proved the second commit stronger than that: it compiled both revisions and diffed the whole `build/classes` tree — **every class file byte-identical, including line-number tables.**
- **Live mainnet dry-eval, read-only, 3/3**: the pre-check permits the deep ADA/FLDT candidate (quote **28,948,493** against **28,021,735** required) and refuses the thin FLDT/USDM one (**824,348,402** against **980,001,429** required — a 16 % shortfall). It refuses the futile order and permits the real one.
- **Degradation is always safe-side**, probed: a zero-reserve pool refuses rather than dividing by zero; a fee at or above the denominator quotes zero or negative and refuses; a quote exactly equal to the requirement proceeds, because `minimum_receive` is a floor.
- **Suite: 136 files, 1069 tests, 0 failures, 45 skipped**, orphan-checked both directions.
- Two audit rounds. Round 1 rejected: three guards were correct and **nothing held them there** — mutants neutering the wallet-too-small catch, the dynamic-fee decode and the converter's fee indices each killed **zero of 1062 tests**. Round 2 accepted after those were pinned, with the repairs themselves mutation-tested.

## Known limitations, stated rather than discovered later

- **The degraded-fee-ceiling path bypasses the sized nomination.** When the protocol-parameter fetch fails, nomination falls back to "largest nominable UTxO" and drops the extra outlay — so on that cycle the new `WalletInputTooSmall` refusal cannot fire and an under-funded build lands in the 30-minute quarantine instead. Inherited from the sibling path, out of this slice's scope, ticketed.
- Falling through from a thin pool to the anticipate path is **not** here — this slice refuses; `CONVERT_BEFORE_ANTICIPATE` is a separate ticket awaiting intake.
- The nomination boundary is untested against a real wallet sized near the requirement (the live rig uses a synthetic UTxO).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AvYgGDeXA4iMw1MqHcMRt
