### PR TITLE
The node can say what it was built from — and say "unknown" when it cannot (re-cut onto main)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -139,15 +139,21 @@ jobs:
       # src/test/java. Raise the floor deliberately when classes are added; a drop is a deletion to
       # justify, never a number to edit away. (CLAUDE.md `## Commands`.)
       #
-      # Floor measured 2026-09-10 on this tree, keyless: 137 files / 1076 tests / 0 failures /
-      # 45 skipped. Raised 136 -> 137 in the merge that brought this branch up to origin/main:
-      # #24 added ConvertLiquidationRouterTest, so the tree grew by one class and the old floor
-      # stopped matching it. A floor is only a measurement while it equals something someone
-      # measured; left at 136 it would have tolerated losing a class silently -- which is the
-      # exact defect this step exists to catch, so it is corrected here rather than carried.
+      # Floor measured 2026-09-10 on THIS tree, keyless (the shape CI runs in): 138 files.
+      #
+      # Provenance, because this number has now been raised three times by three branches that each
+      # measured a different tree and each proposed 137:
+      #   135  base e75ecf9 (#23)
+      #   +1   EnvGatedRigReachabilityTest        (the CI-gate slice, squashed into main as #25)
+      #   +1   ConvertLiquidationRouterTest       (#24)
+      #   +1   config/BuildProvenanceTest         (this slice, 11 tests)
+      #   = 138
+      #
+      # Left at 137 the gate would have tolerated losing a class in silence -- the exact defect this
+      # step exists to catch. Re-measure before changing it; do not reconcile to a number written here.
       - name: Assert the suite did not quietly shrink
         env:
-          RESULT_FILE_FLOOR: '137'
+          RESULT_FILE_FLOOR: '138'
         run: |
           python3 - <<'PY'
           import glob, os, sys, xml.etree.ElementTree as ET

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -141,6 +141,10 @@ jobs:
       #
       # Floor measured 2026-09-10 on THIS tree, keyless (the shape CI runs in): 138 files.
       #
+      # (config/BuildProvenanceTest carries 11 tests: 9 at round 1, plus two the rework added -- one
+      # asserting the startup wiring actually installs the banner's default properties, one asserting
+      # the banner says the word 'unknown' rather than rendering a hole. Same one class, same floor.)
+      #
       # Provenance, because this number has now been raised three times by three branches that each
       # measured a different tree and each proposed 137:
       #   135  base e75ecf9 (#23)

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,15 @@ dependencies {
 
 	implementation 'io.micrometer:micrometer-registry-prometheus:1.13.4'
 
+	// Declared here because NOTHING in this repo asked for actuator until now: the only thing putting
+	// it on the runtime classpath was a third-level transitive of
+	// yaci-store-spring-boot-starter:0.1.7. /actuator/prometheus -- which is how an operator watches
+	// this node -- therefore depended on a third party's dependency graph, and a yaci-store bump that
+	// dropped it would 404 the endpoint with no compile error and no failing test. Measured
+	// 2026-09-10: declaring it explicitly changes nothing on the classpath (runtimeClasspath resolves
+	// to the same 244 artifacts before and after, empty diff). A fragility fix, not a new dependency.
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
 	implementation 'org.postgresql:postgresql:42.6.0'
 	testImplementation 'com.h2database:h2:2.1.214'
 
@@ -70,6 +79,57 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok:1.18.30'
 	testAnnotationProcessor 'org.projectlombok:lombok:1.18.30'
 
+}
+
+// ---------------------------------------------------------------------------------------------
+// Build provenance: what this jar was built FROM, recorded into
+// build/resources/main/META-INF/build-info.properties and served on /actuator/info.
+//
+// Why it exists: the CI image tag is `date +'%Y.%m.%d'`, so two pushes on the same day produce the
+// SAME TAG over DIFFERENT CODE. Nothing in the running process closed that gap; now the process
+// itself can say which commit it is.
+// ---------------------------------------------------------------------------------------------
+
+// Runs git at configuration time and returns null -- never the empty string, never a throw -- when
+// git cannot be reached at all: not installed, not a repository, a source tarball, a Docker context
+// with no `.git`. `providers.exec` rather than the older `exec { }` because the latter adds to the
+// Gradle 9 deprecation output this build already emits.
+def gitOutput = { String... arguments ->
+	try {
+		def execution = providers.exec {
+			commandLine(['git'] + (arguments as List))
+			ignoreExitValue = true
+		}
+		return execution.result.get().exitValue == 0 ? execution.standardOutput.asText.get().trim() : null
+	} catch (Exception ignored) {
+		return null
+	}
+}
+
+def headCommit = gitOutput('rev-parse', 'HEAD')
+def headCommitShort = gitOutput('rev-parse', '--short=12', 'HEAD')
+def workingTreeStatus = gitOutput('status', '--porcelain')
+
+springBoot {
+	buildInfo {
+		properties {
+			additional = [
+					commit     : headCommit ?: 'unknown',
+					commitShort: headCommitShort ?: 'unknown',
+
+					// UNAVAILABLE IS NOT CLEAN, and this line is the whole point of the block.
+					// `workingTreeStatus` has THREE states, not two: null means git could not be
+					// reached, "" means git WAS reached and the tree was clean, non-empty means
+					// dirty. The naive version returns "" from the fallback, finds it empty, and
+					// records dirty=false -- so a build that cannot vouch for its own tree would
+					// instead assert a clean one, on an unauthenticated endpoint an operator reads
+					// to decide whether an image is trustworthy. Silence must not be able to render
+					// as a clean tree.
+					dirty      : workingTreeStatus == null ? 'unknown'
+							: (workingTreeStatus.isEmpty() ? 'false' : 'true'),
+			]
+		}
+	}
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,15 @@ dependencies {
 	// yaci-store-spring-boot-starter:0.1.7. /actuator/prometheus -- which is how an operator watches
 	// this node -- therefore depended on a third party's dependency graph, and a yaci-store bump that
 	// dropped it would 404 the endpoint with no compile error and no failing test. Measured
-	// 2026-09-10: declaring it explicitly changes nothing on the classpath (runtimeClasspath resolves
-	// to the same 244 artifacts before and after, empty diff). A fragility fix, not a new dependency.
+	// 2026-09-10: declaring it explicitly changes nothing on the classpath -- EMPTY DIFF on
+	// `runtimeClasspath`, `testRuntimeClasspath`, `compileClasspath` and `testCompileClasspath`.
+	// Method: `configurations.<name>.resolvedConfiguration.resolvedArtifacts` diffed before/after,
+	// which for `runtimeClasspath` is 217 resolved artifacts / 213 unique module ids / 217 files.
+	// (An earlier revision of this comment said "244 artifacts". That figure came from grepping
+	// `group:artifact:version` out of `./gradlew dependencies` printed text, which double-counts
+	// every `->` version resolution -- it was never a count of artifacts. A number with no method
+	// beside it is how a stale figure becomes the baseline everyone reconciles to.)
+	// A fragility fix, not a new dependency.
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	implementation 'org.postgresql:postgresql:42.6.0'
@@ -106,27 +113,74 @@ def gitOutput = { String... arguments ->
 	}
 }
 
-def headCommit = gitOutput('rev-parse', 'HEAD')
-def headCommitShort = gitOutput('rev-parse', '--short=12', 'HEAD')
-def workingTreeStatus = gitOutput('status', '--porcelain')
+// ⛔ GIT REPOSITORY DISCOVERY WALKS UPWARD, and that turns "no repository" into a CONFIDENT WRONG
+// ANSWER rather than into no answer. A directory with no `.git` placed inside an unrelated
+// repository -- a release tarball unpacked inside a checkout, a Docker build context nested in one:
+// exactly the scenarios this block exists to survive -- answers `git rev-parse HEAD` with the
+// ENCLOSING repository's HEAD and `git status --porcelain` with the enclosing tree's state. That is
+// strictly worse than `unknown`: `commit=unknown, dirty=false` contradicts itself and is visible by
+// eye, while a valid 40-hex sha from some other repository passes every shape assertion, names code
+// this jar was NOT built from, and gives the operator no signal at all.
+//
+// So the repository must be proven to be THIS project before any of its answers are used.
+// `--show-toplevel` compared against `projectDir` is preferred over `file("${projectDir}/.git").exists()`
+// because `.git` is a FILE, not a directory, in a worktree or a submodule -- both legitimate places
+// to build from, and `exists()` happens to hold there, but the toplevel comparison is the property
+// actually being asserted rather than a proxy for it. Canonicalised on both sides so a symlinked
+// checkout does not read as a different repository.
+def repositoryToplevel = gitOutput('rev-parse', '--show-toplevel')
+def gitDescribesThisProject =
+		repositoryToplevel != null && new File(repositoryToplevel).canonicalFile == projectDir.canonicalFile
+
+def headCommit = gitDescribesThisProject ? gitOutput('rev-parse', 'HEAD') : null
+def headCommitShort = gitDescribesThisProject ? gitOutput('rev-parse', '--short=12', 'HEAD') : null
+def workingTreeStatus = gitDescribesThisProject ? gitOutput('status', '--porcelain') : null
+
+def buildCommit = headCommit ?: 'unknown'
+def buildCommitShort = headCommitShort ?: 'unknown'
+
+// UNAVAILABLE IS NOT CLEAN, and this line is the whole point of the block. `workingTreeStatus` has
+// THREE states, not two: null means git could not be reached (or reached the WRONG repository, see
+// above), "" means git WAS reached and the tree was clean, non-empty means dirty. The naive version
+// returns "" from the fallback, finds it empty, and records dirty=false -- so a build that cannot
+// vouch for its own tree would instead assert a clean one, on an unauthenticated endpoint an
+// operator reads to decide whether an image is trustworthy. Silence must not be able to render as a
+// clean tree.
+def buildDirty = workingTreeStatus == null ? 'unknown'
+		: (workingTreeStatus.isEmpty() ? 'false' : 'true')
+
+// ⛔ Build-time self-consistency. The three fields come from ONE decision -- is git usable and is it
+// this repository -- so they are all `unknown` together or none of them is. Any mixture means the
+// three-state handling above has been edited back to a two-state form, and the shape that mixture
+// takes in practice is `commit=unknown` beside `dirty=false`: a build asserting a clean tree it
+// could not read.
+//
+// ⚠ ALL THREE `unknown` is CORRECT and must keep building green -- no `.git` is a supported state,
+// not a startup or build condition. Only the inconsistent combination fails.
+//
+// ⚠ And be honest about its reach: where `.git` is present this check is VACUOUS, which is every
+// developer machine and every CI run. It is a tripwire for someone editing this Groovy, not a test
+// of the git-absent path; a load-bearing harness for that path needs a GradleRunner build of a
+// scratch project and is ticketed separately.
+def provenanceFields = [commit: buildCommit, commitShort: buildCommitShort, dirty: buildDirty]
+def unknownFields = provenanceFields.findAll { name, value -> value == 'unknown' }
+if (!unknownFields.isEmpty() && unknownFields.size() != provenanceFields.size()) {
+	throw new GradleException(
+			"build provenance is internally inconsistent: " +
+					provenanceFields.collect { name, value -> "${name}=${value}" }.join(', ') +
+					". These fields answer one question -- is git usable and is it THIS repository -- " +
+					"so they are all 'unknown' or none of them is. A mixture means unavailability is " +
+					"being reported as a fact (typically 'dirty=false' beside 'commit=unknown'), " +
+					"which is a false statement on an unauthenticated endpoint.")
+}
 
 springBoot {
 	buildInfo {
 		properties {
 			additional = [
-					commit     : headCommit ?: 'unknown',
-					commitShort: headCommitShort ?: 'unknown',
-
-					// UNAVAILABLE IS NOT CLEAN, and this line is the whole point of the block.
-					// `workingTreeStatus` has THREE states, not two: null means git could not be
-					// reached, "" means git WAS reached and the tree was clean, non-empty means
-					// dirty. The naive version returns "" from the fallback, finds it empty, and
-					// records dirty=false -- so a build that cannot vouch for its own tree would
-					// instead assert a clean one, on an unauthenticated endpoint an operator reads
-					// to decide whether an image is trustworthy. Silence must not be able to render
-					// as a clean tree.
-					dirty      : workingTreeStatus == null ? 'unknown'
-							: (workingTreeStatus.isEmpty() ? 'false' : 'true'),
+					commit     : buildCommit,
+					commitShort: buildCommitShort,
+					dirty      : buildDirty,
 			]
 		}
 	}

--- a/src/main/java/com/fluidtokens/aquarium/offchain/AcquariumOffchainApp.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/AcquariumOffchainApp.java
@@ -24,12 +24,28 @@ public class AcquariumOffchainApp {
     private static final String BUILD_INFO = "/META-INF/build-info.properties";
 
     public static void main(String[] args) {
+        configuredApplication().run(args);
+    }
+
+    /**
+     * ⛔ <b>The seam, and it exists because the wiring below is otherwise untestable.</b> Everything
+     * that decides what the banner can render happens here rather than in {@link #main(String[])}:
+     * {@code main} is deliberately a single delegation with nothing of its own to get wrong, because
+     * a test can call this and cannot call {@code main}.
+     *
+     * <p>Without this split, deleting the {@code setDefaultProperties} line leaves every test green
+     * while every banner an operator ever reads says {@code commit unknown (dirty=unknown) :: built
+     * unknown} — the banner half of this feature silently off, with CI reporting success. A test that
+     * renders the banner over a map it built itself proves the placeholders resolve; it does not prove
+     * anything supplies them in production.
+     */
+    static SpringApplication configuredApplication() {
         SpringApplication application = new SpringApplication(AcquariumOffchainApp.class);
         // Default properties, so an operator's -D or environment variable still wins. This is also
         // what makes banner.txt's ${aquarium.build.*} placeholders resolvable: SpringApplication puts
         // default properties into the Environment before the banner is printed.
         application.setDefaultProperties(new LinkedHashMap<>(buildProvenance()));
-        application.run(args);
+        return application;
     }
 
     /**

--- a/src/main/java/com/fluidtokens/aquarium/offchain/AcquariumOffchainApp.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/AcquariumOffchainApp.java
@@ -3,11 +3,70 @@ package com.fluidtokens.aquarium.offchain;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+
 @SpringBootApplication(scanBasePackages = "com.fluidtokens.aquarium.offchain")
 public class AcquariumOffchainApp {
 
+    /**
+     * ⛔ The value every provenance field falls back to. It is deliberately NOT the empty string and
+     * deliberately NOT {@code false}: an operator reading {@code docker logs} or {@code /actuator/info}
+     * must be able to tell "this build does not know" apart from "this build was clean". They are
+     * different claims and only one of them is safe to trust.
+     */
+    public static final String UNKNOWN = "unknown";
+
+    /** Written by Gradle's {@code bootBuildInfo}; absent from a jar built without it. */
+    private static final String BUILD_INFO = "/META-INF/build-info.properties";
+
     public static void main(String[] args) {
-        SpringApplication.run(AcquariumOffchainApp.class, args);
+        SpringApplication application = new SpringApplication(AcquariumOffchainApp.class);
+        // Default properties, so an operator's -D or environment variable still wins. This is also
+        // what makes banner.txt's ${aquarium.build.*} placeholders resolvable: SpringApplication puts
+        // default properties into the Environment before the banner is printed.
+        application.setDefaultProperties(new LinkedHashMap<>(buildProvenance()));
+        application.run(args);
+    }
+
+    /**
+     * What this process was built from, read off the classpath and offered to the Environment under
+     * {@code aquarium.build.*}.
+     *
+     * <p>⚠ <b>A missing or unreadable {@code build-info.properties} is not a startup condition.</b>
+     * The node runs on operators' machines and is also built in ways that never invoke
+     * {@code bootBuildInfo}; refusing to boot because the process cannot describe itself would turn a
+     * cosmetic gap into an outage. Every field then reads {@link #UNKNOWN}, which is a true statement.
+     */
+    public static Map<String, Object> buildProvenance() {
+        Properties properties = new Properties();
+        try (InputStream stream = AcquariumOffchainApp.class.getResourceAsStream(BUILD_INFO)) {
+            if (stream != null) {
+                properties.load(stream);
+            }
+        } catch (IOException | RuntimeException ignored) {
+            // Deliberately swallowed -- see the javadoc above. Nothing here is worth a failed boot.
+        }
+
+        Map<String, Object> provenance = new LinkedHashMap<>();
+        provenance.put("aquarium.build.commit", value(properties, "build.commit"));
+        provenance.put("aquarium.build.commitShort", value(properties, "build.commitShort"));
+        provenance.put("aquarium.build.dirty", value(properties, "build.dirty"));
+        provenance.put("aquarium.build.time", value(properties, "build.time"));
+        return provenance;
+    }
+
+    /**
+     * ⚠ Blank counts as absent. A property present but empty would render the banner as a line with a
+     * hole in it and would report an empty {@code dirty} -- both of which read as "fine" rather than
+     * as "unknown".
+     */
+    private static String value(Properties properties, String key) {
+        String raw = properties.getProperty(key);
+        return raw == null || raw.isBlank() ? UNKNOWN : raw.trim();
     }
 
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -436,7 +436,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,prometheus
+        include: health,prometheus,info
 
 ---
 spring:

--- a/src/main/resources/banner.txt
+++ b/src/main/resources/banner.txt
@@ -1,0 +1,3 @@
+FluidTokens Aquarium Node :: commit ${aquarium.build.commitShort:unknown} (dirty=${aquarium.build.dirty:unknown}) :: built ${aquarium.build.time:unknown}
+  full commit  ${aquarium.build.commit:unknown}
+  the same values are served on /actuator/info; the image tag is a DATE and does not identify code

--- a/src/test/java/com/fluidtokens/aquarium/offchain/config/BuildProvenanceTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/config/BuildProvenanceTest.java
@@ -3,6 +3,7 @@ package com.fluidtokens.aquarium.offchain.config;
 import com.fluidtokens.aquarium.offchain.AcquariumOffchainApp;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.ResourceBanner;
+import org.springframework.boot.SpringApplication;
 import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.info.InfoContributorAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.info.InfoEndpointAutoConfiguration;
@@ -17,11 +18,13 @@ import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
@@ -34,6 +37,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -59,11 +63,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * build.gradle comment on {@code dirty} — and the assertion here is that {@code unknown} is a value
  * the pipeline can actually carry end to end.
  *
- * <h2>Why the last two tests do not touch the container</h2>
- * Everything above them supplies the exposure property by hand, which means the feature could be
- * switched off in the shipped {@code application.yaml} and they would all keep passing. So the file
- * itself is asserted, parsed by Spring's own loader — the {@link ApplicationYamlBindsTest} discipline
- * applied to a one-word key.
+ * <h2>Why some tests here do not touch the container at all</h2>
+ * Everything that hands the exposure property to an {@link ApplicationContextRunner} by hand would
+ * keep passing with the feature switched off in the shipped {@code application.yaml}; and everything
+ * that renders the banner over a map it built itself would keep passing with nothing in production
+ * installing that map. So both wirings are asserted directly — the shipped file parsed by Spring's
+ * own loader (the {@link ApplicationYamlBindsTest} discipline applied to a one-word key), and the
+ * startup wiring's own default properties.
  */
 class BuildProvenanceTest {
 
@@ -105,12 +111,30 @@ class BuildProvenanceTest {
             BuildProperties build = context.getBean(BuildProperties.class);
             String commit = build.get("commit");
             assertNotNull(commit, "build.commit was not recorded at all");
-            assertTrue(commit.matches("[0-9a-f]{40}") || AcquariumOffchainApp.UNKNOWN.equals(commit),
+            // The literal, not AcquariumOffchainApp.UNKNOWN: this value is written by Gradle, and
+            // coupling the assertion to the Java constant would let the two drift apart unnoticed.
+            assertTrue(commit.matches("[0-9a-f]{40}") || "unknown".equals(commit),
                     "build.commit must be a full 40-char sha or exactly 'unknown', was: " + commit);
-            assertTrue(Set.of("true", "false", AcquariumOffchainApp.UNKNOWN).contains(build.get("dirty")),
+            String dirty = build.get("dirty");
+            assertTrue(Set.of("true", "false", "unknown").contains(dirty),
                     "build.dirty must be true, false or unknown -- an empty or absent value reads as "
                             + "'clean' to anyone skimming, which is the one thing it must never do. "
-                            + "Was: " + build.get("dirty"));
+                            + "Was: " + dirty);
+
+            // ⛔ THE CORRELATION, not the set. Set membership ADMITS the defect: the naive two-state
+            // implementation writes commit=unknown beside dirty=false, and 'false' is in the set, so
+            // the assertion above passes on exactly the value its own message forbids. The three
+            // fields answer ONE question -- is git usable and is it this repository -- so the
+            // property with content is that they agree.
+            assertEquals("unknown".equals(commit), "unknown".equals(dirty),
+                    "build.commit and build.dirty disagree about whether git was readable: commit="
+                            + commit + ", dirty=" + dirty + ". 'commit=unknown, dirty=false' is a "
+                            + "build that could not read its own tree asserting a clean one, on an "
+                            + "unauthenticated endpoint an operator uses to decide whether an image "
+                            + "is trustworthy.");
+            assertEquals("unknown".equals(commit), "unknown".equals(build.get("commitShort")),
+                    "build.commit and build.commitShort disagree about whether git was readable: "
+                            + commit + " / " + build.get("commitShort"));
         });
     }
 
@@ -160,8 +184,13 @@ class BuildProvenanceTest {
 
     /**
      * (c) The banner. Rendered through {@link ResourceBanner}, the same class
-     * {@code SpringApplicationBannerPrinter} uses for {@code banner.txt}, over the same default
-     * properties {@code main()} supplies.
+     * {@code SpringApplicationBannerPrinter} uses for {@code banner.txt}, over the same map
+     * {@code main()} supplies.
+     *
+     * <p>⚠ <b>"The same map" is not "the map main() supplies"</b> — this test builds its own
+     * {@link MapPropertySource} and would pass unchanged if nothing in production ever installed one.
+     * {@link #theStartupWiringInstallsTheProvenanceAsDefaultProperties()} is the half that closes
+     * that; neither is sufficient alone.
      */
     @Test
     void theBannerFirstLineCarriesTheResolvedCommitAndBuildTime() {
@@ -179,18 +208,97 @@ class BuildProvenanceTest {
     }
 
     /**
-     * ⚠ And the banner with <b>no provenance at all</b> — the shape a jar built without
-     * {@code bootBuildInfo} has. It must render {@code unknown}, not a literal {@code ${...}} and not
-     * a hole. Note {@code ${application.version}} is deliberately absent from {@code banner.txt}: it
-     * comes from the jar MANIFEST and renders EMPTY outside a boot jar, so asserting on it here would
-     * be a false red waiting to happen.
+     * ⚠ The banner with the provenance keys <b>entirely absent</b> from the environment. This is
+     * {@code banner.txt}'s own {@code ${...:unknown}} defaults firing, and nothing else — it does not
+     * exercise {@link AcquariumOffchainApp#UNKNOWN} at all. Note {@code ${application.version}} is
+     * deliberately absent from {@code banner.txt}: it comes from the jar MANIFEST and renders EMPTY
+     * outside a boot jar, so asserting on it here would be a false red waiting to happen.
+     *
+     * <p>⛔ The assertion is on the <b>literal word</b>, never on the constant. {@code contains(UNKNOWN)}
+     * says "the banner contains whatever that constant happens to be", which is trivially true the
+     * moment the constant becomes {@code ""} — the exact regression the constant's javadoc forbids.
+     * An assertion that reads its expectation out of the code under test asserts nothing.
      */
     @Test
     void theBannerDegradesToUnknownRatherThanToAHole() {
         String firstLine = renderBanner(Map.of());
         assertFalse(firstLine.contains("${"), "unresolved placeholder with no provenance: " + firstLine);
-        assertTrue(firstLine.contains(AcquariumOffchainApp.UNKNOWN),
+        assertTrue(firstLine.contains("unknown"),
                 "with no build info the banner must SAY unknown: " + firstLine);
+    }
+
+    /**
+     * ⛔ <b>And the production shape of the same failure, which the test above cannot reach.</b>
+     *
+     * <p>A jar built without {@code bootBuildInfo} does not leave the keys absent — {@code main()}
+     * installs {@link AcquariumOffchainApp#buildProvenance()} as default properties, so the keys are
+     * <b>present with whatever that method fell back to</b>. {@code banner.txt}'s {@code ${...:unknown}}
+     * defaults never fire on that path; they only cover a key that is missing. So if the fallback ever
+     * became the empty string, the banner an operator actually reads would render
+     * {@code commit  (dirty=) :: built} — a line with holes in it, reading as "fine" rather than as
+     * "this build cannot say" — while every other test in this class stayed green.
+     *
+     * <p>Rendered over the map produced under the hidden-build-info classloader, and asserted against
+     * the literal word.
+     */
+    @Test
+    void theBannerSaysUnknownWhenTheJarCarriesNoBuildInfo() throws Exception {
+        try (URLClassLoader isolated = hidingBuildInfo()) {
+            Map<String, Object> provenance = provenanceFrom(isolated);
+            String firstLine = renderBanner(provenance);
+
+            assertFalse(firstLine.contains("${"),
+                    "unresolved placeholder with no build info: " + firstLine);
+            assertTrue(firstLine.contains("unknown"),
+                    "with no build info the banner must SAY the word 'unknown'; a present-but-empty "
+                            + "fallback renders a hole that reads as 'fine': " + firstLine);
+            provenance.forEach((key, value) -> assertEquals("unknown", value,
+                    key + " must be the literal word 'unknown' with no build info -- an empty "
+                            + "fallback is present-but-blank, which banner.txt's ${...:unknown} "
+                            + "default cannot rescue because the key is not missing"));
+        }
+    }
+
+    /**
+     * ⛔ <b>THE OTHER DISCONNECTED TEST, and it guards the banner half of this feature.</b>
+     *
+     * <p>Every banner test above renders over a map it built itself. Delete the
+     * {@code setDefaultProperties} call from the startup wiring and all of them stay green, while
+     * every banner an operator ever reads says {@code commit unknown (dirty=unknown) :: built unknown}
+     * — the half of this slice that exists so {@code docker logs} identifies the build, silently off,
+     * with CI reporting success. {@link #theShippedYamlExposesInfo()} does exactly this job for the
+     * {@code /actuator/info} half; this is its counterpart, and its absence was the asymmetry.
+     *
+     * <p>Reached reflectively because {@code configuredApplication()} is package-private in
+     * {@code com.fluidtokens.aquarium.offchain} and this class is not, and because
+     * {@code defaultProperties} has no getter on {@link SpringApplication}. If a future Spring version
+     * renames that field the test goes red loudly rather than passing quietly, which is the correct
+     * direction for a fragile read.
+     */
+    @Test
+    void theStartupWiringInstallsTheProvenanceAsDefaultProperties() throws Exception {
+        Method seam = AcquariumOffchainApp.class.getDeclaredMethod("configuredApplication");
+        seam.setAccessible(true);
+        SpringApplication application = (SpringApplication) seam.invoke(null);
+
+        Object defaults = ReflectionTestUtils.getField(application, "defaultProperties");
+        assertNotNull(defaults,
+                "the startup wiring installed NO default properties at all, so banner.txt's "
+                        + "${aquarium.build.*} placeholders resolve to nothing in production and "
+                        + "every banner reads 'commit unknown (dirty=unknown) :: built unknown'");
+        assertInstanceOf(Map.class, defaults, "SpringApplication.defaultProperties is not a Map: " + defaults);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> installed = (Map<String, Object>) defaults;
+
+        Map<String, Object> expected = AcquariumOffchainApp.buildProvenance();
+        assertEquals(4, expected.size(), "buildProvenance() no longer offers four fields: " + expected.keySet());
+        expected.forEach((key, value) -> {
+            assertTrue(key.startsWith("aquarium.build."), "unexpected provenance key: " + key);
+            assertEquals(value, installed.get(key),
+                    "the default properties the startup wiring installs do not carry " + key
+                            + ", so banner.txt's ${" + key + "} resolves to nothing in production. "
+                            + "Installed: " + installed.keySet());
+        });
     }
 
     private static String renderBanner(Map<String, Object> provenance) {
@@ -217,6 +325,28 @@ class BuildProvenanceTest {
      */
     @Test
     void aMissingBuildInfoFileIsNotAStartupCondition() throws Exception {
+        try (URLClassLoader isolated = hidingBuildInfo()) {
+            Map<String, Object> provenance = provenanceFrom(isolated);
+
+            assertEquals(Set.of("aquarium.build.commit", "aquarium.build.commitShort",
+                            "aquarium.build.dirty", "aquarium.build.time"),
+                    new LinkedHashSet<>(provenance.keySet()),
+                    "with no build info the property set must still be complete -- a missing key "
+                            + "leaves the banner placeholder unresolved");
+            // The literal word, not AcquariumOffchainApp.UNKNOWN: comparing the fallback against the
+            // constant that defines it is a tautology that survives the constant becoming "".
+            provenance.forEach((key, value) -> assertEquals("unknown", value,
+                    key + " must read 'unknown' when there is no build info, never blank and never "
+                            + "'false'"));
+        }
+    }
+
+    /**
+     * A classloader over this JVM's own classpath that answers {@code null} for
+     * {@code build-info.properties}. The file is hidden rather than deleted, so the real one survives
+     * for every other test in this run.
+     */
+    private static URLClassLoader hidingBuildInfo() {
         URL[] classpath = Arrays.stream(System.getProperty("java.class.path").split(java.io.File.pathSeparator))
                 .map(entry -> Paths.get(entry).toUri())
                 .map(uri -> {
@@ -228,7 +358,7 @@ class BuildProvenanceTest {
                 })
                 .toArray(URL[]::new);
 
-        try (URLClassLoader withoutBuildInfo = new URLClassLoader(classpath, ClassLoader.getPlatformClassLoader()) {
+        return new URLClassLoader(classpath, ClassLoader.getPlatformClassLoader()) {
             @Override
             public URL getResource(String name) {
                 return name.endsWith("build-info.properties") ? null : super.getResource(name);
@@ -238,25 +368,17 @@ class BuildProvenanceTest {
             public InputStream getResourceAsStream(String name) {
                 return name.endsWith("build-info.properties") ? null : super.getResourceAsStream(name);
             }
-        }) {
-            Class<?> app = withoutBuildInfo.loadClass(AcquariumOffchainApp.class.getName());
-            assertNotSame(AcquariumOffchainApp.class, app,
-                    "the isolated classloader delegated back to the app loader, so the file was "
-                            + "never actually hidden and this test proves nothing");
+        };
+    }
 
-            @SuppressWarnings("unchecked")
-            Map<String, Object> provenance =
-                    (Map<String, Object>) app.getMethod("buildProvenance").invoke(null);
-
-            assertEquals(Set.of("aquarium.build.commit", "aquarium.build.commitShort",
-                            "aquarium.build.dirty", "aquarium.build.time"),
-                    new LinkedHashSet<>(provenance.keySet()),
-                    "with no build info the property set must still be complete -- a missing key "
-                            + "leaves the banner placeholder unresolved");
-            provenance.forEach((key, value) -> assertEquals(AcquariumOffchainApp.UNKNOWN, value,
-                    key + " must read 'unknown' when there is no build info, never blank and never "
-                            + "'false'"));
-        }
+    /** {@code buildProvenance()} as a jar with no build info would compute it. */
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> provenanceFrom(URLClassLoader isolated) throws Exception {
+        Class<?> app = isolated.loadClass(AcquariumOffchainApp.class.getName());
+        assertNotSame(AcquariumOffchainApp.class, app,
+                "the isolated classloader delegated back to the app loader, so the file was "
+                        + "never actually hidden and this test proves nothing");
+        return (Map<String, Object>) app.getMethod("buildProvenance").invoke(null);
     }
 
     /**

--- a/src/test/java/com/fluidtokens/aquarium/offchain/config/BuildProvenanceTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/config/BuildProvenanceTest.java
@@ -1,0 +1,310 @@
+package com.fluidtokens.aquarium.offchain.config;
+
+import com.fluidtokens.aquarium.offchain.AcquariumOffchainApp;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.ResourceBanner;
+import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.info.InfoContributorAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.info.InfoEndpointAutoConfiguration;
+import org.springframework.boot.actuate.info.InfoEndpoint;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.info.ProjectInfoAutoConfiguration;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * ⛔ <b>Can a running node say what it was built from?</b>
+ *
+ * <h2>The gap this closes</h2>
+ * The CI image tag is {@code date +'%Y.%m.%d'}. <b>Two pushes on the same day produce the same tag
+ * over different code</b>, and until now nothing in the running process could tell them apart: an
+ * operator holding a misbehaving container had no way to name the commit inside it. The tag is still
+ * a date — closing that is a separate ticket — but the process itself now answers, twice over: on
+ * {@code /actuator/info}, and on the first line of the boot banner, so {@code docker logs} read from
+ * the top identifies the build with no HTTP call at all.
+ *
+ * <h2>⚠ The assertion that matters is about a WORD, not a feature</h2>
+ * {@code build.dirty} has <b>three</b> states — {@code true}, {@code false}, {@code unknown} — and
+ * the third one is the reason this class exists. When git cannot be reached (a source tarball, a
+ * Docker context with no {@code .git}, git not installed) the naive implementation takes the empty
+ * fallback, finds it empty, and records {@code dirty=false}. That is not a missing feature; it is
+ * <b>a false statement on an unauthenticated endpoint</b>, and it is false in the direction that
+ * makes an untrustworthy image look trustworthy. Both branches were run for this slice — see the
+ * build.gradle comment on {@code dirty} — and the assertion here is that {@code unknown} is a value
+ * the pipeline can actually carry end to end.
+ *
+ * <h2>Why the last two tests do not touch the container</h2>
+ * Everything above them supplies the exposure property by hand, which means the feature could be
+ * switched off in the shipped {@code application.yaml} and they would all keep passing. So the file
+ * itself is asserted, parsed by Spring's own loader — the {@link ApplicationYamlBindsTest} discipline
+ * applied to a one-word key.
+ */
+class BuildProvenanceTest {
+
+    /** Exactly what {@code src/main/resources/application.yaml} ships. Asserted below, not assumed. */
+    private static final String PRODUCTION_EXPOSURE = "health,prometheus,info";
+
+    /**
+     * The actuator slice of the container. {@code InfoEndpoint} is
+     * {@code @ConditionalOnAvailableEndpoint}, so the exposure property is not decoration here: with
+     * the production value absent, <b>the bean does not exist</b> and every assertion about its
+     * content would be vacuous.
+     */
+    private static ApplicationContextRunner actuator(String exposure) {
+        return new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        ProjectInfoAutoConfiguration.class,
+                        InfoContributorAutoConfiguration.class,
+                        EndpointAutoConfiguration.class,
+                        InfoEndpointAutoConfiguration.class))
+                .withPropertyValues("management.endpoints.web.exposure.include=" + exposure);
+    }
+
+    /**
+     * (a) The provenance actually reached the jar. {@code bootBuildInfo} is in the task graph of both
+     * {@code test} and {@code bootJar}, so a cold clone has this file with no {@code dependsOn}
+     * wiring — if it is ever missing, this is where that is noticed.
+     *
+     * <p>⚠ The commit is asserted as <b>40 hex characters OR exactly {@code unknown}</b>, and not as
+     * "the sha of HEAD": a test that shells out to git to compute its own expectation proves only
+     * that git agrees with git, and goes red on a checkout that has no {@code .git} — a false red on
+     * a legitimate build.
+     */
+    @Test
+    void theJarKnowsWhichCommitItWasBuiltFrom() {
+        actuator(PRODUCTION_EXPOSURE).run(context -> {
+            assertTrue(context.getBeanNamesForType(BuildProperties.class).length == 1,
+                    "no BuildProperties bean: META-INF/build-info.properties did not reach the "
+                            + "classpath, so the running node cannot name its own commit");
+            BuildProperties build = context.getBean(BuildProperties.class);
+            String commit = build.get("commit");
+            assertNotNull(commit, "build.commit was not recorded at all");
+            assertTrue(commit.matches("[0-9a-f]{40}") || AcquariumOffchainApp.UNKNOWN.equals(commit),
+                    "build.commit must be a full 40-char sha or exactly 'unknown', was: " + commit);
+            assertTrue(Set.of("true", "false", AcquariumOffchainApp.UNKNOWN).contains(build.get("dirty")),
+                    "build.dirty must be true, false or unknown -- an empty or absent value reads as "
+                            + "'clean' to anyone skimming, which is the one thing it must never do. "
+                            + "Was: " + build.get("dirty"));
+        });
+    }
+
+    /** (b) With the production exposure, the endpoint exists and serves the build section. */
+    @Test
+    void theInfoEndpointServesTheBuildSection() {
+        actuator(PRODUCTION_EXPOSURE).run(context -> {
+            assertEquals(1, context.getBeanNamesForType(InfoEndpoint.class).length,
+                    "InfoEndpoint is @ConditionalOnAvailableEndpoint and did not appear even with "
+                            + "'info' exposed -- /actuator/info would 404");
+            Map<String, Object> info = context.getBean(InfoEndpoint.class).info();
+            assertTrue(info.containsKey("build"), "no build section on /actuator/info: " + info.keySet());
+            @SuppressWarnings("unchecked")
+            Map<String, Object> build = (Map<String, Object>) info.get("build");
+            assertTrue(build.containsKey("commit"),
+                    "the build section carries no commit, which is the only field an operator "
+                            + "holding two same-day image tags actually needs: " + build.keySet());
+            assertTrue(build.containsKey("dirty"), "the build section carries no dirty flag");
+        });
+    }
+
+    /**
+     * ⛔ And <b>nothing but</b> the build section. This endpoint is unauthenticated on an
+     * operator-run node that holds a funded wallet mnemonic, a Blockfrost key and a database
+     * password; {@code management.info.env.*} would put configuration on it. The mirror-image
+     * assertion against the shipped file is {@link #theShippedYamlEnablesNoOtherInfoContributor()} —
+     * this one proves the default wiring is closed, that one proves the file did not open it.
+     */
+    @Test
+    void theInfoEndpointServesNothingBesidesBuild() {
+        actuator(PRODUCTION_EXPOSURE).run(context -> {
+            Map<String, Object> info = context.getBean(InfoEndpoint.class).info();
+            assertEquals(Set.of("build"), info.keySet(),
+                    "/actuator/info must serve the build section and nothing else; anything extra "
+                            + "here is a value an unauthenticated caller can now read");
+        });
+    }
+
+    /** The control: with 'info' not exposed the bean is genuinely absent, so the test above is not vacuous. */
+    @Test
+    void withoutTheExposureThereIsNoEndpointAtAll() {
+        actuator("health,prometheus").run(context ->
+                assertEquals(0, context.getBeanNamesForType(InfoEndpoint.class).length,
+                        "InfoEndpoint appeared without being exposed -- then the exposure property "
+                                + "proves nothing and the tests above pass whatever the yaml says"));
+    }
+
+    /**
+     * (c) The banner. Rendered through {@link ResourceBanner}, the same class
+     * {@code SpringApplicationBannerPrinter} uses for {@code banner.txt}, over the same default
+     * properties {@code main()} supplies.
+     */
+    @Test
+    void theBannerFirstLineCarriesTheResolvedCommitAndBuildTime() {
+        Map<String, Object> provenance = AcquariumOffchainApp.buildProvenance();
+        String firstLine = renderBanner(provenance);
+
+        assertFalse(firstLine.contains("${"),
+                "an unresolved placeholder survived to the banner: " + firstLine);
+        assertTrue(firstLine.contains(String.valueOf(provenance.get("aquarium.build.commitShort"))),
+                "the banner's first line does not carry the short commit: " + firstLine);
+        assertTrue(firstLine.contains(String.valueOf(provenance.get("aquarium.build.time"))),
+                "the banner's first line does not carry the build time: " + firstLine);
+        assertTrue(firstLine.contains(String.valueOf(provenance.get("aquarium.build.dirty"))),
+                "the banner's first line does not carry the dirty flag: " + firstLine);
+    }
+
+    /**
+     * ⚠ And the banner with <b>no provenance at all</b> — the shape a jar built without
+     * {@code bootBuildInfo} has. It must render {@code unknown}, not a literal {@code ${...}} and not
+     * a hole. Note {@code ${application.version}} is deliberately absent from {@code banner.txt}: it
+     * comes from the jar MANIFEST and renders EMPTY outside a boot jar, so asserting on it here would
+     * be a false red waiting to happen.
+     */
+    @Test
+    void theBannerDegradesToUnknownRatherThanToAHole() {
+        String firstLine = renderBanner(Map.of());
+        assertFalse(firstLine.contains("${"), "unresolved placeholder with no provenance: " + firstLine);
+        assertTrue(firstLine.contains(AcquariumOffchainApp.UNKNOWN),
+                "with no build info the banner must SAY unknown: " + firstLine);
+    }
+
+    private static String renderBanner(Map<String, Object> provenance) {
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().addLast(new MapPropertySource("provenance", provenance));
+        ByteArrayOutputStream rendered = new ByteArrayOutputStream();
+        new ResourceBanner(new ClassPathResource("banner.txt")).printBanner(
+                environment, AcquariumOffchainApp.class,
+                new PrintStream(rendered, true, StandardCharsets.UTF_8));
+        return rendered.toString(StandardCharsets.UTF_8).lines()
+                .filter(line -> !line.isBlank())
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("banner.txt rendered nothing"));
+    }
+
+    /**
+     * ⛔ <b>The node must start with no {@code build-info.properties}.</b> Not "should" — an operator
+     * building from a source export, or any jar assembled without {@code bootBuildInfo}, gets exactly
+     * this classpath. Making the process refuse to boot because it cannot describe itself would turn
+     * a cosmetic gap into an outage.
+     *
+     * <p>The file is hidden with a classloader rather than deleted, so the real one survives for
+     * every other test in this run.
+     */
+    @Test
+    void aMissingBuildInfoFileIsNotAStartupCondition() throws Exception {
+        URL[] classpath = Arrays.stream(System.getProperty("java.class.path").split(java.io.File.pathSeparator))
+                .map(entry -> Paths.get(entry).toUri())
+                .map(uri -> {
+                    try {
+                        return uri.toURL();
+                    } catch (IOException e) {
+                        throw new IllegalStateException(e);
+                    }
+                })
+                .toArray(URL[]::new);
+
+        try (URLClassLoader withoutBuildInfo = new URLClassLoader(classpath, ClassLoader.getPlatformClassLoader()) {
+            @Override
+            public URL getResource(String name) {
+                return name.endsWith("build-info.properties") ? null : super.getResource(name);
+            }
+
+            @Override
+            public InputStream getResourceAsStream(String name) {
+                return name.endsWith("build-info.properties") ? null : super.getResourceAsStream(name);
+            }
+        }) {
+            Class<?> app = withoutBuildInfo.loadClass(AcquariumOffchainApp.class.getName());
+            assertNotSame(AcquariumOffchainApp.class, app,
+                    "the isolated classloader delegated back to the app loader, so the file was "
+                            + "never actually hidden and this test proves nothing");
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> provenance =
+                    (Map<String, Object>) app.getMethod("buildProvenance").invoke(null);
+
+            assertEquals(Set.of("aquarium.build.commit", "aquarium.build.commitShort",
+                            "aquarium.build.dirty", "aquarium.build.time"),
+                    new LinkedHashSet<>(provenance.keySet()),
+                    "with no build info the property set must still be complete -- a missing key "
+                            + "leaves the banner placeholder unresolved");
+            provenance.forEach((key, value) -> assertEquals(AcquariumOffchainApp.UNKNOWN, value,
+                    key + " must read 'unknown' when there is no build info, never blank and never "
+                            + "'false'"));
+        }
+    }
+
+    /**
+     * (d) ⛔ <b>THE DISCONNECTED TEST.</b> Everything above hands the exposure list to the container
+     * by hand. Delete {@code info} from {@code application.yaml} and every one of them still passes
+     * while {@code /actuator/info} 404s in production. So: the shipped file, parsed by Spring's own
+     * loader.
+     */
+    @Test
+    void theShippedYamlExposesInfo() throws IOException {
+        assertEquals(PRODUCTION_EXPOSURE, shippedProperty("management.endpoints.web.exposure.include"),
+                "the shipped application.yaml no longer exposes exactly " + PRODUCTION_EXPOSURE
+                        + ". Dropping 'info' 404s the endpoint with every test in this class still "
+                        + "green; dropping 'prometheus' silently blinds operator monitoring.");
+    }
+
+    /**
+     * ⛔ The other half of the unauthenticated-endpoint invariant: the file must not switch on the
+     * contributors that would publish configuration, the JVM or the host. {@code management.info.env}
+     * in particular would expose environment-derived properties on a node that holds a wallet
+     * mnemonic and a Blockfrost key.
+     */
+    @Test
+    void theShippedYamlEnablesNoOtherInfoContributor() throws IOException {
+        for (PropertySource<?> document : shippedYaml()) {
+            if (document instanceof EnumerablePropertySource<?> enumerable) {
+                for (String name : enumerable.getPropertyNames()) {
+                    assertFalse(name.startsWith("management.info."),
+                            "application.yaml sets '" + name + "'. /actuator/info is unauthenticated "
+                                    + "on an operator-run node: it serves the build section and "
+                                    + "nothing else, deliberately.");
+                }
+            }
+        }
+    }
+
+    /** The shipped file, every document, parsed by Spring's own YAML loader. */
+    private static List<PropertySource<?>> shippedYaml() throws IOException {
+        return new YamlPropertySourceLoader().load("application.yaml",
+                new ClassPathResource("application.yaml"));
+    }
+
+    private static Object shippedProperty(String key) throws IOException {
+        for (PropertySource<?> document : shippedYaml()) {
+            if (document.containsProperty(key)) {
+                return document.getProperty(key);
+            }
+        }
+        throw new AssertionError("no document in application.yaml defines " + key);
+    }
+}


### PR DESCRIPTION
**Replaces #26. My sequencing error, not a code change — the two commits are byte-identical in content to the ones you already approved.**

#26 was based on `slice/FAB-84-1` so its diff would show only its own work. You merged it, and it went **into that branch** rather than into `main` — exactly what a base of `slice/FAB-84-1` means. Meanwhile #25 was **squash-merged**, so `slice/FAB-84-1`'s commits are not ancestors of `main` and the branch could not simply be re-pointed. Net effect: you spent a merge and `main` still has no `banner.txt`, exposure still reads `health,prometheus`, and there are zero `buildInfo` blocks.

This branch is cut fresh from `main` (`7e70b9c`) with those two commits cherry-picked. **Same content, correct target.** #26 should be closed.

## What it does
- `/actuator/info` serves `commit` (full sha), `commitShort`, `dirty` and build time — and **nothing else**. The endpoint is unauthenticated on an operator-run node, so no `env`/`java`/`os` contributor is enabled and a test fails if one appears.
- The **boot banner's first line** carries the same sha and time, so `docker logs` identifies the build without an HTTP call.
- `spring-boot-starter-actuator` is now declared. It was reaching the classpath only as a **third-level transitive of `yaci-store-spring-boot-starter`** — a yaci bump that dropped it would 404 `/actuator/prometheus` with no compile error and no failing test. Declaring it changes nothing: empty resolved-classpath diff on all four configurations.

**Why this matters here:** the image tag is `date +'%Y.%m.%d'`, so two pushes on the same day produce the **same tag over different code**. If the tag cannot identify the build, the running node has to.

## Unavailable is not clean
When git cannot be reached, `commit`, `commitShort` **and `dirty` all read `unknown`** — never `dirty=false`. A build that cannot vouch for its own tree must not instead assert a clean one. A build-time invariant fails if the three ever disagree, and does **not** fail merely because git is unavailable, since all-`unknown` is the correct supported state.

## The finding nobody anticipated
Bare `git` runs repository discovery, and **discovery walks upward**. A tree with no `.git` — a source tarball, a Docker context — inside any enclosing repo was serving the **outer** repo's HEAD and tree state: a valid 40-hex sha naming code the jar was not built from. **Strictly worse than the defect this was written to prevent**, because `commit=unknown, dirty=false` at least contradicts itself. Fixed by requiring `git rev-parse --show-toplevel` to be this project; verified not to over-reach across five environments, including a git worktree and a submodule (`.git` is a *file* there) which both still record the real sha.

## Verification
**138 files / 1087 tests / 0 failures / 0 errors / 45 skipped, zero orphans**, on this re-cut tree. `RESULT_FILE_FLOOR` raised to 138 with its full provenance in the comment — three branches each measured a different tree and each proposed 137. Exactly one jar.

## Known gap, already ticketed (FAB-84)
This feature can be switched **entirely off with the suite green**: all-`unknown` is a legal state, so nothing fails and `:latest` publishes. No unit test closes it — it would only prove git agrees with git. The close is a CI assertion against an independent oracle, `build.commit` vs `${{ github.sha }}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)