### PR TITLE
Park the two remaining stale rigs, one gate each

### DIFF
--- a/src/test/java/com/fluidtokens/aquarium/offchain/EnvGatedRigReachabilityTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/EnvGatedRigReachabilityTest.java
@@ -161,6 +161,13 @@ class EnvGatedRigReachabilityTest {
      * Un-parking is still allowed, and it is still one deliberate commit: delete the
      * {@link ParkedRig} entry, delete the gate from the class, and delete the name here — and if the
      * name here is the last one, delete the park checks too rather than leaving them as no-ops.
+     * <p>
+     * ⚠ There may be a FOURTH edit, and it will not look related.
+     * {@code theAnnotationScanAloneSeesTheFullyQualifiedGateForm} hard-codes the expected gate set for
+     * {@code RealLoanDryEvalTest}, so removing that rig's park gate makes it fail too. That coupling is
+     * deliberate — it is what keeps the scan's exactness load-bearing rather than incidental — but to
+     * whoever lifts the park it reads as an unrelated mystery failure. It is not; update the expected
+     * set in the same commit.
      */
     private static final Set<String> EVERY_RIG_EVER_PARKED = new TreeSet<>(List.of(
             "LiquidatePayInAdvanceLiveDryEvalTest",  // FAB-86-1, 2026-09-10
@@ -425,7 +432,14 @@ class EnvGatedRigReachabilityTest {
                             + "the run summary would report " + parked.className() + " as waiting on "
                             + "a key rather than as parked — the very confusion the second-gate shape "
                             + "exists to remove. Name it for what is actually missing.");
-            parkGates.add(parked.gate());
+            assertTrue(parkGates.add(parked.gate()),
+                    "PARKED_RIGS gives " + parked.className() + " the gate " + parked.gate()
+                            + ", which another parked rig already uses. Two rigs behind ONE gate is a "
+                            + "single switch for two unrelated expiries: setting that variable to "
+                            + "revive one silently re-arms the other on a fixture nobody looked at, "
+                            + "and it then goes red for a reason that is not a code fault — which is "
+                            + "the exact repair-reflex this mechanism exists to stop. Give each park "
+                            + "its own name.");
         }
 
         Set<String> carrying = new TreeSet<>();

--- a/src/test/java/com/fluidtokens/aquarium/offchain/EnvGatedRigReachabilityTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/EnvGatedRigReachabilityTest.java
@@ -98,10 +98,21 @@ class EnvGatedRigReachabilityTest {
      * the outside, and the first is a defect while the second is a ruling. This list is where the
      * difference is written down, by name, with its reason attached.
      * <p>
-     * A park is expressed as a <b>second class-level gate whose name is not a credential</b>, so the
+     * A park is expressed as a <b>second gate whose name is not a credential</b>, so the
      * CI run summary reports the rig as waiting on that gate rather than on a key it will never be
      * handed — see {@link #theParkExemptionCoversExactlyTheClassesThatCarryAParkGate()}, which
-     * refuses a park named like a credential. The park gate is deliberately <b>absent</b> from every
+     * refuses a park named like a credential.
+     * <p>
+     * <b>Class-level or method-level is decided by what actually expired</b>, and the answer is not
+     * always the class. {@code RealLoanDryEvalTest} has one method that touches the chain and ten
+     * that are cold pinned literals; a class-level gate there would switch off ten green
+     * verifications to park one stale fixture, and ten verifications that stop running produce no
+     * failure — they produce silence that looks like a pass. So its park sits on the method.
+     * Nothing below depends on the distinction: {@link #gateNames(String)} scans the source text,
+     * not the declaration it is attached to, and so does the run summary's copy of the same pattern.
+     * Park the smallest thing that is actually stale.
+     * <p>
+     * The park gate is deliberately <b>absent</b> from every
      * {@code .env.*} file, and {@link
      * #aParkedRigStaysParkedAndCannotBeUnparkedByEditingAnEnvFile()} keeps it absent: adding it there
      * would quietly re-arm a rig somebody switched off, which then goes red for a reason that is not
@@ -114,22 +125,55 @@ class EnvGatedRigReachabilityTest {
      * #assertParkListIsIntact()} refuses the half-way state, because the two checks below iterate
      * this list and an empty list makes them assert nothing.
      */
-    private static final List<ParkedRig> PARKED_RIGS = List.of(new ParkedRig(
-            "LiquidatePayInAdvanceLiveDryEvalTest",
-            "AQUARIUM_ANTICIPATE_RIG_CANDIDATE",
-            "FAB-86, ruling of 2026-09-10 — parked, not broken: the loan it is pinned to was "
-                    + "liquidated by this bot, so the reference input and the wallet's USDM are gone "
-                    + "and the rig's 3 failures are a stale fixture rather than a code fault. It comes "
-                    + "back only with a live liquidatable loan big enough to exercise wallet sizing, "
-                    + "the balance check and POOL_TOO_THIN — see the class javadoc"));
+    private static final List<ParkedRig> PARKED_RIGS = List.of(
+            new ParkedRig(
+                    "LiquidatePayInAdvanceLiveDryEvalTest",
+                    "AQUARIUM_ANTICIPATE_RIG_CANDIDATE",
+                    "FAB-86, ruling of 2026-09-10 — parked, not broken: the loan it is pinned to was "
+                            + "liquidated by this bot, so the reference input and the wallet's USDM are gone "
+                            + "and the rig's 3 failures are a stale fixture rather than a code fault. It comes "
+                            + "back only with a live liquidatable loan big enough to exercise wallet sizing, "
+                            + "the balance check and POOL_TOO_THIN — see the class javadoc"),
+            new ParkedRig(
+                    "MainnetCompoundEscrowTest",
+                    "AQUARIUM_COMPOUND_RIG_POOL_MANAGER",
+                    "FAB-86, ruling of 2026-09-10 — parked, not broken: the mainnet pool manager NFT "
+                            + "it pins is held by no address any more, so the live compoudingFeePerMille "
+                            + "that is the whole point of the class cannot be read. Stale fixture, not a "
+                            + "code fault. It comes back with a live mainnet pool manager and its unit "
+                            + "written into the class — see the class javadoc"),
+            new ParkedRig(
+                    "RealLoanDryEvalTest",
+                    "AQUARIUM_REAL_LOAN_RIG_CANDIDATE",
+                    "FAB-86, ruling of 2026-09-10 — parked, not broken: the preview loan its ONE live "
+                            + "method is pinned to has left the UTxO set, so that method fails at 'loan "
+                            + "utxo spent'. Stale fixture, not a code fault. ⚠ The park here is "
+                            + "METHOD-level, not class-level: the other ten tests in this class are cold "
+                            + "literals that must keep running — see the class javadoc"));
+
+    /**
+     * ⛔ <b>Every rig this repo has ever parked, hard-named.</b> {@link #assertParkListIsIntact()}
+     * compares this with {@link #PARKED_RIGS} for exact equality, so <em>removing any single entry
+     * from the list above fails</em>. Naming only one of them — as this guard did while one rig was
+     * parked — would let a list of three be emptied down to that one with both park checks still
+     * reporting green over an almost-empty loop.
+     * <p>
+     * Un-parking is still allowed, and it is still one deliberate commit: delete the
+     * {@link ParkedRig} entry, delete the gate from the class, and delete the name here — and if the
+     * name here is the last one, delete the park checks too rather than leaving them as no-ops.
+     */
+    private static final Set<String> EVERY_RIG_EVER_PARKED = new TreeSet<>(List.of(
+            "LiquidatePayInAdvanceLiveDryEvalTest",  // FAB-86-1, 2026-09-10
+            "MainnetCompoundEscrowTest",             // FAB-86-2, 2026-09-10
+            "RealLoanDryEvalTest"));                 // FAB-86-2, 2026-09-10
 
     /**
      * The qualifier is optional on purpose: {@code @EnabledIfEnvironmentVariable} and
      * {@code @org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable} are the same annotation,
      * and both are in this tree. Anchoring {@code @} straight to the simple name made the second form
      * invisible — a gated rig that this class could not see and that CI reported as "waiting on
-     * disabled". Keep {@code *}, not {@code +}: of the 45 annotation usages in this tree, across 23
-     * classes, 44 carry no qualifier and exactly one is fully qualified.
+     * disabled". Keep {@code *}, not {@code +}: of the 47 annotation usages in this tree, across 23
+     * classes, 46 carry no qualifier and exactly one is fully qualified.
      */
     private static final Pattern GATE =
             Pattern.compile("@(?:[A-Za-z_][A-Za-z0-9_]*\\.)*EnabledIfEnvironmentVariable"
@@ -274,11 +318,18 @@ class EnvGatedRigReachabilityTest {
      * So the list is pinned in the same shape and for the same reason as {@link
      * #everyBlockfrostCredentialInTheTestTreeIsOneOfTheKnownNames()}'s {@code sources.size() >= 100}:
      * <em>a scan that quietly matches nothing passes every assertion built on it.</em> Non-empty,
-     * and still naming the rig FAB-86 parked.
+     * and naming <b>every</b> rig ever parked.
+     * <p>
+     * ⚠ <b>Non-empty is not enough once more than one rig is parked</b>, and hard-naming <em>one</em>
+     * of them is not either. With three entries, deleting two still leaves a list that is non-empty
+     * and still contains the one hard-named rig — so both park checks would run one iteration,
+     * report green, and cover a third of what they are supposed to cover. A partial deletion is the
+     * likelier accident than a total one: it is what a merge resolution or a half-finished un-park
+     * leaves behind, and it looks exactly like the healthy state from the outside. So the guard is
+     * an <b>exact set comparison</b> against {@link #EVERY_RIG_EVER_PARKED}: one entry short fails,
+     * and the failure names the missing rig.
      */
     private static void assertParkListIsIntact() {
-        String parkedByFab86 = "LiquidatePayInAdvanceLiveDryEvalTest";
-
         assertFalse(PARKED_RIGS.isEmpty(),
                 "PARKED_RIGS is empty, so both park checks iterate nothing and pass while asserting "
                         + "nothing. Emptying this list is NOT how a park is lifted: the gate stays on "
@@ -287,14 +338,17 @@ class EnvGatedRigReachabilityTest {
                         + "on the class in one deliberate commit. If nothing is parked any more, "
                         + "delete these checks too rather than leaving them behind as no-ops.");
 
-        assertTrue(PARKED_RIGS.stream().anyMatch(p -> p.className().equals(parkedByFab86)),
-                "PARKED_RIGS no longer names " + parkedByFab86 + ", the rig parked by FAB-86, so the "
-                        + "checks below no longer cover it. Dropping the entry is NOT how that park is "
-                        + "lifted: its AQUARIUM_ANTICIPATE_RIG_CANDIDATE gate would stay on the class "
-                        + "— skipped forever, reason gone — and nothing would then stop .env.mainnet "
-                        + "defining that gate and silently re-arming it on a dead fixture. If the "
-                        + "ruling really was reversed, remove the gate from the class in the same "
-                        + "commit and record here what reversed it.");
+        Set<String> listed = new TreeSet<>();
+        PARKED_RIGS.forEach(p -> listed.add(p.className()));
+        assertEquals(EVERY_RIG_EVER_PARKED, listed,
+                "PARKED_RIGS no longer names exactly the rigs this repo has parked, so the two checks "
+                        + "below cover less than they are meant to — and a shortened list is still "
+                        + "non-empty, so nothing else would object. Dropping an entry is NOT how a "
+                        + "park is lifted: the gate would stay on the class — skipped forever, reason "
+                        + "gone — and nothing would then stop a .env.* file defining that gate and "
+                        + "silently re-arming the rig on a dead fixture. If a ruling really was "
+                        + "reversed, remove the gate from the class and the name from "
+                        + "EVERY_RIG_EVER_PARKED in the same commit, and record what reversed it.");
     }
 
     /**
@@ -429,6 +483,13 @@ class EnvGatedRigReachabilityTest {
      * <p>
      * So this asserts on {@link #gateNames(String)} — the annotation pattern by itself, with no
      * getenv fallback available to rescue it.
+     * <p>
+     * ⚠ Since FAB-86 the expected set has <b>two</b> names: the class's one live method is parked
+     * behind a second gate written in the <em>plain</em> form (see {@link #PARKED_RIGS}). That makes
+     * the <b>exactness</b> of the comparison load-bearing rather than incidental — a scan that had
+     * gone blind to the qualified form would now return {@code {AQUARIUM_REAL_LOAN_RIG_CANDIDATE}}
+     * instead of the empty set, so "non-empty" would accept the very defect this test exists to
+     * catch. Keep {@code assertEquals} on the full set; never weaken it to a {@code contains}.
      */
     @Test
     void theAnnotationScanAloneSeesTheFullyQualifiedGateForm() {
@@ -440,7 +501,7 @@ class EnvGatedRigReachabilityTest {
                         + "carries it now — do not delete the assertion, or the scan can go blind to "
                         + "the form again with nothing left to detect it.");
 
-        assertEquals(Set.of("BLOCKFROST_KEY"), gateNames(text),
+        assertEquals(Set.of("BLOCKFROST_KEY", "AQUARIUM_REAL_LOAN_RIG_CANDIDATE"), gateNames(text),
                 "the @EnabledIfEnvironmentVariable scan does not see the fully-qualified form. A rig "
                         + "gated that way is invisible to this class, and the CI step summary reports "
                         + "it as 'waiting on disabled' — the verification reads as off forever.");
@@ -448,7 +509,7 @@ class EnvGatedRigReachabilityTest {
 
     /**
      * And admitting the qualifier must not have cost the plain form. A qualifier made
-     * <em>mandatory</em> — {@code +} where the pattern has {@code *} — would miss all 44 plain
+     * <em>mandatory</em> — {@code +} where the pattern has {@code *} — would miss all 46 plain
      * occurrences in this tree while still satisfying the check above. The rig-level checks would
      * not notice for {@code ConvertLiveDryEvalTest}, because it also reads its credential with
      * {@code System.getenv}; only a gate-only assertion does.

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/MainnetCompoundEscrowTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/MainnetCompoundEscrowTest.java
@@ -49,9 +49,52 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p>Read-only; gated on {@code BLOCKFROST_KEY}. The recorded datum is checked against the live chain
  * rather than trusted, because a recording is only safe when something derived independently is
  * compared against it — this suite has now had two config datums age out from under it.
+ *
+ * <h2>⛔ PARKED — FAB-86, ruling of 2026-09-10. The failure is the FIXTURE'S ABSENCE.</h2>
+ * <ol>
+ *   <li>The pool manager NFT this class pins — {@code getPoolManagerPolicyId() +
+ *       0046337bd27d65a63574039b6293da11701ed2da01bcfaf626c18cccbe} — <b>is no longer held by any
+ *       address</b>, so {@link #theOnlyLiveMainnetPoolManagerStillPublishesAZeroCompoundingFee()}
+ *       fails at <i>"the pool manager NFT has vanished"</i> with the key present. That is a <b>stale
+ *       fixture, not a code fault</b>: nothing in this repo decides whether a pool manager stays
+ *       minted. <b>Do not "repair" it.</b></li>
+ *   <li>That measurement is not a side note here, it is the class's <em>thesis</em>. The whole point
+ *       of the file, said in its own words above, is to keep "there is finally something to
+ *       compound" apart from "compounding it is worth doing" — and the second half is answered
+ *       <em>only</em> by reading the live pool manager's {@code compoudingFeePerMille}. With that
+ *       NFT gone the fee cannot be read at all, so
+ *       {@link #atTheShippedMarginTheOnlyMainnetPoolWouldRefuseThisEscrow()} would still pass while
+ *       having stopped being a fact about mainnet — a green test asserting a number nothing on chain
+ *       supplies any more. The park is class-level for that reason: the remaining tests are not
+ *       independently meaningful once the measurement behind them is gone.</li>
+ *   <li>Re-enabling takes a <b>live mainnet pool manager to read the fee from</b>, and its unit
+ *       written in below in place of the dead one. The two immutable-history tests
+ *       ({@link #aRealRepaymentEscrowExistsAtTheAssetManagerCredential()} and
+ *       {@link #theEscrowNamesTheLenderBondOfTheRepaidLoan()}) come back with it; the repayment
+ *       transaction they read is history and cannot expire.</li>
+ * </ol>
+ * The dead unit is left pinned on purpose — it records what was last measured on mainnet, so
+ * re-enabling means replacing it consciously rather than inheriting it.
+ *
+ * <h3>Why a second gate rather than {@code @Disabled}</h3>
+ * The CI run summary lists, for every class that did not run, the environment variables it was
+ * waiting for. Under {@code @Disabled} this class would still scan as <em>"waiting on
+ * BLOCKFROST_KEY"</em> — a deliberate park reported as a rig waiting for a credential — and
+ * {@code disabledReason} never reaches the JUnit XML, which leaves a bare {@code <skipped/>} and the
+ * gate NAME as the only thing an operator ever reads. A second gate named
+ * {@code AQUARIUM_COMPOUND_RIG_POOL_MANAGER} makes that line say what is actually missing. It is
+ * deliberately <b>not</b> defined in any {@code .env.*} file, and {@code EnvGatedRigReachabilityTest}
+ * carries a narrow, named exemption for this class that keeps it that way.
  */
 @EnabledIfEnvironmentVariable(named = "BLOCKFROST_KEY", matches = ".+",
         disabledReason = "reads mainnet: run with `set -a; . ./.env.mainnet; set +a`")
+@EnabledIfEnvironmentVariable(named = "AQUARIUM_COMPOUND_RIG_POOL_MANAGER", matches = ".+",
+        disabledReason = "FAB-86, parked 2026-09-10: the pinned pool manager NFT "
+                + "…0046337bd27d65a63574039b6293da11701ed2da01bcfaf626c18cccbe is held by no address "
+                + "any more, so the live fee this class exists to measure cannot be read. That is a "
+                + "STALE FIXTURE, not a code fault — do not repair it. Re-enable only with a live "
+                + "mainnet pool manager whose compoudingFeePerMille can actually be read; without "
+                + "one, the refusal test still passes but has stopped being a fact about mainnet.")
 class MainnetCompoundEscrowTest {
 
     private static final String CONFIG_POLICY_ID = "db2c498e1b93da91e6a79f58526a1e66591d97ace3f8e43d2619b416";

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/RealLoanDryEvalTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/RealLoanDryEvalTest.java
@@ -35,6 +35,7 @@ import com.fluidtokens.aquarium.offchain.service.TransactionInputComparator;
 import com.fluidtokens.aquarium.offchain.service.loans.ReferenceScriptPublisher.Validator;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -1298,8 +1299,47 @@ class RealLoanDryEvalTest {
      * <p>
      * Gated on {@code BLOCKFROST_KEY}; it makes network calls and is not part of the cold suite. It
      * submits nothing: the builder has no {@code TransactionProcessor}, and there is no signer here.
+     *
+     * <h3>⛔ PARKED — FAB-86, ruling of 2026-09-10. The failure is the FIXTURE'S ABSENCE.</h3>
+     * <ol>
+     *   <li>With the key present this method failed at <i>"loan utxo spent — the loan may have been
+     *       liquidated"</i>: the preview loan {@code d2a85126…#1} pinned above is no longer in the
+     *       live UTxO set. Every constant in this class was read off preview on 2026-08-17 and a
+     *       loan is a thing other people close. <b>Stale fixture, not a code fault — do not "repair"
+     *       it</b>, and do not re-pin it to whatever loan is unspent today: choosing a replacement is
+     *       a judgement about what this rig should prove.</li>
+     *   <li><b>The park is METHOD-level, deliberately.</b> This is the only test here that touches
+     *       the chain; the other ten are pinned literals that run cold, need no key and are green.
+     *       They include the first evaluation ever run against a real third-party loan. A class-level
+     *       gate would switch all eleven off to park one, and ten verifications that stop running
+     *       produce no failure — they produce silence that looks like a pass.</li>
+     *   <li>Re-enabling takes an <b>unspent preview loan</b> and the constants above re-read against
+     *       it. ⚠ Whoever does that should know the diagnosis is not as sharp as the message reads:
+     *       {@code getTxOutput} yields an empty {@code Optional} for a transport failure as well as
+     *       for a spent output, so an HTTP 403 from a mainnet key pointed at this <em>preview</em>
+     *       URL — the gate is the network-agnostic {@code BLOCKFROST_KEY}, so sourcing
+     *       {@code .env.mainnet} does exactly that — reaches the same {@code orElseThrow} and prints
+     *       the same sentence. Confirm the loan against a preview key before deciding what to
+     *       re-pin.</li>
+     * </ol>
+     * The dead coordinates stay pinned on purpose: they record what was last proven against preview.
+     *
+     * <p><b>Why a second gate rather than {@code @Disabled}:</b> the CI run summary derives "waiting
+     * on X" from the gate names it finds in the source, so a disabled method would still read as
+     * waiting on {@code BLOCKFROST_KEY} — a deliberate park dressed as a missing credential. And
+     * {@code disabledReason} never reaches the JUnit XML; Gradle's writer drops it and leaves a bare
+     * {@code <skipped/>}, so the gate NAME is the only thing an operator ever reads.
+     * {@code AQUARIUM_REAL_LOAN_RIG_CANDIDATE} is deliberately absent from every {@code .env.*} file,
+     * and {@code EnvGatedRigReachabilityTest} carries a narrow, named exemption keeping it absent.
      */
     @org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable(named = "BLOCKFROST_KEY", matches = ".+")
+    @EnabledIfEnvironmentVariable(named = "AQUARIUM_REAL_LOAN_RIG_CANDIDATE", matches = ".+",
+            disabledReason = "FAB-86, parked 2026-09-10: the pinned preview loan d2a85126…#1 is no "
+                    + "longer in the live UTxO set, so this rig fails at 'loan utxo spent'. STALE "
+                    + "FIXTURE, not a code fault — do not repair it and do not re-pin it casually. "
+                    + "Re-enable only with an unspent preview loan and the constants above re-read "
+                    + "against it. Method-level on purpose: the other ten tests in this class run "
+                    + "cold and must keep running.")
     @Test
     void productionWiringPricesTheRealLoanAgainstTheRealChainThroughThePublishedReferenceScript() throws Exception {
         var bf = new com.bloxbean.cardano.client.backend.blockfrost.service.BFBackendService(


### PR DESCRIPTION
Two mainnet-adjacent rigs are red with a key present because the chain state they pin no longer exists — **stale fixtures, not code faults.** Same mechanism as #28, and the re-enable criteria are in FAB-86.

| rig | what expired |
|---|---|
| `RealLoanDryEvalTest` | its preview loan was spent — **verified against preview Blockfrost**, not inferred |
| `MainnetCompoundEscrowTest` | the pool manager NFT it reads has vanished |

## One deliberate deviation from the contract, and it is the important part

The contract said *class-level* gate for both. **`RealLoanDryEvalTest` got a method-level gate instead**, and the auditor ruled that correct.

That class has **eleven tests and only one touches the chain.** The other ten run cold in every keyless run, need no key, are green today, and include the only evaluation this repo has ever run against a real third-party loan. A class-level gate would have switched off **ten passing verifications to park one stale fixture** — and this repo's own rule is that *a test that no longer runs produces no failure; it produces silence that looks like a pass.* The contract would have manufactured the exact defect the mechanism exists to prevent.

Verified, not assumed: both the guard's scan and the CI summary's `gates_of()` match on **source text**, not on the declaration the annotation attaches to, so the mechanism works unchanged at method level. The run summary reads:

```
- `…RealLoanDryEvalTest` - 1 skipped - waiting on `AQUARIUM_REAL_LOAN_RIG_CANDIDATE`, `BLOCKFROST_KEY`
```

## The guard we shipped this morning was already insufficient

`assertParkListIsIntact` asserted the list was non-empty **and named one rig** — correct for a list of one, blind for a list of three: delete two entries and it is still non-empty and still contains the named rig. Replaced with an exact set comparison, and proven by the pair that matters: the identical deletion is **red** under the new guard and **fully green** under the old one.

## Two audit findings taken rather than deferred

- **Gate-name uniqueness was required by the contract and enforced by nothing.** Giving both parks the same name left the whole suite green. One shared gate is a single switch for two unrelated expiries: reviving one silently re-arms the other on a fixture nobody looked at. Now guarded, using the idiom that already sat two statements above it. The auditor's surviving mutant now fails two named tests.
- **Un-parking takes a fourth edit the javadoc did not mention** — one test hard-codes that rig's expected gate set. The coupling is deliberate and keeps the scan's exactness load-bearing; it is now documented where whoever lifts the park will be standing.

## Verification

**138 files / 1089 tests / 0 failures / 0 errors / 45 skipped**, zero orphans, floor 138 — file count unchanged, no class added or removed.

Keyed, one invocation, with the control that makes it mean something: both new parks skip, #28's park still skips, `RealLoanDryEvalTest`'s **other ten tests ran and passed**, and `ConvertLiveDryEvalTest` genuinely reached the network.

The audit ran eleven mutants; three survivors were investigated and two are now closed by the commit above.

## Known residue, inherited

The un-park check inspects only `.env.mainnet` and `.env.preview` — `docker/.env`, a shell profile or a session export still un-parks a rig with nothing red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)