### PR TITLE
Park the anticipate live rig behind a gate that says why

### DIFF
--- a/src/test/java/com/fluidtokens/aquarium/offchain/EnvGatedRigReachabilityTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/EnvGatedRigReachabilityTest.java
@@ -107,8 +107,12 @@ class EnvGatedRigReachabilityTest {
      * would quietly re-arm a rig somebody switched off, which then goes red for a reason that is not
      * a code fault and invites exactly the "repair" the park exists to prevent.
      * <p>
-     * Adding an entry here is a decision, not a maintenance step. Removing one is how a rig comes
-     * back.
+     * Adding an entry here is a decision, not a maintenance step. So is removing one — and removing
+     * one is <b>half</b> of how a rig comes back, never the whole of it: the gate on the class is
+     * what actually holds the rig shut, so an entry deleted on its own leaves the rig skipped
+     * forever with its reason gone. Un-parking is one commit that deletes both. {@link
+     * #assertParkListIsIntact()} refuses the half-way state, because the two checks below iterate
+     * this list and an empty list makes them assert nothing.
      */
     private static final List<ParkedRig> PARKED_RIGS = List.of(new ParkedRig(
             "LiquidatePayInAdvanceLiveDryEvalTest",
@@ -254,6 +258,46 @@ class EnvGatedRigReachabilityTest {
     }
 
     /**
+     * ⛔ <b>The harness guard for the two park checks below.</b> Both of them iterate {@link
+     * #PARKED_RIGS}, so an empty list makes them assert <em>nothing</em> while still reporting as
+     * tests that ran and passed: a zero-iteration loop in one, {@code {}} compared with {@code {}}
+     * in the other. Measured: emptying the list leaves the whole suite green and the test count
+     * unchanged.
+     * <p>
+     * That would make the park switchable off by deleting one line, with nothing red anywhere. The
+     * rig would not be un-parked by it — the gate stays on the class, so it skips forever and its
+     * reason is gone — and the env-file half of the check goes silent, so the next developer reads
+     * {@code waiting on AQUARIUM_ANTICIPATE_RIG_CANDIDATE}, adds it to {@code .env.mainnet} (the
+     * exact reflex {@link #aParkedRigStaysParkedAndCannotBeUnparkedByEditingAnEnvFile()} exists to
+     * stop) and the rig goes red on the dead fixture with no objection at any step.
+     * <p>
+     * So the list is pinned in the same shape and for the same reason as {@link
+     * #everyBlockfrostCredentialInTheTestTreeIsOneOfTheKnownNames()}'s {@code sources.size() >= 100}:
+     * <em>a scan that quietly matches nothing passes every assertion built on it.</em> Non-empty,
+     * and still naming the rig FAB-86 parked.
+     */
+    private static void assertParkListIsIntact() {
+        String parkedByFab86 = "LiquidatePayInAdvanceLiveDryEvalTest";
+
+        assertFalse(PARKED_RIGS.isEmpty(),
+                "PARKED_RIGS is empty, so both park checks iterate nothing and pass while asserting "
+                        + "nothing. Emptying this list is NOT how a park is lifted: the gate stays on "
+                        + "the class, the rig skips forever with its reason gone, and the .env.* half "
+                        + "of the guard goes silent. Un-park a rig by deleting its entry AND the gate "
+                        + "on the class in one deliberate commit. If nothing is parked any more, "
+                        + "delete these checks too rather than leaving them behind as no-ops.");
+
+        assertTrue(PARKED_RIGS.stream().anyMatch(p -> p.className().equals(parkedByFab86)),
+                "PARKED_RIGS no longer names " + parkedByFab86 + ", the rig parked by FAB-86, so the "
+                        + "checks below no longer cover it. Dropping the entry is NOT how that park is "
+                        + "lifted: its AQUARIUM_ANTICIPATE_RIG_CANDIDATE gate would stay on the class "
+                        + "— skipped forever, reason gone — and nothing would then stop .env.mainnet "
+                        + "defining that gate and silently re-arming it on a dead fixture. If the "
+                        + "ruling really was reversed, remove the gate from the class in the same "
+                        + "commit and record here what reversed it.");
+    }
+
+    /**
      * A park is only a park while both halves hold: the gate is still on the class, and no
      * {@code .env.*} file supplies it.
      * <p>
@@ -266,6 +310,8 @@ class EnvGatedRigReachabilityTest {
      */
     @Test
     void aParkedRigStaysParkedAndCannotBeUnparkedByEditingAnEnvFile() {
+        assertParkListIsIntact();
+
         for (ParkedRig parked : PARKED_RIGS) {
             assertTrue(gateNames(read(testSource(parked.className()))).contains(parked.gate()),
                     parked.className() + " no longer carries its park gate " + parked.gate()
@@ -290,9 +336,18 @@ class EnvGatedRigReachabilityTest {
     }
 
     /**
-     * ⚠ <b>The exemption must stay narrow.</b> {@link #PARKED_RIGS} excuses named classes from being
-     * reachable, and an exemption that quietly covers a second rig is how a real defect gets filed
-     * under a past decision. So the list and the tree must agree <b>in both directions</b>: every
+     * ⚠ <b>The list must match the tree exactly.</b> {@link #PARKED_RIGS} excuses a class from
+     * nothing: {@link #sourcingTheNetworkEnvFileEnablesEveryRigThatTalksToThatNetwork()} is
+     * credential-scoped and never sees a park gate, so a listed class is still held to the same
+     * reachability rule as every other rig — measured: with the mainnet key absent from
+     * {@code .env.mainnet}, that check names the parked rig alongside the others exactly as before.
+     * The list only <b>adds</b> constraints (a park must be a real gate, on the named class, absent
+     * from every {@code .env.*} file), which is why deleting an entry weakens the tree rather than
+     * un-parking anything — see {@link #assertParkListIsIntact()}.
+     * <p>
+     * What has to stay narrow is the reverse direction: a list that quietly covers a second rig is
+     * how a real defect gets filed under a past decision. So the list and the tree must agree
+     * <b>in both directions</b>: every
      * listed class carries a park gate, and every class carrying a listed park gate is on the list.
      * Broadening the list to a class that is not parked fails here; copying a park gate onto another
      * rig without listing it fails here too.
@@ -304,6 +359,8 @@ class EnvGatedRigReachabilityTest {
      */
     @Test
     void theParkExemptionCoversExactlyTheClassesThatCarryAParkGate() {
+        assertParkListIsIntact();
+
         Set<String> listed = new TreeSet<>();
         Set<String> parkGates = new TreeSet<>();
         for (ParkedRig parked : PARKED_RIGS) {
@@ -392,7 +449,7 @@ class EnvGatedRigReachabilityTest {
 
     /**
      * And admitting the qualifier must not have cost the plain form. A qualifier made
-     * <em>mandatory</em> — {@code +} where the pattern has {@code *} — would miss all 43 plain
+     * <em>mandatory</em> — {@code +} where the pattern has {@code *} — would miss all 44 plain
      * occurrences in this tree while still satisfying the check above. The rig-level checks would
      * not notice for {@code ConvertLiveDryEvalTest}, because it also reads its credential with
      * {@code System.getenv}; only a gate-only assertion does.

--- a/src/test/java/com/fluidtokens/aquarium/offchain/EnvGatedRigReachabilityTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/EnvGatedRigReachabilityTest.java
@@ -347,10 +347,9 @@ class EnvGatedRigReachabilityTest {
      * <p>
      * What has to stay narrow is the reverse direction: a list that quietly covers a second rig is
      * how a real defect gets filed under a past decision. So the list and the tree must agree
-     * <b>in both directions</b>: every
-     * listed class carries a park gate, and every class carrying a listed park gate is on the list.
-     * Broadening the list to a class that is not parked fails here; copying a park gate onto another
-     * rig without listing it fails here too.
+     * <b>in both directions</b>: every listed class carries a park gate, and every class carrying a
+     * listed park gate is on the list. Broadening the list to a class that is not parked fails here;
+     * copying a park gate onto another rig without listing it fails here too.
      * <p>
      * And a park gate may never be <em>named</em> like a credential. That is the whole point of the
      * shape: the run summary prints the gate names it finds, so a park called

--- a/src/test/java/com/fluidtokens/aquarium/offchain/EnvGatedRigReachabilityTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/EnvGatedRigReachabilityTest.java
@@ -21,6 +21,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -84,13 +85,47 @@ class EnvGatedRigReachabilityTest {
     /** Anything named like a Blockfrost credential. Deliberately wider than the pinned set above. */
     private static final Pattern BLOCKFROST_CREDENTIAL = Pattern.compile("BLOCKFROST[A-Z0-9_]*KEY");
 
+    /** One rig switched off on purpose: the class, the gate that parks it, and why. */
+    private record ParkedRig(String className, String gate, String reason) {
+    }
+
+    /**
+     * ⛔ <b>The parked rigs — unreachable ON PURPOSE, named one by one.</b>
+     * <p>
+     * The checks in this class answer "can a developer reach this rig by following CLAUDE.md". For a
+     * rig that has been deliberately switched off, the honest answer is <em>no, and that is the
+     * decision</em> — but "unreachable by accident" and "unreachable on purpose" look identical from
+     * the outside, and the first is a defect while the second is a ruling. This list is where the
+     * difference is written down, by name, with its reason attached.
+     * <p>
+     * A park is expressed as a <b>second class-level gate whose name is not a credential</b>, so the
+     * CI run summary reports the rig as waiting on that gate rather than on a key it will never be
+     * handed — see {@link #theParkExemptionCoversExactlyTheClassesThatCarryAParkGate()}, which
+     * refuses a park named like a credential. The park gate is deliberately <b>absent</b> from every
+     * {@code .env.*} file, and {@link
+     * #aParkedRigStaysParkedAndCannotBeUnparkedByEditingAnEnvFile()} keeps it absent: adding it there
+     * would quietly re-arm a rig somebody switched off, which then goes red for a reason that is not
+     * a code fault and invites exactly the "repair" the park exists to prevent.
+     * <p>
+     * Adding an entry here is a decision, not a maintenance step. Removing one is how a rig comes
+     * back.
+     */
+    private static final List<ParkedRig> PARKED_RIGS = List.of(new ParkedRig(
+            "LiquidatePayInAdvanceLiveDryEvalTest",
+            "AQUARIUM_ANTICIPATE_RIG_CANDIDATE",
+            "FAB-86, ruling of 2026-09-10 — parked, not broken: the loan it is pinned to was "
+                    + "liquidated by this bot, so the reference input and the wallet's USDM are gone "
+                    + "and the rig's 3 failures are a stale fixture rather than a code fault. It comes "
+                    + "back only with a live liquidatable loan big enough to exercise wallet sizing, "
+                    + "the balance check and POOL_TOO_THIN — see the class javadoc"));
+
     /**
      * The qualifier is optional on purpose: {@code @EnabledIfEnvironmentVariable} and
      * {@code @org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable} are the same annotation,
      * and both are in this tree. Anchoring {@code @} straight to the simple name made the second form
      * invisible — a gated rig that this class could not see and that CI reported as "waiting on
-     * disabled". Keep {@code *}, not {@code +}: of the 44 annotation usages in this tree, across 23
-     * classes, 43 carry no qualifier and exactly one is fully qualified.
+     * disabled". Keep {@code *}, not {@code +}: of the 45 annotation usages in this tree, across 23
+     * classes, 44 carry no qualifier and exactly one is fully qualified.
      */
     private static final Pattern GATE =
             Pattern.compile("@(?:[A-Za-z_][A-Za-z0-9_]*\\.)*EnabledIfEnvironmentVariable"
@@ -147,6 +182,15 @@ class EnvGatedRigReachabilityTest {
      * ⚠ <b>The A3 check.</b> Sourcing {@code .env.<network>} must be enough to make every rig that
      * talks to that network actually run. A rig whose gate names a variable the file does not define
      * skips, and a skip reads as "not failing".
+     * <p>
+     * <b>Scope:</b> this measures <em>credentials</em> — the things a developer is entitled to have
+     * and the {@code .env.*} files exist to supply. It deliberately says nothing about the
+     * opt-in gates ({@code AQUARIUM_*}, {@code SUBMITTABLE_NETWORK}, {@code BUILD_STAKE_REG} …) that
+     * several rigs also carry: those are switches a human is supposed to throw one run at a time,
+     * and a credential file that pre-threw them would be a bug. A rig held shut by one of those is
+     * therefore invisible here — which is fine when the switch is an opt-in and <em>not</em> fine
+     * when it is a park, because a park is permanent. Parks are named in {@link #PARKED_RIGS} and
+     * checked by the two tests below.
      */
     @Test
     void sourcingTheNetworkEnvFileEnablesEveryRigThatTalksToThatNetwork() {
@@ -187,6 +231,12 @@ class EnvGatedRigReachabilityTest {
      * happens to be in the environment (a preview key, if {@code .env.preview} was sourced) at
      * mainnet, which is the HTTP 403 that reads as a code failure. This pins the separation so the
      * wrong fix cannot grow back quietly.
+     * <p>
+     * ⚠ Read this as a statement about the <b>key</b> only. Since FAB-86,
+     * {@code LiquidatePayInAdvanceLiveDryEvalTest} is also parked (see {@link #PARKED_RIGS}), so
+     * sourcing {@code .env.mainnet} runs {@code ConvertLiveDryEvalTest} and not the other one. The
+     * assertions below stay as they are on purpose: the park must not become an excuse for the
+     * mainnet key separation to rot while the rig is off.
      */
     @Test
     void theMainnetDryEvalRigsGateOnTheMainnetSpecificKey() {
@@ -201,6 +251,84 @@ class EnvGatedRigReachabilityTest {
                             + "per network is what keeps a preview key from being pointed at mainnet");
             assertEquals(Set.of("mainnet"), rig.networks(), className + " must talk to mainnet only");
         }
+    }
+
+    /**
+     * A park is only a park while both halves hold: the gate is still on the class, and no
+     * {@code .env.*} file supplies it.
+     * <p>
+     * The second half is the one with teeth. When {@link
+     * #sourcingTheNetworkEnvFileEnablesEveryRigThatTalksToThatNetwork()} reports a rig as
+     * unreachable, the reflex fix is to add the missing variable to the credential file — that was
+     * the correct fix once and it is the wrong one here, because it re-arms a rig that was switched
+     * off deliberately. The rig then fails on a fixture nobody meant to restore, and the next
+     * reader "repairs" it. Nothing else in this tree would notice, so it is pinned here.
+     */
+    @Test
+    void aParkedRigStaysParkedAndCannotBeUnparkedByEditingAnEnvFile() {
+        for (ParkedRig parked : PARKED_RIGS) {
+            assertTrue(gateNames(read(testSource(parked.className()))).contains(parked.gate()),
+                    parked.className() + " no longer carries its park gate " + parked.gate()
+                            + ". If it was deliberately brought back, delete its PARKED_RIGS entry in "
+                            + "the same commit: an entry left behind is a standing exemption for a rig "
+                            + "nobody is parking any more. Reason on record — " + parked.reason());
+
+            for (String network : List.of("mainnet", "preview")) {
+                Path envFile = repoRoot().resolve(".env." + network);
+                if (!Files.exists(envFile)) {
+                    continue; // CI holds no .env.* files, by design: nothing to cross-check here
+                }
+                assertFalse(effectivelyDefinedNames(envFile).contains(parked.gate()),
+                        ".env." + network + " now defines " + parked.gate() + ", which silently "
+                                + "un-parks " + parked.className() + ": sourcing that file would run a "
+                                + "rig that was switched off on purpose, and it would go red for "
+                                + "something that is not a code fault. Un-park it by deleting the "
+                                + "PARKED_RIGS entry and the gate, deliberately — not by editing a "
+                                + "credential file. Reason on record — " + parked.reason());
+            }
+        }
+    }
+
+    /**
+     * ⚠ <b>The exemption must stay narrow.</b> {@link #PARKED_RIGS} excuses named classes from being
+     * reachable, and an exemption that quietly covers a second rig is how a real defect gets filed
+     * under a past decision. So the list and the tree must agree <b>in both directions</b>: every
+     * listed class carries a park gate, and every class carrying a listed park gate is on the list.
+     * Broadening the list to a class that is not parked fails here; copying a park gate onto another
+     * rig without listing it fails here too.
+     * <p>
+     * And a park gate may never be <em>named</em> like a credential. That is the whole point of the
+     * shape: the run summary prints the gate names it finds, so a park called
+     * {@code BLOCKFROST_SOMETHING_KEY} would be reported as a rig waiting for a key it will never be
+     * handed — indistinguishable from the credential skip this class exists to make visible.
+     */
+    @Test
+    void theParkExemptionCoversExactlyTheClassesThatCarryAParkGate() {
+        Set<String> listed = new TreeSet<>();
+        Set<String> parkGates = new TreeSet<>();
+        for (ParkedRig parked : PARKED_RIGS) {
+            assertTrue(listed.add(parked.className()),
+                    "PARKED_RIGS lists " + parked.className() + " twice: two reasons for one park "
+                            + "means one of them is not being read");
+            assertFalse(BLOCKFROST_CREDENTIAL.matcher(parked.gate()).matches(),
+                    "the park gate " + parked.gate() + " is named like a Blockfrost credential, so "
+                            + "the run summary would report " + parked.className() + " as waiting on "
+                            + "a key rather than as parked — the very confusion the second-gate shape "
+                            + "exists to remove. Name it for what is actually missing.");
+            parkGates.add(parked.gate());
+        }
+
+        Set<String> carrying = new TreeSet<>();
+        for (Path source : testSources()) {
+            if (gateNames(read(source)).stream().anyMatch(parkGates::contains)) {
+                carrying.add(source.getFileName().toString().replace(".java", ""));
+            }
+        }
+
+        assertEquals(listed, carrying,
+                "PARKED_RIGS and the test tree disagree about which rigs are parked. A listed class "
+                        + "that carries no park gate is an exemption covering a rig nobody switched "
+                        + "off; an unlisted class carrying one is a park with no reason written down.");
     }
 
     /**

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidatePayInAdvanceLiveDryEvalTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidatePayInAdvanceLiveDryEvalTest.java
@@ -90,8 +90,46 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * It proves the scripts pass — phase 2, the failure that forfeits collateral — for the token-principal
  * shape, for real, against both real oracles. It says nothing about the ledger's phase 1 (fees,
  * min-ada, witness sets, collateral adequacy — CCL trap 11).
+ *
+ * <h2>⛔ PARKED — FAB-86, ruling of 2026-09-10. The failures are the FIXTURE'S ABSENCE.</h2>
+ * <ol>
+ *   <li>The candidate pinned below, loan {@code 279499ff77d9c8efacda5940a06659f091e1aaa15ce929f779d8d3fd},
+ *       <b>was liquidated by this very bot</b> as {@code fa16e8eb0376…} in block 13,921,999. The loan
+ *       reference input {@code 0d080eb2…#1} is no longer in the live UTxO set, and {@link #BOT_WALLET}
+ *       no longer carries the USDM because the bot spent it in that same liquidation.</li>
+ *   <li>So with {@code BLOCKFROST_MAINNET_KEY} set this class was 3 tests / 3 failures — a <b>stale
+ *       fixture, not a code fault</b>. Mainnet is healthy and the bot is live and armed. <b>Do not
+ *       "repair" these failures</b>: there is nothing here to fix, and re-pinning to whatever loan
+ *       happens to be liquidatable today is the wrong reflex (see below).</li>
+ *   <li>Re-enabling it takes a live liquidatable loan <em>of a scale that actually exercises</em>
+ *       wallet sizing, the balance check and {@code POOL_TOO_THIN}. The only other USDM loan on chain
+ *       today is <b>10 USDM at 71% LTV</b> and exercises none of the three — a green rig that proves
+ *       nothing is worse than a disabled one. The durable answer is the offline synthetic-oracle rig,
+ *       which is FAB-86's own future work and deliberately not this change.</li>
+ * </ol>
+ * The coordinates below are left pinned to the dead loan on purpose: they are the record of what was
+ * last proven on mainnet, so re-enabling means replacing them consciously rather than inheriting them.
+ *
+ * <h3>Why a second gate rather than {@code @Disabled}</h3>
+ * The CI run summary lists, for every class that did not run, the environment variables it was waiting
+ * for. Under {@code @Disabled} this class would still scan as <em>"waiting on BLOCKFROST_MAINNET_KEY"</em>
+ * — a deliberate park reported as a rig waiting for a credential, which is exactly the
+ * skip-that-reads-as-a-pass this repo has already been bitten by. A second gate named
+ * {@code AQUARIUM_ANTICIPATE_RIG_CANDIDATE} makes the summary line read
+ * <em>"waiting on AQUARIUM_ANTICIPATE_RIG_CANDIDATE, BLOCKFROST_MAINNET_KEY"</em>: self-describing, and
+ * credential-independent by construction. The variable is deliberately <b>not</b> defined in
+ * {@code .env.mainnet} — defining it would re-enable the rig and undo the ruling — which is why
+ * {@code EnvGatedRigReachabilityTest} carries a narrow, named exemption for this one class.
  */
 @EnabledIfEnvironmentVariable(named = "BLOCKFROST_MAINNET_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "AQUARIUM_ANTICIPATE_RIG_CANDIDATE", matches = ".+",
+        disabledReason = "FAB-86, parked 2026-09-10: the pinned candidate 279499ff was liquidated by "
+                + "this bot as fa16e8eb in block 13,921,999, so the loan reference input and the "
+                + "wallet's USDM are both gone. The 3 failures are a STALE FIXTURE, not a code fault "
+                + "— do not repair them. Re-enable only with a live liquidatable loan large enough to "
+                + "exercise wallet sizing, the balance check and POOL_TOO_THIN; the only other USDM "
+                + "loan today (10 USDM at 71% LTV) exercises none of them, and a green rig that "
+                + "proves nothing is worse than a disabled one.")
 class LiquidatePayInAdvanceLiveDryEvalTest {
 
     private static final String URL = "https://cardano-mainnet.blockfrost.io/api/v0/";


### PR DESCRIPTION
The mainnet pay-in-advance rig is pinned to loan `279499ff…`, **which our own bot then liquidated** as `fa16e8eb0376…` in block 13,921,999. Its fixture no longer exists, so with the mainnet key present it is 3/3 red. **That is a stale fixture, not a code fault.** Mainnet is healthy; the bot is LIVE, armed, and has submitted nothing since.

Giovanni's ruling: disable it for now, ticket the re-enable. Not deleted, not re-pinned — the only other USDM loan is 10 USDM at 71% LTV and would exercise neither wallet sizing, nor the balance check, nor `POOL_TOO_THIN`. **A green rig that proves nothing is worse than a disabled one.**

## Why a second gate rather than `@Disabled`
`@Disabled` would have reintroduced the exact ambiguity #25 just closed. Step 3b's `gates_of()` would still find `BLOCKFROST_MAINNET_KEY` and print `waiting on BLOCKFROST_MAINNET_KEY` — reporting a deliberate park as a rig waiting for a credential.

So the rig carries a second, self-describing gate, `AQUARIUM_ANTICIPATE_RIG_CANDIDATE`, and the CI summary reads:

```
- `…LiquidatePayInAdvanceLiveDryEvalTest` (3) - waiting on AQUARIUM_ANTICIPATE_RIG_CANDIDATE, BLOCKFROST_MAINNET_KEY
```

A reader sees it wants a **candidate**, not a **key**.

⚑ **This shape turned out to be load-bearing for a reason nobody knew when it was chosen.** `disabledReason` **never reaches the JUnit XML** — Gradle's writer drops it, leaving a bare `<skipped/>`. So the only thing an operator ever reads is the gate *name*. `@Disabled("reason")` would have put the explanation somewhere nothing surfaces. **A skip reason that exists only in an annotation is invisible to the artefact that gets read.**

## The guard against the reflex fix
The reflex response to an unreachable rig is to add the variable to `.env.mainnet` — which here would silently **un-park** it onto the dead fixture. `aParkedRigStaysParkedAndCannotBeUnparkedByEditingAnEnvFile` fails if any `.env.*` defines the park gate.

## The finding that sent round 1 back
The guard **switched off by deleting one list entry, with the whole suite green** — both park tests iterated `PARKED_RIGS`, so an empty list made them assert nothing while still counting as passing tests. The remedy was already written five methods above in the same class (`sources.size() >= 100`), for exactly this reason: *a source scan that quietly matches nothing passes every assertion built on it.* Both tests now call a harness guard first, and the javadoc that **invited** the deletion has been corrected.

## Verification
**138 files / 1089 tests / 0 failures / 0 errors / 45 skipped, zero orphans**, floor matching exactly.

Keyed, the park holds **with its control**: the parked rig skips 3/3 (`time=0.001`, it does not run) while the sibling `ConvertLiveDryEvalTest` runs against mainnet in the same invocation — without that control, "skipped" would prove nothing. A positive control confirms the skip is produced by this gate at runtime: revert the rig file and the class runs again.

Eleven mutants in the audit, ten killed, each by the test whose *name* claims the property.

Re-enable criteria and the durable alternative — an offline synthetic-oracle rig that needs no live candidate — are in FAB-86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)