### PR TITLE
Report unservable lending markets with cadence-aware warnings

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -174,15 +174,19 @@ jobs:
       #   before  139 files / 1098 tests / 0 failures / 45 skipped
       #   after   139 files / 1105 tests / 0 failures / 45 skipped   (+6 in MarketCoverageReporterTest,
       #                                                              +1 in LiquidationExecutorTest)
-      # NO class was added, so the floor stays 139 -- and that is the case worth stating out loud,
-      # because "the floor did not move" is indistinguishable from "nobody re-measured" unless the
-      # measurement is written down. Orphan check re-run: 139 files, 0 orphans.
+      # No class was added in r2, so that branch's floor stayed 139. That is the case worth stating
+      # out loud, because "the floor did not move" is indistinguishable from "nobody re-measured"
+      # unless the measurement is written down. Orphan check re-run: 139 files, 0 orphans.
+      #
+      # FAB-81 reconciliation on current main measured 139 files before integration and 140 after:
+      # MarketCoverageReporterTest is the one added class. Final cold run: 140 files / 1117 tests /
+      # 0 failures / 0 errors / 46 skipped, with 0 orphans. The floor therefore rises to 140.
       #
       # Left at 137 the gate would have tolerated losing a class in silence -- the exact defect this
       # step exists to catch. Re-measure before changing it; do not reconcile to a number written here.
       - name: Assert the suite did not quietly shrink
         env:
-          RESULT_FILE_FLOOR: '139'
+          RESULT_FILE_FLOOR: '140'
         run: |
           python3 - <<'PY'
           import glob, os, sys, xml.etree.ElementTree as ET

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -156,9 +156,17 @@ jobs:
       #
       # FAB-81-1 measured both sides of its own change, keyless, with `rm -rf build/test-results/test`
       # then `./gradlew cleanTest test`, counting the XML rather than reading BUILD SUCCESSFUL:
-      #   before  138 files / 1087 tests / 0 failures / 45 skipped
-      #   after   139 files / 1096 tests / 0 failures / 45 skipped   (+1 class, +8 tests there,
+      #   before  138 files / 1089 tests / 0 failures / 45 skipped
+      #   after   139 files / 1098 tests / 0 failures / 45 skipped   (+1 class, +8 tests there,
       #                                                              +1 in LiquidationExecutorTest)
+      #
+      # ⚠ THE TEST TOTALS ABOVE WERE RE-MEASURED ON RE-CUT. The slice was built on main before PR #28
+      # (the anticipate-rig park) merged, and was cherry-picked onto main afterwards. Its own run read
+      # 1087 -> 1096; on this tree, which carries #28's two extra park tests, the same change reads
+      # 1089 -> 1098. The FILE counts and the delta (+1 class, +9 tests) are unchanged.
+      # Recorded rather than corrected silently: a number measured on a base that has since moved is
+      # not wrong, it is a measurement OF SOMETHING ELSE -- and that is exactly how a stale figure
+      # survives, by having been true once.
       #
       # Left at 137 the gate would have tolerated losing a class in silence -- the exact defect this
       # step exists to catch. Re-measure before changing it; do not reconcile to a number written here.

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -139,7 +139,7 @@ jobs:
       # src/test/java. Raise the floor deliberately when classes are added; a drop is a deletion to
       # justify, never a number to edit away. (CLAUDE.md `## Commands`.)
       #
-      # Floor measured 2026-09-10 on THIS tree, keyless (the shape CI runs in): 139 files.
+      # Floor measured 2026-09-11 on THIS tree, keyless (the shape CI runs in): 140 files.
       #
       # (config/BuildProvenanceTest carries 11 tests: 9 at round 1, plus two the rework added -- one
       # asserting the startup wiring actually installs the banner's default properties, one asserting

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -139,7 +139,7 @@ jobs:
       # src/test/java. Raise the floor deliberately when classes are added; a drop is a deletion to
       # justify, never a number to edit away. (CLAUDE.md `## Commands`.)
       #
-      # Floor measured 2026-09-10 on THIS tree, keyless (the shape CI runs in): 138 files.
+      # Floor measured 2026-09-10 on THIS tree, keyless (the shape CI runs in): 139 files.
       #
       # (config/BuildProvenanceTest carries 11 tests: 9 at round 1, plus two the rework added -- one
       # asserting the startup wiring actually installs the banner's default properties, one asserting
@@ -150,14 +150,21 @@ jobs:
       #   135  base e75ecf9 (#23)
       #   +1   EnvGatedRigReachabilityTest        (the CI-gate slice, squashed into main as #25)
       #   +1   ConvertLiquidationRouterTest       (#24)
-      #   +1   config/BuildProvenanceTest         (this slice, 11 tests)
-      #   = 138
+      #   +1   config/BuildProvenanceTest         (11 tests)
+      #   +1   service/loans/MarketCoverageReporterTest  (FAB-81-1, 8 tests)
+      #   = 139
+      #
+      # FAB-81-1 measured both sides of its own change, keyless, with `rm -rf build/test-results/test`
+      # then `./gradlew cleanTest test`, counting the XML rather than reading BUILD SUCCESSFUL:
+      #   before  138 files / 1087 tests / 0 failures / 45 skipped
+      #   after   139 files / 1096 tests / 0 failures / 45 skipped   (+1 class, +8 tests there,
+      #                                                              +1 in LiquidationExecutorTest)
       #
       # Left at 137 the gate would have tolerated losing a class in silence -- the exact defect this
       # step exists to catch. Re-measure before changing it; do not reconcile to a number written here.
       - name: Assert the suite did not quietly shrink
         env:
-          RESULT_FILE_FLOOR: '138'
+          RESULT_FILE_FLOOR: '139'
         run: |
           python3 - <<'PY'
           import glob, os, sys, xml.etree.ElementTree as ET

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -151,7 +151,8 @@ jobs:
       #   +1   EnvGatedRigReachabilityTest        (the CI-gate slice, squashed into main as #25)
       #   +1   ConvertLiquidationRouterTest       (#24)
       #   +1   config/BuildProvenanceTest         (11 tests)
-      #   +1   service/loans/MarketCoverageReporterTest  (FAB-81-1, 8 tests)
+      #   +1   service/loans/MarketCoverageReporterTest  (FAB-81-1, 8 tests at round 1; 14 after
+      #                                                   the r2 rework -- same one class, same floor)
       #   = 139
       #
       # FAB-81-1 measured both sides of its own change, keyless, with `rm -rf build/test-results/test`
@@ -167,6 +168,15 @@ jobs:
       # Recorded rather than corrected silently: a number measured on a base that has since moved is
       # not wrong, it is a measurement OF SOMETHING ELSE -- and that is exactly how a stale figure
       # survives, by having been true once.
+      #
+      #
+      # FAB-81-1 r2 (the rework) measured both sides again on d3abf03, keyless, same procedure:
+      #   before  139 files / 1098 tests / 0 failures / 45 skipped
+      #   after   139 files / 1105 tests / 0 failures / 45 skipped   (+6 in MarketCoverageReporterTest,
+      #                                                              +1 in LiquidationExecutorTest)
+      # NO class was added, so the floor stays 139 -- and that is the case worth stating out loud,
+      # because "the floor did not move" is indistinguishable from "nobody re-measured" unless the
+      # measurement is written down. Orphan check re-run: 139 files, 0 orphans.
       #
       # Left at 137 the gate would have tolerated losing a class in silence -- the exact defect this
       # step exists to catch. Re-measure before changing it; do not reconcile to a number written here.

--- a/src/main/java/com/fluidtokens/aquarium/offchain/model/loans/UnservableMarket.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/model/loans/UnservableMarket.java
@@ -2,20 +2,36 @@ package com.fluidtokens.aquarium.offchain.model.loans;
 
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.Locale;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
 /**
  * ⛔ <b>A MARKET THE BOT MET AND COULD NOT SERVE, AND WHY.</b>
  *
- * <h2>A market is the token for the principal</h2>
+ * <h2>A market is the token for the principal — and a loan has TWO legs</h2>
  * Giovanni's vocabulary, adopted verbatim: <i>"for market is the token for the principal"</i>. Same
  * keying as {@code MarketGate}, which caps per-market exposure on the same identity, and the same
  * string {@code CompoundCandidateScanner} already logs — {@code principalAsset().toUnit()}.
  * <p>
- * The market is read off the <b>bond</b>, never the loan: an assessment may carry a {@code null}
- * loan ({@link LiquidationExclusion#LOAN_NOT_FOUND}) but never a null bond, so the bond is the only
- * place the market is always available.
+ * ⚠ <b>But a liquidation prices two assets, and either can be the one we cannot price.</b>
+ * {@link LiquidationExclusion#COLLATERAL_ORACLE_UNUSABLE} is a gap in the <em>collateral</em> token's
+ * coverage, and keying it by the principal was a real defect: two ada-principal loans whose different
+ * collateral tokens had no feed collapsed into one series saying {@code market="lovelace"}, which
+ * pages the operator about <b>ada</b> — a market that is always priceable — while the token that
+ * actually needs a feed appears nowhere. Giovanni's <i>"a new stablecoin loan appears"</i> arrives as
+ * collateral as often as as principal.
+ * <p>
+ * So the key names <b>the leg's own asset</b> and carries {@link Leg} to say which leg it is. The
+ * asset is read from the only place it is reliably available for that leg:
+ * <ul>
+ *   <li>{@link Leg#PRINCIPAL} — off the <b>bond</b>. An assessment may carry a {@code null} loan
+ *       ({@link LiquidationExclusion#LOAN_NOT_FOUND}) but never a null bond.</li>
+ *   <li>{@link Leg#COLLATERAL} — off the <b>loan</b>, which is the only carrier of
+ *       {@code CollateralAsset}. It is never null for a collateral-leg refusal: the scanner returns
+ *       {@code LOAN_NOT_FOUND} before it ever reaches the collateral feed lookup, and
+ *       {@code LOAN_NOT_FOUND} is classified servable and so is never reported.</li>
+ * </ul>
  *
  * <h2>⚠ This class DECIDES NOTHING. It re-reads a verdict that already exists</h2>
  * Every value here is derived from {@link LiquidationAssessment}s the scanner has already produced.
@@ -32,17 +48,34 @@ import java.util.TreeMap;
  * the <em>validator itself</em> forbids liquidation, and no change to this node could ever serve
  * them — reporting those would page an operator about work that does not exist.
  *
- * @param market the token for the principal, as {@code policyId + assetName} (or {@code lovelace}) —
- *               the same canonical unit string used everywhere else in this package. Never a human
+ * @param market the token for this LEG, as {@code policyId + assetName} (or {@code lovelace}) — the
+ *               same canonical unit string used everywhere else in this package. Never a human
  *               name: {@link com.fluidtokens.aquarium.offchain.model.AssetType#unsafeHumanAssetName()}
  *               decodes attacker-chosen bytes, which must not reach a log line or a metric label.
+ * @param leg    which side of the loan {@link #market} is — the label that stops a collateral-side
+ *               gap reading as a principal-side one
  * @param reason the scanner's own machine-readable reason, unchanged
  */
-public record UnservableMarket(String market, LiquidationExclusion reason)
+public record UnservableMarket(String market, Leg leg, LiquidationExclusion reason)
         implements Comparable<UnservableMarket> {
+
+    /**
+     * Which side of the loan an unservable reason is about. A liquidation prices the principal and
+     * the collateral separately, and the two are different tokens with different feeds.
+     */
+    public enum Leg {
+        PRINCIPAL,
+        COLLATERAL;
+
+        /** The metric label value: lower case, so {@code leg="collateral"} reads as prose. */
+        public String label() {
+            return name().toLowerCase(Locale.ROOT);
+        }
+    }
 
     private static final Comparator<UnservableMarket> ORDER =
             Comparator.comparing(UnservableMarket::market)
+                    .thenComparing(m -> m.leg().name())
                     .thenComparing(m -> m.reason().name());
 
     /**
@@ -107,20 +140,80 @@ public record UnservableMarket(String market, LiquidationExclusion reason)
         };
     }
 
-    /** The market one assessment sits in: the token for the principal, off the bond. */
-    public static String marketOf(LiquidationAssessment assessment) {
-        return assessment.bond().datum().principalAsset().toUnit();
+    /**
+     * ⛔ <b>Which leg of the loan a refusal is about</b> — the thing that decides which token gets
+     * named.
+     *
+     * <p>Exhaustive and {@code default}-less for the same reason as {@link #isUnservable}: a new
+     * constant must not compile until someone has said which asset it is about. The seven servable
+     * reasons throw rather than picking a leg, because they are never reported and a leg for them
+     * would be a guess that nothing would ever contradict.
+     *
+     * <p>{@link LiquidationExclusion#HEALTH_NOT_COMPUTABLE} and
+     * {@link LiquidationExclusion#CONVERSION_TO_PRINCIPAL_REQUIRED} are about the loan as a whole
+     * rather than about one feed, so they take the principal — which is Giovanni's market — rather
+     * than being split across both legs.
+     */
+    public static Leg legOf(LiquidationExclusion reason) {
+        return switch (reason) {
+            case COLLATERAL_ORACLE_UNUSABLE -> Leg.COLLATERAL;
+            case PRINCIPAL_ORACLE_UNUSABLE,
+                 HEALTH_NOT_COMPUTABLE,
+                 CONVERSION_TO_PRINCIPAL_REQUIRED -> Leg.PRINCIPAL;
+            case LOAN_NOT_FOUND,
+                 NOT_LIQUIDATABLE,
+                 MODE_NOT_LIQUIDATION,
+                 EQUITY_IN_PRINCIPAL_CURRENCY,
+                 COLLATERAL_IS_COLLECTION,
+                 COLLATERAL_AMOUNT_TOO_SMALL,
+                 BOND_NOT_DELEGATED -> throw new IllegalArgumentException(
+                    reason + " is servable — isUnservable() says so — and a servable reason has no "
+                            + "leg, because nothing reports it and nothing would contradict a guess");
+        };
     }
 
     /**
-     * Every distinct (market, reason) pair one scan met and could not serve, each with <b>one</b>
-     * example {@code detail} — the scanner's own sentence about the first assessment that produced
-     * that pair.
+     * The asset one leg of one assessment names.
+     *
+     * <p>⛔ <b>There is no fallback to the principal.</b> A collateral-leg refusal whose loan is
+     * missing would be a violation of {@link LiquidationAssessment}'s own contract (a null loan is
+     * possible only for {@code LOAN_NOT_FOUND}, which is servable and never reported), and naming
+     * the principal instead would be exactly the mis-attribution this leg label exists to end. It
+     * throws instead; {@code LiquidationExecutor} calls the reporter inside a guard, so the cycle is
+     * unaffected and the fault is logged every cycle until someone looks.
+     */
+    public static String assetOf(LiquidationAssessment assessment, Leg leg) {
+        return switch (leg) {
+            case PRINCIPAL -> assessment.bond().datum().principalAsset().toUnit();
+            case COLLATERAL -> {
+                Loan loan = assessment.loan();
+                if (loan == null) {
+                    throw new IllegalStateException(
+                            "collateral-leg refusal " + assessment.exclusion() + " on bond "
+                                    + assessment.bond().utxoRef() + " carries no loan, so the "
+                                    + "collateral token cannot be named; refusing to report the "
+                                    + "principal in its place");
+                }
+                yield loan.datum().collateral().assetType().toUnit();
+            }
+        };
+    }
+
+    /** The (asset, leg, reason) triple one unservable assessment sits in. */
+    public static UnservableMarket of(LiquidationAssessment assessment) {
+        Leg leg = legOf(assessment.exclusion());
+        return new UnservableMarket(assetOf(assessment, leg), leg, assessment.exclusion());
+    }
+
+    /**
+     * Every distinct {@code (market, leg, reason)} triple one scan met and could not serve, each with
+     * <b>one</b> example {@code detail} — the scanner's own sentence about the first assessment that
+     * produced that triple.
      *
      * <p>⚠ <b>The detail is a value, never part of the key.</b> It carries an instant
      * ({@code "outside its validity window at 1757…"}), so keying on it would mint a new metric
      * series every cycle — the unbounded-cardinality failure this slice is forbidden to ship. The
-     * key is the pair; the detail only ever reaches a log line.
+     * key is the triple; the detail only ever reaches a log line.
      *
      * <p>Sorted, so the log and the gauge order are stable between cycles and a test can assert
      * them.
@@ -132,8 +225,7 @@ public record UnservableMarket(String market, LiquidationExclusion reason)
             if (assessment.buildable() || !isUnservable(assessment.exclusion())) {
                 continue;
             }
-            seen.putIfAbsent(new UnservableMarket(marketOf(assessment), assessment.exclusion()),
-                    assessment.detail());
+            seen.putIfAbsent(of(assessment), assessment.detail());
         }
         return seen;
     }

--- a/src/main/java/com/fluidtokens/aquarium/offchain/model/loans/UnservableMarket.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/model/loans/UnservableMarket.java
@@ -1,0 +1,145 @@
+package com.fluidtokens.aquarium.offchain.model.loans;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * ⛔ <b>A MARKET THE BOT MET AND COULD NOT SERVE, AND WHY.</b>
+ *
+ * <h2>A market is the token for the principal</h2>
+ * Giovanni's vocabulary, adopted verbatim: <i>"for market is the token for the principal"</i>. Same
+ * keying as {@code MarketGate}, which caps per-market exposure on the same identity, and the same
+ * string {@code CompoundCandidateScanner} already logs — {@code principalAsset().toUnit()}.
+ * <p>
+ * The market is read off the <b>bond</b>, never the loan: an assessment may carry a {@code null}
+ * loan ({@link LiquidationExclusion#LOAN_NOT_FOUND}) but never a null bond, so the bond is the only
+ * place the market is always available.
+ *
+ * <h2>⚠ This class DECIDES NOTHING. It re-reads a verdict that already exists</h2>
+ * Every value here is derived from {@link LiquidationAssessment}s the scanner has already produced.
+ * Nothing in this file is consulted by any liquidation decision, and adding a reason to
+ * {@link #isUnservable} can only change what is <em>reported</em>.
+ *
+ * <h2>The question this answers, and the one it does not</h2>
+ * It answers <b>"is there something here we cannot do?"</b> — the failure Giovanni named: <i>"assume
+ * a new stable coin loan appears and I wouldn't be able to process that loan if it went sour, well I
+ * would need to know."</i> It does <b>not</b> answer "should we" (profitability, capital, market
+ * policy); those refusals are about choice, not capability, and they belong to a different metric.
+ * <p>
+ * ⚠ It is therefore <b>not</b> "the bot is broken here". Three of the eleven exclusions below mean
+ * the <em>validator itself</em> forbids liquidation, and no change to this node could ever serve
+ * them — reporting those would page an operator about work that does not exist.
+ *
+ * @param market the token for the principal, as {@code policyId + assetName} (or {@code lovelace}) —
+ *               the same canonical unit string used everywhere else in this package. Never a human
+ *               name: {@link com.fluidtokens.aquarium.offchain.model.AssetType#unsafeHumanAssetName()}
+ *               decodes attacker-chosen bytes, which must not reach a log line or a metric label.
+ * @param reason the scanner's own machine-readable reason, unchanged
+ */
+public record UnservableMarket(String market, LiquidationExclusion reason)
+        implements Comparable<UnservableMarket> {
+
+    private static final Comparator<UnservableMarket> ORDER =
+            Comparator.comparing(UnservableMarket::market)
+                    .thenComparing(m -> m.reason().name());
+
+    /**
+     * ⛔ <b>Which exclusions mean "there is something here we cannot do".</b>
+     *
+     * <p>A deliberately exhaustive {@code switch} with <b>no {@code default}</b>: adding a constant
+     * to {@link LiquidationExclusion} must not compile until someone has classified it. A default
+     * arm would silently classify every future refusal as servable — the direction that fails
+     * quiet, and quiet is the whole defect this slice exists to close.
+     *
+     * <h2>TRUE — we cannot act, or cannot even tell</h2>
+     * <ul>
+     *   <li>{@link LiquidationExclusion#PRINCIPAL_ORACLE_UNUSABLE} and
+     *       {@link LiquidationExclusion#COLLATERAL_ORACLE_UNUSABLE} — <b>Giovanni's exact
+     *       scenario.</b> A leg has no usable feed, so the loan cannot be priced and its health
+     *       cannot even be established. {@code POOLED} and {@code PRICE_DATA_ORCFAX} feeds are not
+     *       modelled by this node at all ({@code OracleEntry.usableForLiquidation}), so a market
+     *       priced by one of them is unservable until the bot is changed.</li>
+     *   <li>{@link LiquidationExclusion#HEALTH_NOT_COMPUTABLE} — our own arithmetic threw. Whatever
+     *       the cause, we did not reach a verdict.</li>
+     *   <li>{@link LiquidationExclusion#CONVERSION_TO_PRINCIPAL_REQUIRED} — a shape the plain
+     *       {@code Liquidate} path does not build. <b>Not produced by
+     *       {@code LiquidationCandidateScanner} today</b> (convert candidates are routed rather than
+     *       excluded), so this arm is unreachable from a live scan; it is classified true because if
+     *       the scanner ever emits it again it will mean exactly "a loan we are not equipped to
+     *       liquidate".</li>
+     * </ul>
+     *
+     * <h2>FALSE — there is nothing here to do, so there is nothing we are failing to do</h2>
+     * <ul>
+     *   <li>{@link LiquidationExclusion#LOAN_NOT_FOUND} — the ordinary post-settlement state: the
+     *       loan closed and burned its NFT while the bond survives. Reporting it would page on
+     *       history.</li>
+     *   <li>{@link LiquidationExclusion#NOT_LIQUIDATABLE} — the loan is <em>healthy</em>. This is the
+     *       single most common exclusion on a working node, and the one whose misclassification
+     *       would make the metric useless.</li>
+     *   <li>{@link LiquidationExclusion#MODE_NOT_LIQUIDATION} — the lender chose a bond mode with no
+     *       liquidation. Their choice, not our gap.</li>
+     *   <li>{@link LiquidationExclusion#EQUITY_IN_PRINCIPAL_CURRENCY},
+     *       {@link LiquidationExclusion#COLLATERAL_IS_COLLECTION} and
+     *       {@link LiquidationExclusion#COLLATERAL_AMOUNT_TOO_SMALL} — <b>the validator forbids the
+     *       liquidation</b> (every working LenderManager liquidation action {@code expect}s the
+     *       opposite). No off-chain change could serve these; nobody can.</li>
+     *   <li>{@link LiquidationExclusion#BOND_NOT_DELEGATED} — produced only by the loan-anchored
+     *       {@code GET /api/v1/loans} join, never by a scan. The lender never delegated to this bot,
+     *       so there is nothing for it to do.</li>
+     * </ul>
+     */
+    public static boolean isUnservable(LiquidationExclusion reason) {
+        return switch (reason) {
+            case PRINCIPAL_ORACLE_UNUSABLE,
+                 COLLATERAL_ORACLE_UNUSABLE,
+                 HEALTH_NOT_COMPUTABLE,
+                 CONVERSION_TO_PRINCIPAL_REQUIRED -> true;
+            case LOAN_NOT_FOUND,
+                 NOT_LIQUIDATABLE,
+                 MODE_NOT_LIQUIDATION,
+                 EQUITY_IN_PRINCIPAL_CURRENCY,
+                 COLLATERAL_IS_COLLECTION,
+                 COLLATERAL_AMOUNT_TOO_SMALL,
+                 BOND_NOT_DELEGATED -> false;
+        };
+    }
+
+    /** The market one assessment sits in: the token for the principal, off the bond. */
+    public static String marketOf(LiquidationAssessment assessment) {
+        return assessment.bond().datum().principalAsset().toUnit();
+    }
+
+    /**
+     * Every distinct (market, reason) pair one scan met and could not serve, each with <b>one</b>
+     * example {@code detail} — the scanner's own sentence about the first assessment that produced
+     * that pair.
+     *
+     * <p>⚠ <b>The detail is a value, never part of the key.</b> It carries an instant
+     * ({@code "outside its validity window at 1757…"}), so keying on it would mint a new metric
+     * series every cycle — the unbounded-cardinality failure this slice is forbidden to ship. The
+     * key is the pair; the detail only ever reaches a log line.
+     *
+     * <p>Sorted, so the log and the gauge order are stable between cycles and a test can assert
+     * them.
+     */
+    public static SortedMap<UnservableMarket, String> seenIn(
+            Collection<LiquidationAssessment> assessments) {
+        SortedMap<UnservableMarket, String> seen = new TreeMap<>(ORDER);
+        for (LiquidationAssessment assessment : assessments) {
+            if (assessment.buildable() || !isUnservable(assessment.exclusion())) {
+                continue;
+            }
+            seen.putIfAbsent(new UnservableMarket(marketOf(assessment), assessment.exclusion()),
+                    assessment.detail());
+        }
+        return seen;
+    }
+
+    @Override
+    public int compareTo(UnservableMarket other) {
+        return ORDER.compare(this, other);
+    }
+}

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutor.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutor.java
@@ -234,6 +234,14 @@ public class LiquidationExecutor {
 
     private final LiquidationDecisionLog decisionLog;
 
+    /**
+     * The other sink for what a scan saw, beside {@link #decisionLog}: the one that keeps the ASSET
+     * IDENTITY. {@code liveExclusions} below is a histogram keyed by reason, so by the time the scan
+     * line is logged the market is gone — which is exactly why a market the bot cannot serve could
+     * not be named. This is handed the assessments before that collapse happens.
+     */
+    private final MarketCoverageReporter marketCoverage;
+
     private final ObjectProvider<FluidOracleClient> oracleClient;
 
     private final AppConfig.Network network;
@@ -287,14 +295,15 @@ public class LiquidationExecutor {
                                ObjectProvider<ConvertLiquidationRouter> convertRouter,
                                LoansContractRegistry registry,
                                LiquidationDecisionLog decisionLog,
+                               MarketCoverageReporter marketCoverage,
                                ObjectProvider<FluidOracleClient> oracleClient,
                                AppConfig.Network network,
                                ProtocolParamsSupplier protocolParamsSupplier,
                                CardanoConverters converters,
                                BFBackendService backendService) {
         this(configuration, blockEventListener, appUtxoService, account, scanner, utxoResolver, builder,
-                payInAdvanceRouter, convertRouter.getIfAvailable(), registry, decisionLog, oracleClient,
-                network, protocolParamsSupplier, converters,
+                payInAdvanceRouter, convertRouter.getIfAvailable(), registry, decisionLog, marketCoverage,
+                oracleClient, network, protocolParamsSupplier, converters,
                 bytes -> backendService.getTransactionService().submitTransaction(bytes));
     }
 
@@ -309,13 +318,14 @@ public class LiquidationExecutor {
                                PayInAdvanceLiquidationRouter payInAdvanceRouter,
                                LoansContractRegistry registry,
                                LiquidationDecisionLog decisionLog,
+                               MarketCoverageReporter marketCoverage,
                                ObjectProvider<FluidOracleClient> oracleClient,
                                AppConfig.Network network,
                                ProtocolParamsSupplier protocolParamsSupplier,
                                CardanoConverters converters,
                                TransactionSubmitter submitter) {
         this(configuration, blockEventListener, appUtxoService, account, scanner, utxoResolver, builder,
-                payInAdvanceRouter, null, registry, decisionLog, oracleClient, network,
+                payInAdvanceRouter, null, registry, decisionLog, marketCoverage, oracleClient, network,
                 protocolParamsSupplier, converters, submitter);
     }
 
@@ -331,6 +341,7 @@ public class LiquidationExecutor {
                                ConvertLiquidationRouter convertRouter,
                                LoansContractRegistry registry,
                                LiquidationDecisionLog decisionLog,
+                               MarketCoverageReporter marketCoverage,
                                ObjectProvider<FluidOracleClient> oracleClient,
                                AppConfig.Network network,
                                ProtocolParamsSupplier protocolParamsSupplier,
@@ -347,6 +358,7 @@ public class LiquidationExecutor {
         this.convertRouter = convertRouter;
         this.registry = registry;
         this.decisionLog = decisionLog;
+        this.marketCoverage = marketCoverage;
         this.oracleClient = oracleClient;
         this.network = network;
         this.protocolParamsSupplier = protocolParamsSupplier;
@@ -667,6 +679,25 @@ public class LiquidationExecutor {
         List<LiquidationAssessment> buildable = assessments.stream()
                 .filter(LiquidationAssessment::buildable)
                 .toList();
+
+        // ⛔ BEFORE THE HISTOGRAM COLLAPSES THE ASSET IDENTITY.
+        //
+        // `histogram` below is keyed by REASON, so from the next line on the scan can say "2 bonds
+        // excluded, PRINCIPAL_ORACLE_UNUSABLE" and cannot say WHICH TOKEN. Giovanni's requirement is
+        // the token: "assume a new stable coin loan appears and I wouldn't be able to process that
+        // loan if it went sour, well I would need to know." The verdict already exists here; this
+        // line is only declining to throw it away.
+        //
+        // ⚠ GUARDED, AND THE GUARD IS THE POINT: observation must never cost a liquidation. The
+        // reporter touches a MeterRegistry, and a metrics backend is not part of this loop's
+        // contract — a fault in it is reported and the cycle carries on exactly as it would have.
+        // Nothing downstream reads anything the reporter produces.
+        try {
+            marketCoverage.report(assessments);
+        } catch (RuntimeException e) {
+            log.warn("market-coverage reporting failed; the cycle is unaffected", e);
+        }
+
         Map<LiquidationExclusion, Integer> exclusions = histogram(assessments);
 
         // T-060 PART 2 — A BOND WHOSE LOAN NO LONGER EXISTS IS NOT AN EXCLUSION.

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/MarketCoverageReporter.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/MarketCoverageReporter.java
@@ -1,0 +1,176 @@
+package com.fluidtokens.aquarium.offchain.service.loans;
+
+import com.fluidtokens.aquarium.offchain.model.loans.LiquidationAssessment;
+import com.fluidtokens.aquarium.offchain.model.loans.UnservableMarket;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * ⛔ <b>The bot says which market it cannot serve, by name.</b>
+ *
+ * <h2>What it is for</h2>
+ * Giovanni: <i>"assume a new stable coin loan appears and I wouldn't be able to process that loan if
+ * it went sour, well I would need to know"</i> — and, for how: <i>"a nice prometheus metric with
+ * labels and the label being the asset name … we could add an alert and if there is anything it
+ * trigger paging"</i>, with <i>"a WARN in the logs would be a good starting point"</i>.
+ * <p>
+ * So there are two outputs and they have different jobs. <b>The gauge is what wakes someone</b> —
+ * an alert rule fires on {@code loans_market_unservable == 1} and the market is in the label.
+ * <b>The log is for the human reading afterwards</b>, and carries the scanner's own sentence about
+ * why, which the label deliberately does not.
+ *
+ * <h2>⚠ It observes; it decides nothing</h2>
+ * Everything below is derived from {@link LiquidationAssessment}s the scanner already produced.
+ * Before this class existed, {@code LiquidationExecutor} collapsed them into a histogram keyed by
+ * reason and <b>the asset identity was gone by the time anything was logged</b> — so this is not new
+ * analysis, it is declining to discard something already computed. No liquidation decision reads
+ * anything here, and {@code LiquidationExecutor} calls {@link #report} inside its own guard so a
+ * fault in observation cannot cost a cycle.
+ *
+ * <h2>⛔ CARDINALITY IS BOUNDED BY CONSTRUCTION, and that is not a detail</h2>
+ * A metric label whose values come from chain data is an unbounded label unless something bounds
+ * it: anyone can lock a lender bond naming an arbitrary asset as its principal, so "markets seen"
+ * is attacker-influenced, not a closed set of tens. An unbounded label is how a metrics backend
+ * falls over, which is worse than no metric at all.
+ * <p>
+ * Hence {@link #MAX_TRACKED_SERIES}: past that many distinct {@code (market, reason)} pairs, <b>no
+ * further series is created</b>. The overflow is not silent — {@code loans_market_unservable_untracked}
+ * counts the pairs being refused a series, so the reader can tell "nothing more is wrong" from "we
+ * stopped saying". Same shape and same reason as {@code LiquidationExecutor.MAX_QUARANTINED}.
+ *
+ * <h2>Transitions, not repetitions</h2>
+ * The cycle runs every {@code loans.liquidation.delay-seconds}. Logging every unservable market
+ * every cycle would bury the line that matters under thousands of identical ones, so a WARN is
+ * emitted when a pair <b>becomes</b> unservable and an INFO when it stops. The gauge, not the log,
+ * is the thing that is true continuously — which is exactly the division of labour Giovanni asked
+ * for.
+ * <p>
+ * ⚠ <b>A recovered market's series stays, holding 0.</b> Deleting it would make "servable again" and
+ * "we stopped looking" the same observation, and an alert rule cannot tell those apart.
+ *
+ * <h2>⚠ Known limitation: an oracle blackout looks like an unservable market</h2>
+ * {@code PRINCIPAL_ORACLE_UNUSABLE} covers both "this feed is a variant we do not model" (permanent,
+ * and the thing worth paging on) and "this feed's validity window does not cover now" (transient —
+ * preview has a real ~60–80s blackout every 5 minutes, upstream of us). The scanner reports one
+ * reason for both, so this gauge flaps for the second case. <b>The WARN's {@code detail} tells them
+ * apart</b> ({@code "no oracle entry for …"} / {@code "not usable for liquidation"} versus
+ * {@code "outside its validity window at …"}), and an alert rule wanting only the permanent case
+ * should hold the condition for longer than a blackout. Distinguishing them in the metric itself
+ * needs a structured sub-reason on the scanner's side, which is a decision this slice does not make.
+ */
+@Component
+@Slf4j
+public class MarketCoverageReporter {
+
+    /**
+     * The name an alert rule matches on. Micrometer renders it as {@code loans_market_unservable}
+     * in the Prometheus exposition; {@code 1} means the bot met a loan in that market it cannot
+     * process, {@code 0} means it did not on the most recent scan.
+     */
+    static final String UNSERVABLE = "loans.market.unservable";
+
+    /** How many pairs were refused a series by {@link #MAX_TRACKED_SERIES} on the last scan. */
+    static final String UNTRACKED = "loans.market.unservable.untracked";
+
+    /**
+     * The cardinality ceiling: at most this many distinct {@code (market, reason)} series. Generous
+     * against reality — markets are tens and there are four unservable reasons — and finite against
+     * an adversary, which is the only property that matters here.
+     */
+    static final int MAX_TRACKED_SERIES = 256;
+
+    private final MeterRegistry registry;
+
+    /** One {@link AtomicInteger} per registered series; also the bound's counter. */
+    private final Map<UnservableMarket, AtomicInteger> series = new ConcurrentHashMap<>();
+
+    private final AtomicInteger untracked = new AtomicInteger();
+
+    public MarketCoverageReporter(MeterRegistry registry) {
+        this.registry = Objects.requireNonNull(registry, "registry");
+        Gauge.builder(UNTRACKED, untracked, AtomicInteger::doubleValue)
+                .description("Distinct (market, reason) pairs the bot could not serve and could not "
+                        + "give a metric series to, because the cardinality bound was reached")
+                .register(registry);
+    }
+
+    /**
+     * Re-read one scan's verdicts and publish the ones that say "we cannot serve this market".
+     *
+     * <p>Called once per liquidation cycle with <b>every</b> assessment, including the buildable
+     * ones — the servable majority is what makes a series fall back to 0.
+     */
+    public void report(Collection<LiquidationAssessment> assessments) {
+        SortedMap<UnservableMarket, String> unservable = UnservableMarket.seenIn(assessments);
+        Set<UnservableMarket> stillUnservable = unservable.keySet();
+
+        // Recovery first, so a market that changed reason reads as one line clearing and another
+        // firing rather than as two simultaneous truths.
+        for (Map.Entry<UnservableMarket, AtomicInteger> tracked : series.entrySet()) {
+            if (stillUnservable.contains(tracked.getKey()) || tracked.getValue().getAndSet(0) == 0) {
+                continue;
+            }
+            log.info("market {} is servable again — {} no longer applies; gauge {} is back to 0 "
+                            + "for market={} reason={}",
+                    tracked.getKey().market(), tracked.getKey().reason(), UNSERVABLE,
+                    tracked.getKey().market(), tracked.getKey().reason());
+        }
+
+        int refused = 0;
+        for (Map.Entry<UnservableMarket, String> gap : unservable.entrySet()) {
+            AtomicInteger value = seriesFor(gap.getKey());
+            if (value == null) {
+                refused++;
+                continue;
+            }
+            if (value.getAndSet(1) == 1) {
+                continue;
+            }
+            log.warn("⛔ UNSERVABLE MARKET {} — {} ({}). A market is the token for the principal, "
+                            + "and the bot met a loan in this one it cannot process as it stands. "
+                            + "Gauge {} is now 1 for market={} reason={}",
+                    gap.getKey().market(), gap.getKey().reason(), gap.getValue(), UNSERVABLE,
+                    gap.getKey().market(), gap.getKey().reason());
+        }
+
+        if (untracked.getAndSet(refused) == 0 && refused > 0) {
+            log.warn("⛔ {} unservable (market, reason) pair(s) have no metric series: the {} bound "
+                            + "of {} series is reached. They are counted in {} and nowhere else — "
+                            + "this bot is now reporting LESS than it knows.",
+                    refused, UNSERVABLE, MAX_TRACKED_SERIES, UNTRACKED);
+        }
+    }
+
+    /**
+     * The series for one pair, creating it on first sight — or {@code null} once
+     * {@link #MAX_TRACKED_SERIES} is reached, which is the whole cardinality bound.
+     */
+    private AtomicInteger seriesFor(UnservableMarket market) {
+        AtomicInteger existing = series.get(market);
+        if (existing != null) {
+            return existing;
+        }
+        if (series.size() >= MAX_TRACKED_SERIES) {
+            return null;
+        }
+        AtomicInteger value = new AtomicInteger();
+        series.put(market, value);
+        Gauge.builder(UNSERVABLE, value, AtomicInteger::doubleValue)
+                .description("1 when the bot met a loan whose principal is this token and could not "
+                        + "process it; 0 when it did not on the most recent scan")
+                .tag("market", market.market())
+                .tag("reason", market.reason().name())
+                .register(registry);
+        return value;
+    }
+}

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/MarketCoverageReporter.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/MarketCoverageReporter.java
@@ -5,6 +5,8 @@ import com.fluidtokens.aquarium.offchain.model.loans.UnservableMarket;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
@@ -37,36 +39,62 @@ import java.util.concurrent.atomic.AtomicInteger;
  * anything here, and {@code LiquidationExecutor} calls {@link #report} inside its own guard so a
  * fault in observation cannot cost a cycle.
  *
- * <h2>⛔ CARDINALITY IS BOUNDED BY CONSTRUCTION, and that is not a detail</h2>
+ * <h2>⛔ CARDINALITY IS BOUNDED, AND THE BOUND IS RECLAIMABLE — that distinction is the whole thing</h2>
  * A metric label whose values come from chain data is an unbounded label unless something bounds
  * it: anyone can lock a lender bond naming an arbitrary asset as its principal, so "markets seen"
  * is attacker-influenced, not a closed set of tens. An unbounded label is how a metrics backend
  * falls over, which is worse than no metric at all.
  * <p>
- * Hence {@link #MAX_TRACKED_SERIES}: past that many distinct {@code (market, reason)} pairs, <b>no
- * further series is created</b>. The overflow is not silent — {@code loans_market_unservable_untracked}
- * counts the pairs being refused a series, so the reader can tell "nothing more is wrong" from "we
- * stopped saying". Same shape and same reason as {@code LiquidationExecutor.MAX_QUARANTINED}.
+ * {@link #MAX_TRACKED_SERIES} caps how many {@code (market, leg, reason)} triples hold a series
+ * <b>at once</b>. It is <b>not</b> a lifetime quota, and the difference is not academic: a ceiling
+ * that only ever fills is a one-shot, ~1000-ada switch-off of an operator's market alerting for the
+ * life of the process — roughly 256 min-ada junk bonds and the bot goes quiet forever, and
+ * {@code LenderBondService.findAll()} returns every bond at the credential, not only this
+ * operator's. So the bound behaves like {@code LiquidationExecutor.MAX_QUARANTINED}, whose two
+ * mechanisms this mirrors:
+ * <ul>
+ *   <li><b>eviction</b> — at the ceiling a newcomer is admitted by dropping a series that is
+ *       currently reading {@code 0} (the one that has read 0 longest), never one reading {@code 1}
+ *       and never one that is unservable on this very cycle. A recovered market losing its series
+ *       is the cheapest thing to give up; an active alert is the most expensive;</li>
+ *   <li><b>refusal is loud AND named</b> — only when all {@link #MAX_TRACKED_SERIES} series are
+ *       simultaneously reading {@code 1} is there nothing to evict. That is already an emergency,
+ *       and the newcomer still gets <b>a WARN naming it</b> ({@link #UNTRACKED} counts them).
+ *       Logs are not a cardinality-limited medium, so the floor Giovanni asked for never depends on
+ *       a metric slot being free.</li>
+ * </ul>
+ * In markets rather than triples: one asset can occupy at most four series (three principal-leg
+ * reasons plus one collateral-leg one), so {@link #MAX_TRACKED_SERIES} guarantees at least 64
+ * distinct assets and in practice tracks 256.
  *
- * <h2>Transitions, not repetitions</h2>
- * The cycle runs every {@code loans.liquidation.delay-seconds}. Logging every unservable market
- * every cycle would bury the line that matters under thousands of identical ones, so a WARN is
- * emitted when a pair <b>becomes</b> unservable and an INFO when it stops. The gauge, not the log,
- * is the thing that is true continuously — which is exactly the division of labour Giovanni asked
- * for.
+ * <h2>Transitions, not repetitions — and not blackouts either</h2>
+ * The cycle runs every {@code loans.liquidation.delay-seconds} (default 60). Logging every
+ * unservable market every cycle would bury the line that matters under thousands of identical ones,
+ * so a WARN is emitted when a triple <b>becomes</b> unservable and an INFO when it stops.
  * <p>
- * ⚠ <b>A recovered market's series stays, holding 0.</b> Deleting it would make "servable again" and
- * "we stopped looking" the same observation, and an alert rule cannot tell those apart.
+ * ⚠ <b>A transition alone is not enough, because the oracle blackout IS a transition.</b> Preview
+ * has a real ~60–80 s price blackout every five minutes, upstream of us, which at the default cycle
+ * makes a non-ada market flip unservable and back roughly 288 times a day. A WARN on each flip turns
+ * Giovanni's floor into noise on the first network the bot runs on. So the condition must hold for
+ * {@link #DEFAULT_WARN_AFTER_CYCLES} <b>consecutive</b> cycles before the first WARN, and the
+ * matching INFO is emitted only if that WARN was reached — a blackout that never warned never
+ * recovers out loud either.
+ * <p>
+ * <b>The gauge still goes to 1 on the first cycle.</b> It is the continuously-true thing, and an
+ * alert rule holds it with its own {@code for:} clause; the log is the thing that cannot be held
+ * after the fact.
  *
- * <h2>⚠ Known limitation: an oracle blackout looks like an unservable market</h2>
+ * <p>⚠ <b>A recovered market's series stays, holding 0</b> until the bound needs its slot. Deleting
+ * it eagerly would make "servable again" and "we stopped looking" the same observation, and an alert
+ * rule cannot tell those apart. (Telling <em>absence</em> from "the bot never scanned" needs a
+ * heartbeat, which is ticketed separately — always-present zeros would blow the bound above.)
+ *
+ * <h2>⚠ Known limitation: a permanently unsupported feed and a stale one share one reason</h2>
  * {@code PRINCIPAL_ORACLE_UNUSABLE} covers both "this feed is a variant we do not model" (permanent,
- * and the thing worth paging on) and "this feed's validity window does not cover now" (transient —
- * preview has a real ~60–80s blackout every 5 minutes, upstream of us). The scanner reports one
- * reason for both, so this gauge flaps for the second case. <b>The WARN's {@code detail} tells them
- * apart</b> ({@code "no oracle entry for …"} / {@code "not usable for liquidation"} versus
- * {@code "outside its validity window at …"}), and an alert rule wanting only the permanent case
- * should hold the condition for longer than a blackout. Distinguishing them in the metric itself
- * needs a structured sub-reason on the scanner's side, which is a decision this slice does not make.
+ * and the thing worth paging on) and "this feed's validity window does not cover now" (transient).
+ * The consecutive-cycle gate above is what keeps the second out of the log; distinguishing them in
+ * the metric itself needs a structured sub-reason on the scanner's side, which is a decision this
+ * slice does not make.
  */
 @Component
 @Slf4j
@@ -74,34 +102,69 @@ public class MarketCoverageReporter {
 
     /**
      * The name an alert rule matches on. Micrometer renders it as {@code loans_market_unservable}
-     * in the Prometheus exposition; {@code 1} means the bot met a loan in that market it cannot
-     * process, {@code 0} means it did not on the most recent scan.
+     * in the Prometheus exposition; {@code 1} means the bot met a loan whose {@code leg} is this
+     * token and could not process it, {@code 0} means it did not on the most recent scan.
      */
     static final String UNSERVABLE = "loans.market.unservable";
 
-    /** How many pairs were refused a series by {@link #MAX_TRACKED_SERIES} on the last scan. */
+    /** How many triples were refused a series by {@link #MAX_TRACKED_SERIES} on the last scan. */
     static final String UNTRACKED = "loans.market.unservable.untracked";
 
     /**
-     * The cardinality ceiling: at most this many distinct {@code (market, reason)} series. Generous
-     * against reality — markets are tens and there are four unservable reasons — and finite against
-     * an adversary, which is the only property that matters here.
+     * The cardinality ceiling: at most this many {@code (market, leg, reason)} series at once.
+     * Generous against reality — markets are tens and there are four unservable reasons — and
+     * finite against an adversary, which is the only property that matters here. Slots are
+     * reclaimed by eviction, so this is a concurrency ceiling and not a lifetime quota.
      */
     static final int MAX_TRACKED_SERIES = 256;
 
+    /**
+     * How many consecutive cycles a triple must stay unservable before the first WARN.
+     *
+     * <p>Three, against a measured adversary rather than a guess: preview's oracle blackout lasts
+     * ~60–80 s and the default cycle is 60 s, so a blackout spans one or two consecutive cycles and
+     * three is the smallest value a single blackout cannot reach. Overridable with
+     * {@link #WARN_AFTER_CYCLES_PROPERTY} — set it to 1 to have the log follow the gauge exactly, on
+     * a network with no blackout.
+     */
+    static final int DEFAULT_WARN_AFTER_CYCLES = 3;
+
+    /** The property {@link #DEFAULT_WARN_AFTER_CYCLES} is the default of; asserted equal in test. */
+    static final String WARN_AFTER_CYCLES_PROPERTY = "loans.market-coverage.warn-after-cycles";
+
     private final MeterRegistry registry;
 
-    /** One {@link AtomicInteger} per registered series; also the bound's counter. */
-    private final Map<UnservableMarket, AtomicInteger> series = new ConcurrentHashMap<>();
+    private final int warnAfterCycles;
+
+    /** One {@link Coverage} per registered series; also the bound's counter. */
+    private final Map<UnservableMarket, Coverage> series = new ConcurrentHashMap<>();
 
     private final AtomicInteger untracked = new AtomicInteger();
 
-    public MarketCoverageReporter(MeterRegistry registry) {
+    /**
+     * Monotonic cycle number, used only to order eviction candidates ("which series has read 0
+     * longest"). Not published anywhere.
+     */
+    private long cycle;
+
+    @Autowired
+    public MarketCoverageReporter(MeterRegistry registry,
+                                  @Value("${loans.market-coverage.warn-after-cycles:3}")
+                                  int warnAfterCycles) {
         this.registry = Objects.requireNonNull(registry, "registry");
+        // Clamped rather than rejected: a nonsensical value here must not stop an operator's node
+        // booting over a metric, and 1 is the strictest thing the gate can mean.
+        this.warnAfterCycles = Math.max(1, warnAfterCycles);
         Gauge.builder(UNTRACKED, untracked, AtomicInteger::doubleValue)
-                .description("Distinct (market, reason) pairs the bot could not serve and could not "
-                        + "give a metric series to, because the cardinality bound was reached")
+                .description("Distinct (market, leg, reason) triples the bot could not serve and "
+                        + "could not give a metric series to, because every series was already "
+                        + "reading 1 at the cardinality bound")
                 .register(registry);
+    }
+
+    /** Test seam; {@code @Value} owns {@code warnAfterCycles} in production. */
+    MarketCoverageReporter(MeterRegistry registry) {
+        this(registry, DEFAULT_WARN_AFTER_CYCLES);
     }
 
     /**
@@ -111,66 +174,170 @@ public class MarketCoverageReporter {
      * ones — the servable majority is what makes a series fall back to 0.
      */
     public void report(Collection<LiquidationAssessment> assessments) {
+        long now = ++cycle;
         SortedMap<UnservableMarket, String> unservable = UnservableMarket.seenIn(assessments);
         Set<UnservableMarket> stillUnservable = unservable.keySet();
 
         // Recovery first, so a market that changed reason reads as one line clearing and another
-        // firing rather than as two simultaneous truths.
-        for (Map.Entry<UnservableMarket, AtomicInteger> tracked : series.entrySet()) {
-            if (stillUnservable.contains(tracked.getKey()) || tracked.getValue().getAndSet(0) == 0) {
+        // firing rather than as two simultaneous truths — and so a slot freed this cycle is
+        // available to a newcomer in the loop below.
+        for (Map.Entry<UnservableMarket, Coverage> tracked : series.entrySet()) {
+            if (stillUnservable.contains(tracked.getKey())) {
                 continue;
             }
-            log.info("market {} is servable again — {} no longer applies; gauge {} is back to 0 "
-                            + "for market={} reason={}",
-                    tracked.getKey().market(), tracked.getKey().reason(), UNSERVABLE,
-                    tracked.getKey().market(), tracked.getKey().reason());
+            Coverage coverage = tracked.getValue();
+            coverage.unservableCycles = 0;
+            if (coverage.gauge.getAndSet(0) == 0) {
+                continue;
+            }
+            coverage.zeroSince = now;
+            if (coverage.warned) {
+                coverage.warned = false;
+                log.info("market {} ({} leg) is servable again — {} no longer applies; gauge {} is "
+                                + "back to 0 for market={} leg={} reason={}",
+                        tracked.getKey().market(), tracked.getKey().leg().label(),
+                        tracked.getKey().reason(), UNSERVABLE, tracked.getKey().market(),
+                        tracked.getKey().leg().label(), tracked.getKey().reason());
+            }
         }
 
         int refused = 0;
         for (Map.Entry<UnservableMarket, String> gap : unservable.entrySet()) {
-            AtomicInteger value = seriesFor(gap.getKey());
-            if (value == null) {
+            Coverage coverage = seriesFor(gap.getKey(), stillUnservable, now);
+            if (coverage == null) {
+                // ⛔ NO SERIES, BUT NEVER NO WARNING. The bound is on metric series; the log has no
+                // such ceiling, and Giovanni's WARN is the floor of this slice. Refusing both is how
+                // a genuine new unservable market becomes invisible — which is the failure the whole
+                // slice exists to end. Un-deduplicated on purpose: with nothing to evict there is
+                // nowhere to keep "already said", and every series reading 1 at once is an emergency
+                // in which loud beats tidy.
                 refused++;
+                warn(gap.getKey(), gap.getValue(), " ⚠ IT HAS NO METRIC SERIES: all "
+                        + MAX_TRACKED_SERIES + " are already reading 1, so this market is named in "
+                        + "this log line and in no metric — see " + UNTRACKED);
                 continue;
             }
-            if (value.getAndSet(1) == 1) {
+            coverage.gauge.set(1);
+            coverage.zeroSince = Long.MAX_VALUE;
+            if (coverage.warned || ++coverage.unservableCycles < warnAfterCycles) {
                 continue;
             }
-            log.warn("⛔ UNSERVABLE MARKET {} — {} ({}). A market is the token for the principal, "
-                            + "and the bot met a loan in this one it cannot process as it stands. "
-                            + "Gauge {} is now 1 for market={} reason={}",
-                    gap.getKey().market(), gap.getKey().reason(), gap.getValue(), UNSERVABLE,
-                    gap.getKey().market(), gap.getKey().reason());
+            coverage.warned = true;
+            warn(gap.getKey(), gap.getValue(), " Gauge " + UNSERVABLE + " is now 1 for market="
+                    + gap.getKey().market() + " leg=" + gap.getKey().leg().label()
+                    + " reason=" + gap.getKey().reason());
         }
 
         if (untracked.getAndSet(refused) == 0 && refused > 0) {
-            log.warn("⛔ {} unservable (market, reason) pair(s) have no metric series: the {} bound "
-                            + "of {} series is reached. They are counted in {} and nowhere else — "
-                            + "this bot is now reporting LESS than it knows.",
-                    refused, UNSERVABLE, MAX_TRACKED_SERIES, UNTRACKED);
+            log.warn("⛔ {} unservable (market, leg, reason) triple(s) have no metric series: all {} "
+                            + "series of {} are reading 1 at once. They are counted in {} and named "
+                            + "in the WARN lines above — this bot is now reporting LESS than it knows.",
+                    refused, MAX_TRACKED_SERIES, UNSERVABLE, UNTRACKED);
         }
     }
 
+    /** The one WARN shape, so "no series available" cannot quietly become a different sentence. */
+    private void warn(UnservableMarket market, String detail, String tail) {
+        log.warn("⛔ UNSERVABLE MARKET {} ({} leg) — {} ({}). {}{}",
+                market.market(), market.leg().label(), market.reason(), detail,
+                explain(market.leg()), tail);
+    }
+
     /**
-     * The series for one pair, creating it on first sight — or {@code null} once
-     * {@link #MAX_TRACKED_SERIES} is reached, which is the whole cardinality bound.
+     * ⚠ The sentence has to follow the leg. "A market is the token for the principal" is Giovanni's
+     * definition and is exactly right for a principal-side gap — and is a lie on a collateral-side
+     * one, where the token named is the collateral and the principal is a different, servable
+     * market. An operator reading the wrong sentence goes looking for the wrong loan.
      */
-    private AtomicInteger seriesFor(UnservableMarket market) {
-        AtomicInteger existing = series.get(market);
+    private static String explain(UnservableMarket.Leg leg) {
+        return switch (leg) {
+            case PRINCIPAL -> "A market is the token for the principal, and the bot met a loan in "
+                    + "this one it cannot process as it stands.";
+            case COLLATERAL -> "This token is the COLLATERAL of a loan the bot cannot process as it "
+                    + "stands; the loan's own principal is a different market and may be fine.";
+        };
+    }
+
+    /**
+     * The series for one triple, creating it on first sight — evicting a series that is currently
+     * reading {@code 0} if the bound is in the way, and returning {@code null} only when every
+     * series is reading {@code 1} and there is therefore nothing to give up.
+     */
+    private Coverage seriesFor(UnservableMarket market, Set<UnservableMarket> stillUnservable,
+                               long now) {
+        Coverage existing = series.get(market);
         if (existing != null) {
             return existing;
         }
-        if (series.size() >= MAX_TRACKED_SERIES) {
+        if (series.size() >= MAX_TRACKED_SERIES && !evictLongestZero(stillUnservable)) {
             return null;
         }
-        AtomicInteger value = new AtomicInteger();
-        series.put(market, value);
-        Gauge.builder(UNSERVABLE, value, AtomicInteger::doubleValue)
-                .description("1 when the bot met a loan whose principal is this token and could not "
-                        + "process it; 0 when it did not on the most recent scan")
+        Coverage coverage = new Coverage();
+        coverage.meter = Gauge.builder(UNSERVABLE, coverage.gauge, AtomicInteger::doubleValue)
+                .description("1 when the bot met a loan whose principal or collateral is this token "
+                        + "and could not process it; 0 when it did not on the most recent scan")
                 .tag("market", market.market())
+                .tag("leg", market.leg().label())
                 .tag("reason", market.reason().name())
                 .register(registry);
-        return value;
+        coverage.zeroSince = now;
+        series.put(market, coverage);
+        return coverage;
+    }
+
+    /**
+     * Drops the series that has been reading {@code 0} longest, so a newly unservable market can
+     * have its slot. Mirrors {@code LiquidationExecutor.quarantineUntil}'s "evict the entry closest
+     * to expiry and admit the newcomer" — the difference being that a series reading {@code 1} is an
+     * active alert and is never a candidate, and neither is one that is unservable on this cycle but
+     * has not been raised to 1 yet.
+     *
+     * @return whether anything could be given up
+     */
+    private boolean evictLongestZero(Set<UnservableMarket> stillUnservable) {
+        Map.Entry<UnservableMarket, Coverage> oldest = null;
+        for (Map.Entry<UnservableMarket, Coverage> candidate : series.entrySet()) {
+            if (candidate.getValue().gauge.get() != 0 || stillUnservable.contains(candidate.getKey())) {
+                continue;
+            }
+            if (oldest == null || candidate.getValue().zeroSince < oldest.getValue().zeroSince) {
+                oldest = candidate;
+            }
+        }
+        if (oldest == null) {
+            return false;
+        }
+        series.remove(oldest.getKey());
+        registry.remove(oldest.getValue().meter);
+        log.info("dropped the {} series for market={} leg={} reason={} — it has been reading 0 "
+                        + "longest, and the {}-series bound needs its slot for a market that is "
+                        + "unservable now",
+                UNSERVABLE, oldest.getKey().market(), oldest.getKey().leg().label(),
+                oldest.getKey().reason(), MAX_TRACKED_SERIES);
+        return true;
+    }
+
+    /**
+     * One tracked triple: the published value, the meter that publishes it (kept so eviction can
+     * remove exactly that one), and the small amount of state the WARN gate needs.
+     *
+     * <p>⚠ Plain fields, not atomics: {@code report} is called from the single liquidation cycle
+     * thread. Only {@link #gauge} is read from elsewhere — the metrics scrape thread — and that one
+     * is an {@link AtomicInteger} for exactly that reason.
+     */
+    private static final class Coverage {
+
+        private final AtomicInteger gauge = new AtomicInteger();
+
+        private Gauge meter;
+
+        /** Consecutive cycles this triple has been unservable; the WARN gate's counter. */
+        private int unservableCycles;
+
+        /** Whether the WARN has already been emitted for the current unservable episode. */
+        private boolean warned;
+
+        /** The cycle at which the gauge last fell to 0; {@code MAX_VALUE} while it reads 1. */
+        private long zeroSince = Long.MAX_VALUE;
     }
 }

--- a/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/MarketCoverageReporter.java
+++ b/src/main/java/com/fluidtokens/aquarium/offchain/service/loans/MarketCoverageReporter.java
@@ -76,9 +76,9 @@ import java.util.concurrent.atomic.AtomicInteger;
  * has a real ~60–80 s price blackout every five minutes, upstream of us, which at the default cycle
  * makes a non-ada market flip unservable and back roughly 288 times a day. A WARN on each flip turns
  * Giovanni's floor into noise on the first network the bot runs on. So the condition must hold for
- * {@link #DEFAULT_WARN_AFTER_CYCLES} <b>consecutive</b> cycles before the first WARN, and the
- * matching INFO is emitted only if that WARN was reached — a blackout that never warned never
- * recovers out loud either.
+ * the cadence-derived number from {@link #warnAfterCyclesFor(long)} of <b>consecutive</b> cycles
+ * before the first WARN, and the matching INFO is emitted only if that WARN was reached — a
+ * blackout that never warned never recovers out loud either.
  * <p>
  * <b>The gauge still goes to 1 on the first cycle.</b> It is the continuously-true thing, and an
  * alert rule holds it with its own {@code for:} clause; the log is the thing that cannot be held
@@ -112,25 +112,51 @@ public class MarketCoverageReporter {
 
     /**
      * The cardinality ceiling: at most this many {@code (market, leg, reason)} series at once.
-     * Generous against reality — markets are tens and there are four unservable reasons — and
-     * finite against an adversary, which is the only property that matters here. Slots are
-     * reclaimed by eviction, so this is a concurrency ceiling and not a lifetime quota.
+     * Generous against reality — markets are tens and there are four unservable reasons — and finite
+     * in this JVM. It is <b>not</b> finite in the metrics backend: eviction removes the local meter,
+     * but Prometheus retains every distinct historical label set for its retention period, and the
+     * {@code market} label is derived from on-chain data. That cardinality-retention residue is
+     * backlogged; this bound, its eviction policy and their behaviour are unchanged here.
      */
     static final int MAX_TRACKED_SERIES = 256;
 
     /**
-     * How many consecutive cycles a triple must stay unservable before the first WARN.
+     * Measured upper end of preview's ~60–80 s Charli3 feed blackouts every five minutes, upstream
+     * of this service (design §6.7–6.8). This is observed provenance, not a guessed tuning value.
+     */
+    static final int MAX_BLACKOUT_SECONDS = 80;
+
+    /**
+     * How many consecutive cycles a triple must stay unservable before the first WARN at the
+     * default 60 s cadence. This is the value {@link #warnAfterCyclesFor(long)} derives there.
      *
-     * <p>Three, against a measured adversary rather than a guess: preview's oracle blackout lasts
-     * ~60–80 s and the default cycle is 60 s, so a blackout spans one or two consecutive cycles and
-     * three is the smallest value a single blackout cannot reach. Overridable with
+     * <p>Overridable with
      * {@link #WARN_AFTER_CYCLES_PROPERTY} — set it to 1 to have the log follow the gauge exactly, on
      * a network with no blackout.
      */
     static final int DEFAULT_WARN_AFTER_CYCLES = 3;
 
-    /** The property {@link #DEFAULT_WARN_AFTER_CYCLES} is the default of; asserted equal in test. */
+    /** Operator override; zero or absence selects the cadence-derived WARN gate. */
     static final String WARN_AFTER_CYCLES_PROPERTY = "loans.market-coverage.warn-after-cycles";
+
+    /**
+     * Derives the first consecutive-cycle count that one measured blackout cannot reach.
+     *
+     * <p>A blackout of {@code D} seconds, observed by scans at spacing {@code C}, falls on at most
+     * {@code floor(D/C) + 1} consecutive scans: an arithmetic progression of spacing {@code C}
+     * places at most that many points inside an interval of length {@code D}. Therefore
+     * {@code floor(D/C) + 2} is the first count a single blackout cannot reach. Spring's
+     * {@code @Scheduled(fixedDelay...)} measures the gap between completions, so the real period is
+     * at least {@code C}; this derivation consequently errs toward fewer observations, which is the
+     * conservative direction. A non-positive cadence falls back to the production default rather
+     * than producing a nonsensical debounce or preventing the node from booting.
+     */
+    static int warnAfterCyclesFor(long delaySeconds) {
+        if (delaySeconds <= 0) {
+            return DEFAULT_WARN_AFTER_CYCLES;
+        }
+        return (int) (MAX_BLACKOUT_SECONDS / delaySeconds) + 2;
+    }
 
     private final MeterRegistry registry;
 
@@ -149,12 +175,17 @@ public class MarketCoverageReporter {
 
     @Autowired
     public MarketCoverageReporter(MeterRegistry registry,
-                                  @Value("${loans.market-coverage.warn-after-cycles:3}")
-                                  int warnAfterCycles) {
+                                  @Value("${loans.market-coverage.warn-after-cycles:0}")
+                                  int warnAfterCycles,
+                                  @Value("${loans.liquidation.delay-seconds:60}")
+                                  long delaySeconds) {
         this.registry = Objects.requireNonNull(registry, "registry");
         // Clamped rather than rejected: a nonsensical value here must not stop an operator's node
         // booting over a metric, and 1 is the strictest thing the gate can mean.
-        this.warnAfterCycles = Math.max(1, warnAfterCycles);
+        int effectiveWarnAfterCycles = warnAfterCycles == 0
+                ? warnAfterCyclesFor(delaySeconds)
+                : warnAfterCycles;
+        this.warnAfterCycles = Math.max(1, effectiveWarnAfterCycles);
         Gauge.builder(UNTRACKED, untracked, AtomicInteger::doubleValue)
                 .description("Distinct (market, leg, reason) triples the bot could not serve and "
                         + "could not give a metric series to, because every series was already "
@@ -162,9 +193,9 @@ public class MarketCoverageReporter {
                 .register(registry);
     }
 
-    /** Test seam; {@code @Value} owns {@code warnAfterCycles} in production. */
+    /** Test seam; 60 s is the production-default cadence used when Spring does not supply one. */
     MarketCoverageReporter(MeterRegistry registry) {
-        this(registry, DEFAULT_WARN_AFTER_CYCLES);
+        this(registry, 0, 60);
     }
 
     /**

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutorTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutorTest.java
@@ -31,6 +31,8 @@ import com.fluidtokens.aquarium.offchain.model.loans.RepaymentMode;
 import com.fluidtokens.aquarium.offchain.service.AppUtxoService;
 import com.fluidtokens.aquarium.offchain.service.BlockEventListener;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
@@ -1402,6 +1404,52 @@ class LiquidationExecutorTest {
                         .anyMatch(event -> event.getFormattedMessage()
                                 .contains("market-coverage reporting failed")),
                 "a swallowed fault is worse than the fault: the cycle carries on, and says so");
+    }
+
+    /**
+     * ⛔ <b>THE SEAM: the executor must hand the reporter the WHOLE scan, not the buildable part.</b>
+     *
+     * <p>The failure this exists for is a one-word edit — {@code report(assessments)} to
+     * {@code report(buildable)} — after which <b>no market is ever reported unservable again, on any
+     * node, forever</b>, and the whole suite stays green. It survived because the seam was unowned:
+     * the only executor-level test touching the reporter drove it through a mock that throws on
+     * {@code any()}, so the argument was never inspected, and every other wiring hands it a real
+     * reporter on a registry <b>nothing ever scrapes</b>. "The cycle survives the reporter" is not
+     * "the reporter receives what makes it work".
+     *
+     * <p>So this one scrapes. A real {@link PrometheusMeterRegistry}, a scan whose only assessment is
+     * an EXCLUDED one — precisely the kind {@code buildable} filters out — and the assertion is the
+     * labelled series existing at all. Under {@code report(buildable)} the reporter is handed an
+     * empty list and the series is absent.
+     */
+    @Test
+    void theExecutorHandsTheReporterEveryAssessmentAndNotOnlyTheBuildableOnes() {
+        PrometheusMeterRegistry prometheus = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        LiquidationAssessment blind = LiquidationAssessment.excluded(usdmBond(), null,
+                LiquidationExclusion.PRINCIPAL_ORACLE_UNUSABLE,
+                "principal leg: no oracle entry for " + USDM_UNIT);
+
+        Wiring wiring = wiring(shadow(SMALL_MARGIN), List.of(blind), List.of(), Map.of(),
+                List.of(WALLET_UTXO), noOracle(), false, false, LoanFixtures.protocolParams(),
+                null, null, new MarketCoverageReporter(prometheus));
+        wiring.executor().cycle(NOW);
+
+        assertTrue(prometheus.scrape().contains(
+                        "loans_market_unservable{leg=\"principal\",market=\"" + USDM_UNIT
+                                + "\",reason=\"PRINCIPAL_ORACLE_UNUSABLE\"} 1.0"),
+                () -> "the excluded assessment never reached the reporter, so the market the bot "
+                        + "cannot serve is nameless — scrape was:\n" + prometheus.scrape());
+    }
+
+    /** {@code c48c…47ad} + the CIP-68 (222) prefix and {@code USDM}, as USDM appears on chain. */
+    private static final String USDM_UNIT =
+            "c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad" + "0014df105553444d";
+
+    /** A bond whose principal — and therefore whose MARKET — is USDM rather than ada. */
+    private static LenderBond usdmBond() {
+        return new LenderBond("00".repeat(32), 0, "addr_test1", "usdmbond01", "d87980",
+                new LenderManagerDatum(null, null, false, BigInteger.ZERO, "",
+                        AssetType.fromUnit(USDM_UNIT)));
     }
 
     // ======================================================================================

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutorTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationExecutorTest.java
@@ -30,6 +30,7 @@ import com.fluidtokens.aquarium.offchain.model.loans.OraclePriceFeed;
 import com.fluidtokens.aquarium.offchain.model.loans.RepaymentMode;
 import com.fluidtokens.aquarium.offchain.service.AppUtxoService;
 import com.fluidtokens.aquarium.offchain.service.BlockEventListener;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
@@ -91,6 +92,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * {@link LiquidationSubmitVetoTest}.
  */
 class LiquidationExecutorTest {
+
+    /**
+     * A live {@link MarketCoverageReporter} for every wiring in this class, on a throwaway registry.
+     *
+     * <p>⚠ <b>Not a stub, and deliberately not.</b> Every cycle these tests run therefore executes the
+     * real reporting path, so the claim this slice makes — that observing which market cannot be
+     * served changes no decision — is carried by this whole class rather than asserted once. The
+     * dedicated proof is {@code aThrowingReporterChangesNothingAboutTheTransactionThatIsRecorded()}.
+     */
+    private static MarketCoverageReporter metrics() {
+        return new MarketCoverageReporter(new SimpleMeterRegistry());
+    }
 
     // ---- ECONOMICS GATE direction (token-principals slice) -----------------------------------------
 
@@ -547,7 +560,7 @@ class LiquidationExecutorTest {
                                  boolean syncing,
                                  boolean honestExUnits) {
         return wiring(configuration, scanned, inUniverse, stillUnspent, walletUtxos, oracles, syncing,
-                honestExUnits, LoanFixtures.protocolParams(), null, null);
+                honestExUnits, LoanFixtures.protocolParams(), null, null, metrics());
     }
 
     /**
@@ -575,7 +588,8 @@ class LiquidationExecutorTest {
                                  boolean honestExUnits,
                                  ProtocolParamsSupplier builderParams,
                                  RuntimeException resolverThrows,
-                                 LiquidateTransactionBuilder plainBuilder) {
+                                 LiquidateTransactionBuilder plainBuilder,
+                                 MarketCoverageReporter marketCoverage) {
         List<Utxo> universe = new ArrayList<>(List.of(CONFIG_UTXO, LM_CONFIG_UTXO));
         universe.addAll(walletUtxos);
         for (Scenario scenario : inUniverse) {
@@ -603,7 +617,7 @@ class LiquidationExecutorTest {
 
         LiquidationExecutor executor = new LiquidationExecutor(configuration, blockEventListener,
                 new FakeAppUtxoService(walletUtxos), ACCOUNT, scanner, resolver, builder,
-                payInAdvanceRouter, LoanFixtures.registry(), log, oracles,
+                payInAdvanceRouter, LoanFixtures.registry(), log, marketCoverage, oracles,
                 previewNetwork(), LoanFixtures.protocolParams(), LoanFixtures.converters(),
                 EXPLODING_SUBMITTER);
         return new Wiring(executor, log, scanner, resolver, oracles, blockEventListener);
@@ -666,6 +680,17 @@ class LiquidationExecutorTest {
                                  boolean syncing) {
         return wiring(configuration, List.of(scenario.assessment()), List.of(scenario),
                 allUnspent(List.of(scenario)), List.of(WALLET_UTXO), noOracle(), syncing);
+    }
+
+    /**
+     * The common case with the market-coverage reporter STATED, so a test can hand the loop one that
+     * fails and show the decision is the same either way.
+     */
+    private static Wiring wiring(AppConfig.LiquidationConfiguration configuration, Scenario scenario,
+                                 boolean syncing, MarketCoverageReporter marketCoverage) {
+        return wiring(configuration, List.of(scenario.assessment()), List.of(scenario),
+                allUnspent(List.of(scenario)), List.of(WALLET_UTXO), noOracle(), syncing, false,
+                LoanFixtures.protocolParams(), null, null, marketCoverage);
     }
 
     /** As above with the scanner's verdicts supplied whole, for the exclusion histogram. */
@@ -941,7 +966,7 @@ class LiquidationExecutorTest {
 
         LiquidationExecutor executor = new LiquidationExecutor(configuration, blockEventListener,
                 new FakeAppUtxoService(List.of(WALLET_UTXO)), ACCOUNT, scanner, resolver, builder,
-                router, LoanFixtures.registry(), log, oracles, previewNetwork(),
+                router, LoanFixtures.registry(), log, metrics(), oracles, previewNetwork(),
                 LoanFixtures.protocolParams(), LoanFixtures.converters(), EXPLODING_SUBMITTER);
         return new Wiring(executor, log, scanner, resolver, oracles, blockEventListener);
     }
@@ -983,7 +1008,7 @@ class LiquidationExecutorTest {
 
         LiquidationExecutor executor = new LiquidationExecutor(configuration, blockEventListener,
                 new FakeAppUtxoService(List.of(WALLET_UTXO)), ACCOUNT, scanner, resolver, plainBuilder,
-                payInAdvanceRouter, new FakeConvertRouter(canned), LoanFixtures.registry(), log, oracles,
+                payInAdvanceRouter, new FakeConvertRouter(canned), LoanFixtures.registry(), log, metrics(), oracles,
                 previewNetwork(), LoanFixtures.protocolParams(), LoanFixtures.converters(),
                 EXPLODING_SUBMITTER);
         return new Wiring(executor, log, scanner, resolver, oracles, blockEventListener);
@@ -1324,6 +1349,59 @@ class LiquidationExecutorTest {
                 ("the transaction is %d bytes, at or under the 16_384 maxTxSize — that contradicts "
                         + "the measured 18_584 bytes of validators this plan rests on, so the "
                         + "measurement has to be redone before slice 3").formatted(size));
+    }
+
+    // ======================================================================================
+    // market coverage: the slice that OBSERVES, and must not decide
+    // ======================================================================================
+
+    /**
+     * ⛔ <b>THE INVARIANT THE MARKET-COVERAGE SLICE MUST NOT BREAK: it observes, it does not decide.</b>
+     *
+     * <p>{@code MarketCoverageReporter} is called from inside {@code cycle()}, before the exclusion
+     * histogram throws the asset identity away, and it touches a {@code MeterRegistry} — something
+     * outside this loop's contract, that can fail for reasons that have nothing to do with a loan.
+     * A reporting fault must therefore cost a metric and never a liquidation.
+     *
+     * <p>The proof is a comparison rather than an assertion about intent: the same candidate, the
+     * same instant, the same wiring, run twice — once with a working reporter and once with one that
+     * throws on contact — and the recorded decision must be <b>equal in every field</b>, the built
+     * transaction's CBOR included. A change that let observation influence the decision path, or an
+     * unguarded call that lost the cycle, both fail here.
+     */
+    @Test
+    void aThrowingReporterChangesNothingAboutTheTransactionThatIsRecorded() {
+        Wiring observed = wiring(shadow(SMALL_MARGIN), scenario(FAT_FEE_PER_MILLE), false,
+                new MarketCoverageReporter(new SimpleMeterRegistry()));
+        observed.executor().cycle(NOW);
+        LiquidationDecision withReporting = onlyDecision(observed);
+
+        MarketCoverageReporter broken = mock(MarketCoverageReporter.class);
+        doThrow(new IllegalStateException("the metrics backend is down")).when(broken).report(any());
+        Wiring unobserved = wiring(shadow(SMALL_MARGIN), scenario(FAT_FEE_PER_MILLE), false, broken);
+
+        var logger = (Logger) LoggerFactory.getLogger(LiquidationExecutor.class);
+        var appender = new ListAppender<ILoggingEvent>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            unobserved.executor().cycle(NOW);
+        } finally {
+            logger.detachAppender(appender);
+        }
+        LiquidationDecision withoutReporting = onlyDecision(unobserved);
+
+        assertEquals(withReporting.txCborHex(), withoutReporting.txCborHex(),
+                "the built transaction must be byte-identical whether or not the market-coverage "
+                        + "reporting worked");
+        assertEquals(withReporting, withoutReporting,
+                "no field of the decision may depend on observation — outcome, veto, fee, size and "
+                        + "hash included");
+        assertTrue(appender.list.stream()
+                        .filter(event -> event.getLevel() == Level.WARN)
+                        .anyMatch(event -> event.getFormattedMessage()
+                                .contains("market-coverage reporting failed")),
+                "a swallowed fault is worse than the fault: the cycle carries on, and says so");
     }
 
     // ======================================================================================
@@ -1996,7 +2074,7 @@ class LiquidationExecutorTest {
 
         LiquidationExecutor executor = new LiquidationExecutor(configuration, blockEventListener,
                 new FakeAppUtxoService(walletUtxos), ACCOUNT, scanner, resolver,
-                plainBuilder, router, LoanFixtures.registry(), log, oracles, previewNetwork(),
+                plainBuilder, router, LoanFixtures.registry(), log, metrics(), oracles, previewNetwork(),
                 LoanFixtures.protocolParams(), LoanFixtures.converters(), EXPLODING_SUBMITTER);
         return new Wiring(executor, log, scanner, resolver, oracles, blockEventListener);
     }
@@ -2602,7 +2680,7 @@ class LiquidationExecutorTest {
         Scenario honest = scenario(FAT_FEE_PER_MILLE);
         Wiring wiring = wiring(shadow(SMALL_MARGIN), List.of(honest.assessment()), List.of(honest),
                 allUnspent(List.of(honest)), List.of(WALLET_UTXO), noOracle(), false, false,
-                LoanFixtures.protocolParams(), null, brokenBuilder);
+                LoanFixtures.protocolParams(), null, brokenBuilder, metrics());
 
         var logger = (Logger) LoggerFactory.getLogger(LiquidationExecutor.class);
         var appender = new ListAppender<ILoggingEvent>();
@@ -2651,7 +2729,7 @@ class LiquidationExecutorTest {
         Scenario honest = scenario(FAT_FEE_PER_MILLE);
         Wiring wiring = wiring(shadow(SMALL_MARGIN), List.of(honest.assessment()), List.of(honest),
                 allUnspent(List.of(honest)), List.of(WALLET_UTXO), noOracle(), false, false,
-                LoanFixtures.protocolParams(), boom, null);
+                LoanFixtures.protocolParams(), boom, null, metrics());
 
         var logger = (Logger) LoggerFactory.getLogger(LiquidationExecutor.class);
         var appender = new ListAppender<ILoggingEvent>();
@@ -2701,7 +2779,7 @@ class LiquidationExecutorTest {
         Scenario honest = scenario(FAT_FEE_PER_MILLE);
         Wiring wiring = wiring(shadow(SMALL_MARGIN), List.of(honest.assessment()), List.of(honest),
                 allUnspent(List.of(honest)), List.of(WALLET_UTXO), noOracle(), false, false,
-                throwingParams(), null, null);
+                throwingParams(), null, null, metrics());
 
         var logger = (Logger) LoggerFactory.getLogger(LiquidationExecutor.class);
         var appender = new ListAppender<ILoggingEvent>();
@@ -2815,7 +2893,7 @@ class LiquidationExecutorTest {
 
         Wiring wiring = wiring(shadow(SMALL_MARGIN), List.of(honest.assessment()), List.of(honest),
                 allUnspent(List.of(honest)), List.of(WALLET_UTXO), noOracle(), false, false,
-                LoanFixtures.protocolParams(), null, unserialisable);
+                LoanFixtures.protocolParams(), null, unserialisable, metrics());
 
         var logger = (Logger) LoggerFactory.getLogger(LiquidationExecutor.class);
         var appender = new ListAppender<ILoggingEvent>();
@@ -3292,7 +3370,7 @@ class LiquidationExecutorTest {
         CapturingConvertRouter capturing = new CapturingConvertRouter(4_000_000L);
         LiquidationExecutor executor = new LiquidationExecutor(configuration, blockEventListener,
                 new FakeAppUtxoService(List.of(refScriptUtxo, WALLET_UTXO)), ACCOUNT, scanner, resolver, plainBuilder,
-                payInAdvanceRouter, capturing, LoanFixtures.registry(), log, oracles,
+                payInAdvanceRouter, capturing, LoanFixtures.registry(), log, metrics(), oracles,
                 previewNetwork(), LoanFixtures.protocolParams(), LoanFixtures.converters(),
                 EXPLODING_SUBMITTER);
         executor.cycle(NOW);
@@ -3341,7 +3419,7 @@ class LiquidationExecutorTest {
         CapturingConvertRouter capturing = new CapturingConvertRouter(60_000_000L);
         LiquidationExecutor executor = new LiquidationExecutor(configuration, blockEventListener,
                 new FakeAppUtxoService(List.of(tooSmall, WALLET_UTXO)), ACCOUNT, scanner, resolver,
-                plainBuilder, payInAdvanceRouter, capturing, LoanFixtures.registry(), log, noOracle(),
+                plainBuilder, payInAdvanceRouter, capturing, LoanFixtures.registry(), log, metrics(), noOracle(),
                 previewNetwork(), LoanFixtures.protocolParams(), LoanFixtures.converters(),
                 EXPLODING_SUBMITTER);
         executor.cycle(NOW);
@@ -3395,7 +3473,7 @@ class LiquidationExecutorTest {
                 new FakeAppUtxoService(List.of(WALLET_UTXO)), ACCOUNT,
                 new FakeScanner(List.of(convert.assessment())),
                 new FakeResolver(allUnspent(List.of(convert))), plainBuilder, payInAdvanceRouter,
-                router, LoanFixtures.registry(), log, noOracle(), previewNetwork(),
+                router, LoanFixtures.registry(), log, metrics(), noOracle(), previewNetwork(),
                 LoanFixtures.protocolParams(), LoanFixtures.converters(), EXPLODING_SUBMITTER);
         return new ConvertWiring(executor, log, router);
     }

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationSubmitVetoTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/LiquidationSubmitVetoTest.java
@@ -25,6 +25,7 @@ import com.fluidtokens.aquarium.offchain.model.loans.OraclePriceFeed;
 import com.fluidtokens.aquarium.offchain.model.loans.RepaymentMode;
 import com.fluidtokens.aquarium.offchain.service.AppUtxoService;
 import com.fluidtokens.aquarium.offchain.service.BlockEventListener;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 import org.cardanofoundation.conversions.CardanoConverters;
 import org.slf4j.LoggerFactory;
@@ -80,6 +81,18 @@ import static org.mockito.Mockito.spy;
  * and fails this test.
  */
 class LiquidationSubmitVetoTest {
+
+    /**
+     * A live {@link MarketCoverageReporter} for every wiring in this class, on a throwaway registry.
+     *
+     * <p>⚠ <b>Not a stub, and deliberately not.</b> Every cycle these tests run therefore executes the
+     * real reporting path, so the claim this slice makes — that observing which market cannot be
+     * served changes no decision — is carried by this whole class rather than asserted once. The
+     * dedicated proof is {@code aThrowingReporterChangesNothingAboutTheTransactionThatIsRecorded()}.
+     */
+    private static MarketCoverageReporter metrics() {
+        return new MarketCoverageReporter(new SimpleMeterRegistry());
+    }
 
     private static final long NOW = 1_700_000_000_000L;
 
@@ -686,7 +699,8 @@ class LiquidationSubmitVetoTest {
                     new FakeAppUtxoService(), account, new FakeScanner(List.of(scenario.assessment())),
                     new FakeResolver(unspent, loanAnswersBeforeItIsGone, bondAnswersBeforeItIsGone,
                             loanThrows),
-                    builder, payInAdvanceRouter, LoanFixtures.registry(), log, provider(oracle),
+                    builder, payInAdvanceRouter, LoanFixtures.registry(), log, metrics(),
+                    provider(oracle),
                     networkNamed(networkName), params, executorConverters, submitter);
             long[] elapsed = {0};
             executor.setSubmitClock(() -> submitTime + elapsed[0]);
@@ -1871,7 +1885,8 @@ class LiquidationSubmitVetoTest {
                 new LiquidateTransactionBuilder(LoanFixtures.registry(), LoanFixtures.NETWORK,
                         LoanFixtures.converters(), LoanFixtures.utxoSupplier(universe),
                         protocolParams()),
-                payInAdvanceRouter, LoanFixtures.registry(), log, provider(new FakeOracleClient(List.of())),
+                payInAdvanceRouter, LoanFixtures.registry(), log, metrics(),
+                provider(new FakeOracleClient(List.of())),
                 networkNamed("preview"), protocolParams(),
                 LoanFixtures.converters(), submitter);
         executor.setSubmitClock(() -> NOW);

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/MarketCoverageReporterTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/MarketCoverageReporterTest.java
@@ -5,10 +5,13 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import com.fluidtokens.aquarium.offchain.model.AssetType;
+import com.fluidtokens.aquarium.offchain.model.loans.CollateralAsset;
 import com.fluidtokens.aquarium.offchain.model.loans.LenderBond;
 import com.fluidtokens.aquarium.offchain.model.loans.LenderManagerDatum;
 import com.fluidtokens.aquarium.offchain.model.loans.LiquidationAssessment;
 import com.fluidtokens.aquarium.offchain.model.loans.LiquidationExclusion;
+import com.fluidtokens.aquarium.offchain.model.loans.Loan;
+import com.fluidtokens.aquarium.offchain.model.loans.LoanDatum;
 import com.fluidtokens.aquarium.offchain.model.loans.UnservableMarket;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -17,31 +20,40 @@ import io.micrometer.prometheusmetrics.PrometheusConfig;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.prometheus.PrometheusMetricsExportAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Parameter;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.StreamSupport;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * <h2>Reviewer's orientation — what this class proves, and what it does not</h2>
  * <b>Proves:</b> that a market the bot cannot serve is NAMED — in a WARN and in a Prometheus gauge
- * label — that the label set is bounded, and that a healthy or settled market produces neither.
+ * label, and named on the LEG that actually lacks a feed — that the label set is bounded and the
+ * bound is RECLAIMABLE, that reaching it costs a metric series and never the WARN, that a single
+ * oracle blackout says nothing at all, and that a healthy or settled market produces neither output.
  * <b>Does NOT prove:</b> anything about liquidation. Nothing here builds, prices or submits a
  * transaction; the assessments are hand-built. That no decision changed is
  * {@link LiquidationExecutorTest}'s to carry, and it does
- * ({@code aThrowingReporterChangesNothingAboutTheTransactionThatIsRecorded}).
+ * ({@code aThrowingReporterChangesNothingAboutTheTransactionThatIsRecorded}); that the executor
+ * hands the reporter the WHOLE scan rather than only the buildable part is
+ * {@code theExecutorHandsTheReporterEveryAssessmentAndNotOnlyTheBuildableOnes}.
  * <b>Evaluator:</b> none needed — no transaction exists in this file.
  *
  * <h2>The failure being bought protection against</h2>
@@ -59,6 +71,13 @@ class MarketCoverageReporterTest {
     private static final String USDM_NAME = "0014df105553444d";
 
     private static final String USDM_UNIT = USDM_POLICY + USDM_NAME;
+
+    /** A second token, so a collateral-side gap has something to be confused with. */
+    private static final String SNEK_UNIT =
+            "279c909f348e533da5808898f87f9a14bb2c3dfbbacccd631d927a3f" + "534e454b";
+
+    private static final String HOSKY_UNIT =
+            "a0028f350aaabe0545fdcb56b039bfb08e4bb4d8c4d7c3c7d481c235" + "484f534b59";
 
     // =====================================================================================
     // 1. the classification — which refusals mean "there is something here we cannot do"
@@ -98,6 +117,44 @@ class MarketCoverageReporterTest {
     }
 
     /**
+     * ⛔ <b>Every reported refusal is attributed to a LEG, and that decides which token is named.</b>
+     *
+     * <p>It also fixes the ceiling in markets rather than in triples, which is the only unit an
+     * operator can reason about: three of the four reported reasons are principal-leg and one is
+     * collateral-leg, so a single asset can occupy at most FOUR of
+     * {@link MarketCoverageReporter#MAX_TRACKED_SERIES} series — at least 64 distinct assets are
+     * always representable, and 256 in the ordinary case of one reason each.
+     *
+     * <p>The seven servable reasons throw rather than defaulting to a leg. A default would be a
+     * guess about a token nothing ever reports, and nothing would ever contradict it.
+     */
+    @Test
+    void everyReportedRefusalIsAttributedToALegAndTheServableOnesRefuseToGuess() {
+        EnumSet<LiquidationExclusion> principal = EnumSet.noneOf(LiquidationExclusion.class);
+        EnumSet<LiquidationExclusion> collateral = EnumSet.noneOf(LiquidationExclusion.class);
+        for (LiquidationExclusion reason : LiquidationExclusion.values()) {
+            if (!UnservableMarket.isUnservable(reason)) {
+                assertThrows(IllegalArgumentException.class, () -> UnservableMarket.legOf(reason),
+                        () -> reason + " is servable, so it has no leg and must not be given one");
+                continue;
+            }
+            (UnservableMarket.legOf(reason) == UnservableMarket.Leg.PRINCIPAL ? principal : collateral)
+                    .add(reason);
+        }
+
+        assertEquals(EnumSet.of(LiquidationExclusion.PRINCIPAL_ORACLE_UNUSABLE,
+                        LiquidationExclusion.HEALTH_NOT_COMPUTABLE,
+                        LiquidationExclusion.CONVERSION_TO_PRINCIPAL_REQUIRED),
+                principal, "the principal leg is Giovanni's market: the token for the principal");
+        assertEquals(EnumSet.of(LiquidationExclusion.COLLATERAL_ORACLE_UNUSABLE), collateral,
+                "a collateral feed gap is about the COLLATERAL token, not about the principal");
+        assertEquals(4, principal.size() + collateral.size(),
+                "one asset occupies at most this many of the " + MarketCoverageReporter.MAX_TRACKED_SERIES
+                        + " series, so the bound is worth at least "
+                        + MarketCoverageReporter.MAX_TRACKED_SERIES / 4 + " distinct assets");
+    }
+
+    /**
      * The single most consequential half of that partition, stated as behaviour rather than as a
      * set: a healthy market and a settled one must produce <b>no series at all</b>, not a series
      * holding 0. A node whose loans are all fine publishes nothing here.
@@ -108,14 +165,16 @@ class MarketCoverageReporterTest {
         MarketCoverageReporter reporter = new MarketCoverageReporter(registry);
         List<ILoggingEvent> logged = capture();
 
-        reporter.report(List.of(
-                excluded(USDM_UNIT, LiquidationExclusion.NOT_LIQUIDATABLE,
-                        "not late and currentLtv <= liquidationLtv"),
-                excluded(USDM_UNIT, LiquidationExclusion.LOAN_NOT_FOUND,
-                        "no loan under the loan policy shares bond asset name aa"),
-                excluded("lovelace", LiquidationExclusion.MODE_NOT_LIQUIDATION,
-                        "liquidationMode is NoLiquidationFullCollateralClaim"),
-                buildable("lovelace")));
+        for (int cycle = 0; cycle < CYCLES_TO_WARN + 2; cycle++) {
+            reporter.report(List.of(
+                    excluded(USDM_UNIT, LiquidationExclusion.NOT_LIQUIDATABLE,
+                            "not late and currentLtv <= liquidationLtv"),
+                    excluded(USDM_UNIT, LiquidationExclusion.LOAN_NOT_FOUND,
+                            "no loan under the loan policy shares bond asset name aa"),
+                    excluded("lovelace", LiquidationExclusion.MODE_NOT_LIQUIDATION,
+                            "liquidationMode is NoLiquidationFullCollateralClaim"),
+                    buildable("lovelace")));
+        }
 
         assertFalse(registry.scrape().contains(UNSERVABLE_METRIC),
                 "no market was unservable, so the metric must not exist at all: an always-present "
@@ -133,8 +192,8 @@ class MarketCoverageReporterTest {
      * process it — and it says so, naming USDM, in both places.
      *
      * <p>The gauge exposition is asserted as a whole line rather than by
-     * {@code contains("USDM-ish")}: the label NAME, the label VALUE and the gauge VALUE are all
-     * load-bearing for an alert rule, and a test that checked only the token would stay green if the
+     * {@code contains("USDM-ish")}: the label NAMES, the label VALUES and the gauge VALUE are all
+     * load-bearing for an alert rule, and a test that checked only the token would stay green if a
      * label were renamed or the sense of the gauge inverted.
      */
     @Test
@@ -143,50 +202,121 @@ class MarketCoverageReporterTest {
         MarketCoverageReporter reporter = new MarketCoverageReporter(registry);
         List<ILoggingEvent> logged = capture();
 
-        reporter.report(List.of(
-                excluded(USDM_UNIT, LiquidationExclusion.PRINCIPAL_ORACLE_UNUSABLE,
-                        "principal leg: no oracle entry for " + USDM_UNIT),
-                buildable("lovelace")));
+        for (int cycle = 0; cycle < CYCLES_TO_WARN; cycle++) {
+            reporter.report(List.of(
+                    excluded(USDM_UNIT, LiquidationExclusion.PRINCIPAL_ORACLE_UNUSABLE,
+                            "principal leg: no oracle entry for " + USDM_UNIT),
+                    buildable("lovelace")));
+        }
 
         assertEquals(1, warnings(logged).size(), () -> "one WARN, once: " + warnings(logged));
-        assertEquals("⛔ UNSERVABLE MARKET " + USDM_UNIT + " — PRINCIPAL_ORACLE_UNUSABLE "
-                        + "(principal leg: no oracle entry for " + USDM_UNIT + "). A market is the "
-                        + "token for the principal, and the bot met a loan in this one it cannot "
-                        + "process as it stands. Gauge loans.market.unservable is now 1 for market="
-                        + USDM_UNIT + " reason=PRINCIPAL_ORACLE_UNUSABLE",
+        assertEquals("⛔ UNSERVABLE MARKET " + USDM_UNIT + " (principal leg) — "
+                        + "PRINCIPAL_ORACLE_UNUSABLE (principal leg: no oracle entry for " + USDM_UNIT
+                        + "). A market is the token for the principal, and the bot met a loan in "
+                        + "this one it cannot process as it stands. Gauge loans.market.unservable "
+                        + "is now 1 for market=" + USDM_UNIT
+                        + " leg=principal reason=PRINCIPAL_ORACLE_UNUSABLE",
                 warnings(logged).get(0),
                 "the WARN must name the asset and carry the scanner's own reason for it");
 
         assertTrue(registry.scrape().contains(
-                        "loans_market_unservable{market=\"" + USDM_UNIT
+                        "loans_market_unservable{leg=\"principal\",market=\"" + USDM_UNIT
                                 + "\",reason=\"PRINCIPAL_ORACLE_UNUSABLE\"} 1.0"),
                 () -> "the gauge must be labelled by market and read 1; scrape was:\n" + registry.scrape());
     }
 
     /**
-     * ⚠ <b>A recovered market keeps its series, holding 0.</b> Deleting it would make "servable
-     * again" and "this bot stopped looking" the same observation, and no alert rule can tell those
-     * apart. The INFO is what a human reading the log afterwards needs; the 0 is what the alert
-     * needs.
+     * ⛔ <b>A COLLATERAL feed gap names the COLLATERAL token.</b>
+     *
+     * <p>The defect this pins: {@code COLLATERAL_ORACLE_UNUSABLE} keyed by the principal collapses
+     * every ada-principal loan into one series saying {@code market="lovelace"} — so the operator is
+     * paged that <b>ada</b> is the market the bot cannot serve, which is false and unactionable,
+     * while the token that actually needs a feed appears in no label at all. Giovanni's "a new
+     * stablecoin loan appears" arrives as collateral at least as often as as principal.
+     *
+     * <p>Two ada-principal loans, two different collateral tokens, and therefore two series named
+     * after the tokens that lack feeds — and no {@code lovelace} series anywhere.
+     */
+    @Test
+    void aCollateralSideGapNamesTheCollateralTokenAndNotThePrincipal() {
+        PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        MarketCoverageReporter reporter = new MarketCoverageReporter(registry);
+        List<ILoggingEvent> logged = capture();
+
+        for (int cycle = 0; cycle < CYCLES_TO_WARN; cycle++) {
+            reporter.report(List.of(
+                    collateralGap("lovelace", SNEK_UNIT),
+                    collateralGap("lovelace", HOSKY_UNIT)));
+        }
+
+        String scrape = registry.scrape();
+        assertEquals(2, seriesCount(registry),
+                () -> "two different collateral tokens are two markets, not one; scrape was:\n" + scrape);
+        assertTrue(scrape.contains("loans_market_unservable{leg=\"collateral\",market=\"" + SNEK_UNIT
+                        + "\",reason=\"COLLATERAL_ORACLE_UNUSABLE\"} 1.0"),
+                () -> "the collateral token must be the label; scrape was:\n" + scrape);
+        assertTrue(scrape.contains("loans_market_unservable{leg=\"collateral\",market=\"" + HOSKY_UNIT
+                        + "\",reason=\"COLLATERAL_ORACLE_UNUSABLE\"} 1.0"),
+                () -> "the collateral token must be the label; scrape was:\n" + scrape);
+        assertFalse(scrape.contains("market=\"lovelace\""),
+                () -> "ada is the PRINCIPAL of both loans and is perfectly serviceable; paging on it "
+                        + "is the mis-attribution this leg label exists to end. Scrape was:\n" + scrape);
+
+        assertEquals(2, warnings(logged).size(), () -> warnings(logged).toString());
+        assertTrue(warnings(logged).stream().anyMatch(w -> w.contains(SNEK_UNIT + " (collateral leg)")),
+                () -> "the WARN names the collateral token and says which leg: " + warnings(logged));
+        assertTrue(warnings(logged).stream().noneMatch(w -> w.contains("is the token for the principal")),
+                () -> "and it must not read the operator Giovanni's definition of a market on a line "
+                        + "where the token named is the COLLATERAL: " + warnings(logged));
+    }
+
+    /**
+     * ⛔ <b>A collateral-leg refusal with no loan does not fall back to the principal.</b>
+     *
+     * <p>{@link LiquidationAssessment} allows a null loan only for {@code LOAN_NOT_FOUND}, which is
+     * servable and never reported — so this shape is a contract violation rather than a case. It
+     * throws, loudly, into {@code LiquidationExecutor}'s reporting guard. Naming the principal
+     * instead would be indistinguishable from a genuine principal-side gap, which is precisely the
+     * confusion the leg label exists to remove.
+     */
+    @Test
+    void aCollateralLegRefusalWithNoLoanRefusesToNameThePrincipalInstead() {
+        LiquidationAssessment impossible = LiquidationAssessment.excluded(bond("lovelace"), null,
+                LiquidationExclusion.COLLATERAL_ORACLE_UNUSABLE, "collateral leg: no oracle entry");
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class,
+                () -> UnservableMarket.seenIn(List.of(impossible)));
+        assertTrue(thrown.getMessage().contains("refusing to report the principal in its place"),
+                () -> thrown.getMessage());
+    }
+
+    /**
+     * ⚠ <b>A recovered market keeps its series, holding 0.</b> Deleting it eagerly would make
+     * "servable again" and "this bot stopped looking" the same observation, and no alert rule can
+     * tell those apart. The INFO is what a human reading the log afterwards needs; the 0 is what the
+     * alert needs.
      */
     @Test
     void aRecoveredMarketFallsBackToZeroRatherThanDisappearing() {
         PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
         MarketCoverageReporter reporter = new MarketCoverageReporter(registry);
 
-        reporter.report(List.of(excluded(USDM_UNIT, LiquidationExclusion.PRINCIPAL_ORACLE_UNUSABLE,
-                "principal leg: oracle feed for " + USDM_UNIT + " is outside its validity window at 1")));
+        for (int cycle = 0; cycle < CYCLES_TO_WARN; cycle++) {
+            reporter.report(List.of(excluded(USDM_UNIT, LiquidationExclusion.PRINCIPAL_ORACLE_UNUSABLE,
+                    "principal leg: oracle feed for " + USDM_UNIT
+                            + " is outside its validity window at 1")));
+        }
         List<ILoggingEvent> logged = capture();
         reporter.report(List.of(buildable(USDM_UNIT)));
 
         assertTrue(registry.scrape().contains(
-                        "loans_market_unservable{market=\"" + USDM_UNIT
+                        "loans_market_unservable{leg=\"principal\",market=\"" + USDM_UNIT
                                 + "\",reason=\"PRINCIPAL_ORACLE_UNUSABLE\"} 0.0"),
                 () -> "the series must survive at 0; scrape was:\n" + registry.scrape());
         assertTrue(warnings(logged).isEmpty(), () -> "recovery is not a WARN: " + warnings(logged));
         assertEquals(1, infos(logged).size(), () -> "recovery says so once: " + infos(logged));
-        assertTrue(infos(logged).get(0).startsWith("market " + USDM_UNIT + " is servable again"),
-                () -> infos(logged).get(0));
+        assertTrue(infos(logged).get(0).startsWith("market " + USDM_UNIT + " (principal leg) is "
+                        + "servable again"), () -> infos(logged).get(0));
     }
 
     /**
@@ -194,20 +324,70 @@ class MarketCoverageReporterTest {
      * under thousands of identical ones, so the log carries TRANSITIONS and the gauge carries the
      * state — which is the division of labour Giovanni described ("a WARN in the logs would be a
      * good starting point" for the human; "a prometheus metric … trigger paging" for the alert).
+     *
+     * <p>⚠ The assertion is on the WARN's <b>content</b>, not only on the count. A count alone stays
+     * green when the transition WARN is entirely absent and some other WARN — the cardinality bound's,
+     * say — happens to fire once instead, which is a way for this mechanism to disappear silently.
      */
     @Test
-    void theWarnFiresOnTheTransitionAndNotOnEveryCycle() {
+    void theWarnFiresOnceTheConditionHoldsAndNotOnEveryCycle() {
         MarketCoverageReporter reporter = new MarketCoverageReporter(new SimpleMeterRegistry());
         List<ILoggingEvent> logged = capture();
 
         LiquidationAssessment blind = excluded(USDM_UNIT,
                 LiquidationExclusion.PRINCIPAL_ORACLE_UNUSABLE, "principal leg: oracle client disabled");
-        reporter.report(List.of(blind));
-        reporter.report(List.of(blind));
-        reporter.report(List.of(blind));
+        for (int cycle = 0; cycle < CYCLES_TO_WARN + 5; cycle++) {
+            reporter.report(List.of(blind));
+        }
 
         assertEquals(1, warnings(logged).size(),
-                () -> "three cycles, one transition, one WARN: " + warnings(logged));
+                () -> (CYCLES_TO_WARN + 5) + " cycles, one episode, one WARN: " + warnings(logged));
+        assertTrue(warnings(logged).get(0).startsWith("⛔ UNSERVABLE MARKET"),
+                () -> "it must be the UNSERVABLE MARKET line itself, not some other WARN that "
+                        + "happens to fire once: " + warnings(logged));
+    }
+
+    /**
+     * ⛔ <b>A SINGLE ORACLE BLACKOUT SAYS NOTHING AT ALL.</b>
+     *
+     * <p>Preview has a real ~60–80 s price blackout every five minutes, upstream of us, and
+     * {@code loans.liquidation.delay-seconds} defaults to 60 — so a blackout spans one or two
+     * consecutive cycles and happens ~288 times a day per non-ada market. A WARN on each transition
+     * would turn Giovanni's floor into noise on the first network the bot runs on, and the recovery
+     * INFO would double it.
+     *
+     * <p>So the gauge — the continuously-true thing, which an alert rule can hold with its own
+     * {@code for:} clause — goes to 1 on the first cycle, and the log says nothing until the
+     * condition has held for {@link MarketCoverageReporter#DEFAULT_WARN_AFTER_CYCLES} consecutive
+     * cycles.
+     */
+    @Test
+    void aSingleOracleBlackoutProducesNoWarnAndNoInfo() {
+        PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        MarketCoverageReporter reporter = new MarketCoverageReporter(registry);
+        List<ILoggingEvent> logged = capture();
+
+        LiquidationAssessment blacked = excluded(USDM_UNIT,
+                LiquidationExclusion.PRINCIPAL_ORACLE_UNUSABLE,
+                "principal leg: oracle feed for " + USDM_UNIT
+                        + " is outside its validity window at 1757500000000");
+
+        // the blackout: 80s of it, which at the default 60s cycle is two consecutive cycles
+        reporter.report(List.of(blacked));
+        assertTrue(registry.scrape().contains(
+                        "loans_market_unservable{leg=\"principal\",market=\"" + USDM_UNIT
+                                + "\",reason=\"PRINCIPAL_ORACLE_UNUSABLE\"} 1.0"),
+                () -> "the GAUGE is the continuously-true thing and must not wait; scrape was:\n"
+                        + registry.scrape());
+        reporter.report(List.of(blacked));
+
+        // the feed comes back
+        reporter.report(List.of(buildable(USDM_UNIT)));
+
+        assertTrue(warnings(logged).isEmpty(),
+                () -> "a blackout is not a market the bot cannot serve: " + warnings(logged));
+        assertTrue(infos(logged).stream().noneMatch(i -> i.contains("is servable again")),
+                () -> "and a recovery from something never warned about is not news: " + infos(logged));
     }
 
     // =====================================================================================
@@ -220,7 +400,8 @@ class MarketCoverageReporterTest {
      * <p>The scanner's detail for a stale feed embeds the instant it was asked about — "outside its
      * validity window at 1757500000000". Keying the metric on it would mint a fresh series every
      * single cycle, forever, for one market: the unbounded-label failure that takes a metrics
-     * backend down. One market, one reason, two different details ⇒ exactly one series and one WARN.
+     * backend down. One market, one reason, a different detail every cycle ⇒ exactly one series and
+     * one WARN.
      */
     @Test
     void aChangingDetailDoesNotMintANewSeries() {
@@ -228,46 +409,125 @@ class MarketCoverageReporterTest {
         MarketCoverageReporter reporter = new MarketCoverageReporter(registry);
         List<ILoggingEvent> logged = capture();
 
-        reporter.report(List.of(excluded(USDM_UNIT, LiquidationExclusion.PRINCIPAL_ORACLE_UNUSABLE,
-                "principal leg: oracle feed for x is outside its validity window at 1757500000000")));
-        reporter.report(List.of(excluded(USDM_UNIT, LiquidationExclusion.PRINCIPAL_ORACLE_UNUSABLE,
-                "principal leg: oracle feed for x is outside its validity window at 1757500060000")));
+        for (int cycle = 0; cycle < CYCLES_TO_WARN; cycle++) {
+            reporter.report(List.of(excluded(USDM_UNIT, LiquidationExclusion.PRINCIPAL_ORACLE_UNUSABLE,
+                    "principal leg: oracle feed for x is outside its validity window at "
+                            + (1757500000000L + cycle * 60000L))));
+        }
 
         assertEquals(1, seriesCount(registry),
-                "the (market, reason) pair is the key; the detail only ever reaches a log line");
+                "the (market, leg, reason) triple is the key; the detail only ever reaches a log line");
         assertEquals(1, warnings(logged).size(), () -> warnings(logged).toString());
     }
 
     /**
-     * ⛔ <b>The label set is bounded BY CONSTRUCTION, not by optimism.</b>
+     * ⛔ <b>The label set is bounded BY CONSTRUCTION, not by optimism — and refusal is never
+     * silent.</b>
      *
      * <p>Anyone can lock a lender bond naming an arbitrary asset as its principal, so "markets the
      * bot has seen" is attacker-influenced rather than a closed set of tens. Past
-     * {@link MarketCoverageReporter#MAX_TRACKED_SERIES} no further series is created — and the
-     * overflow is COUNTED, because a bot that quietly reports less than it knows is the failure this
-     * whole slice exists to end.
+     * {@link MarketCoverageReporter#MAX_TRACKED_SERIES} <em>simultaneously unservable</em> triples
+     * no further series is created — and this is the case the bound must survive: every series is
+     * reading 1, so there is nothing to evict.
+     *
+     * <p>⛔ <b>The genuine newcomer is still NAMED.</b> The overflow is counted <em>and</em> the
+     * market appears in a WARN of its own. Logs are not a cardinality-limited medium, and a bot that
+     * cannot say which market it just stopped covering is the exact failure this slice exists to
+     * end — a few hundred min-ada junk bonds must not be able to buy an operator's silence.
      */
     @Test
-    void pastTheBoundNoNewSeriesIsCreatedAndTheOverflowIsCounted() {
+    void atTheBoundTheNewcomerLosesItsSeriesButNeverItsWarning() {
         PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
         MarketCoverageReporter reporter = new MarketCoverageReporter(registry);
-        List<ILoggingEvent> logged = capture();
 
-        int flood = MarketCoverageReporter.MAX_TRACKED_SERIES + 50;
-        List<LiquidationAssessment> spam = new ArrayList<>();
-        for (int i = 0; i < flood; i++) {
-            spam.add(excluded(String.format("%056x", i) + "6675",
+        List<LiquidationAssessment> junk = new ArrayList<>();
+        for (int i = 0; i < MarketCoverageReporter.MAX_TRACKED_SERIES; i++) {
+            junk.add(excluded(String.format("%056x", i) + "6675",
                     LiquidationExclusion.PRINCIPAL_ORACLE_UNUSABLE, "principal leg: oracle client disabled"));
         }
-        reporter.report(spam);
+        for (int cycle = 0; cycle < CYCLES_TO_WARN; cycle++) {
+            reporter.report(junk);
+        }
+
+        // the market that actually matters turns up after the flood, and stays
+        List<ILoggingEvent> logged = capture();
+        List<LiquidationAssessment> withNewcomer = new ArrayList<>(junk);
+        withNewcomer.add(excluded(USDM_UNIT, LiquidationExclusion.PRINCIPAL_ORACLE_UNUSABLE,
+                "principal leg: no oracle entry for " + USDM_UNIT));
+        reporter.report(withNewcomer);
 
         assertEquals(MarketCoverageReporter.MAX_TRACKED_SERIES, seriesCount(registry),
                 "the bound is the bound: an unbounded label brings a metrics backend down, which is "
                         + "worse than no metric");
-        assertTrue(registry.scrape().contains("loans_market_unservable_untracked 50.0"),
-                () -> "the refused pairs must be counted; scrape tail was:\n" + untrackedLine(registry));
+        assertFalse(registry.scrape().contains(USDM_UNIT),
+                () -> "with every series reading 1 there is nothing to evict, so the newcomer gets "
+                        + "no series; scrape was:\n" + registry.scrape());
+        assertTrue(registry.scrape().contains("loans_market_unservable_untracked 1.0"),
+                () -> "the refused triples must be counted; scrape tail was:\n" + untrackedLine(registry));
+
+        List<String> named = warnings(logged).stream()
+                .filter(w -> w.startsWith("⛔ UNSERVABLE MARKET " + USDM_UNIT))
+                .toList();
+        assertEquals(1, named.size(),
+                () -> "the newcomer must be named in a WARN even with no series to give it: "
+                        + warnings(logged));
+        assertTrue(named.get(0).contains("IT HAS NO METRIC SERIES"),
+                () -> "and the WARN must say the metric is missing, so 'nothing more is wrong' and "
+                        + "'we stopped saying' stay distinguishable: " + named.get(0));
         assertTrue(warnings(logged).stream().anyMatch(w -> w.contains("have no metric series")),
-                () -> "reaching the bound must be said out loud: " + warnings(logged));
+                () -> "reaching the bound must also be said as a total: " + warnings(logged));
+    }
+
+    /**
+     * ⛔ <b>THE BOUND IS A CONCURRENCY CEILING, NOT A LIFETIME QUOTA.</b>
+     *
+     * <p>The failure this pins: a bound that only ever fills is a one-shot switch-off. Roughly 256
+     * min-ada junk bonds — on the order of a thousand ada, and
+     * {@code LenderBondService.findAll()} returns every bond at the credential rather than only this
+     * operator's — would permanently exhaust the slots, and even after every one of those markets
+     * recovered, a genuine new unservable market would get no series for the life of the process.
+     *
+     * <p>So a slot that has fallen back to 0 is reclaimable, exactly as
+     * {@code LiquidationExecutor.quarantineUntil} evicts the entry closest to expiry rather than
+     * refusing the newcomer.
+     */
+    @Test
+    void aRecoveredSlotIsReclaimedForANewlyUnservableMarket() {
+        PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        MarketCoverageReporter reporter = new MarketCoverageReporter(registry);
+
+        List<LiquidationAssessment> junk = new ArrayList<>();
+        for (int i = 0; i < MarketCoverageReporter.MAX_TRACKED_SERIES; i++) {
+            junk.add(excluded(String.format("%056x", i) + "6675",
+                    LiquidationExclusion.PRINCIPAL_ORACLE_UNUSABLE, "principal leg: oracle client disabled"));
+        }
+        reporter.report(junk);
+        assertEquals(MarketCoverageReporter.MAX_TRACKED_SERIES, seriesCount(registry),
+                "the flood filled every slot");
+
+        // every one of them recovers — the junk bonds are settled, or the feeds arrive
+        reporter.report(List.of(buildable("lovelace")));
+
+        // and only now does the market Giovanni cares about turn up
+        List<ILoggingEvent> logged = capture();
+        for (int cycle = 0; cycle < CYCLES_TO_WARN; cycle++) {
+            reporter.report(List.of(excluded(USDM_UNIT,
+                    LiquidationExclusion.PRINCIPAL_ORACLE_UNUSABLE,
+                    "principal leg: no oracle entry for " + USDM_UNIT)));
+        }
+
+        assertEquals(MarketCoverageReporter.MAX_TRACKED_SERIES, seriesCount(registry),
+                "still bounded — the newcomer took a slot, it did not add one");
+        assertTrue(registry.scrape().contains(
+                        "loans_market_unservable{leg=\"principal\",market=\"" + USDM_UNIT
+                                + "\",reason=\"PRINCIPAL_ORACLE_UNUSABLE\"} 1.0"),
+                () -> "a recovered slot must be reclaimable, or a thousand ada buys permanent "
+                        + "silence; scrape was:\n" + registry.scrape());
+        assertTrue(registry.scrape().contains("loans_market_unservable_untracked 0.0"),
+                () -> "nothing was refused; scrape tail was:\n" + untrackedLine(registry));
+        assertEquals(1, warnings(logged).size(), () -> warnings(logged).toString());
+        assertTrue(warnings(logged).get(0).startsWith("⛔ UNSERVABLE MARKET " + USDM_UNIT),
+                () -> warnings(logged).get(0));
     }
 
     // =====================================================================================
@@ -282,7 +542,8 @@ class MarketCoverageReporterTest {
      * with every unit test green ({@code ContainerWiringTest}'s whole reason for existing).
      *
      * <p>This stands the relevant auto-configurations up and asks the container for the bean, the
-     * same way production gets it.
+     * same way production gets it — including resolving the {@code @Value} on the WARN gate, which
+     * is the other thing that can fail at container start and nowhere else.
      */
     @Test
     void theContainerCanBuildTheReporterFromTheAutoConfiguredRegistry() {
@@ -291,20 +552,50 @@ class MarketCoverageReporterTest {
                         CompositeMeterRegistryAutoConfiguration.class,
                         PrometheusMetricsExportAutoConfiguration.class))
                 .withUserConfiguration(MarketCoverageReporter.class)
+                .withPropertyValues(MarketCoverageReporter.WARN_AFTER_CYCLES_PROPERTY + "=1")
                 .run(context -> {
                     assertFalse(context.getStartupFailure() != null,
                             () -> "context failed to start: " + context.getStartupFailure());
                     assertTrue(context.getBean(MeterRegistry.class) instanceof PrometheusMeterRegistry,
                             "the registry behind /actuator/prometheus is what the gauge must land in");
+                    List<ILoggingEvent> logged = capture();
                     context.getBean(MarketCoverageReporter.class)
-                            .report(List.of(excluded(USDM_UNIT,
-                                    LiquidationExclusion.COLLATERAL_ORACLE_UNUSABLE,
-                                    "collateral leg: oracle client disabled")));
+                            .report(List.of(collateralGap(USDM_UNIT, SNEK_UNIT)));
                     assertTrue(context.getBean(PrometheusMeterRegistry.class).scrape().contains(
-                                    "loans_market_unservable{market=\"" + USDM_UNIT
+                                    "loans_market_unservable{leg=\"collateral\",market=\"" + SNEK_UNIT
                                             + "\",reason=\"COLLATERAL_ORACLE_UNUSABLE\"} 1.0"),
                             "the container-built reporter must publish onto the scraped registry");
+                    // ONE cycle warned, so the property above was really bound: the constant default
+                    // is 3 and would have said nothing here. A misspelt property name fails nowhere
+                    // else — it simply reverts the node to the default, silently.
+                    assertEquals(1, warnings(logged).size(),
+                            () -> "the container must bind " + MarketCoverageReporter
+                                    .WARN_AFTER_CYCLES_PROPERTY + ": " + warnings(logged));
                 });
+    }
+
+    /**
+     * ⚠ The {@code @Value} default and {@link MarketCoverageReporter#DEFAULT_WARN_AFTER_CYCLES} are
+     * two copies of one number — the annotation cannot reference the constant — and every test in
+     * this class exercises the constant while <b>production only ever reads the annotation</b>. If
+     * they drift, the blackout suppression is measured here and absent on the node.
+     */
+    @Test
+    void theWarnGateDefaultInTheAnnotationMatchesTheConstantTheTestsUse() {
+        Constructor<?> injected = null;
+        for (Constructor<?> candidate : MarketCoverageReporter.class.getDeclaredConstructors()) {
+            if (candidate.getParameterCount() == 2) {
+                injected = candidate;
+            }
+        }
+        assertTrue(injected != null, "the two-argument constructor is the one Spring uses");
+
+        Parameter gate = injected.getParameters()[1];
+        Value value = gate.getAnnotation(Value.class);
+        assertTrue(value != null, "the WARN gate must be configurable, per the blackout finding");
+        assertEquals("${" + MarketCoverageReporter.WARN_AFTER_CYCLES_PROPERTY + ":"
+                        + MarketCoverageReporter.DEFAULT_WARN_AFTER_CYCLES + "}", value.value(),
+                "the property name and its default must be the ones the tests and the javadoc claim");
     }
 
     // =====================================================================================
@@ -313,10 +604,23 @@ class MarketCoverageReporterTest {
 
     private static final String UNSERVABLE_METRIC = "loans_market_unservable{";
 
+    /** How many consecutive unservable cycles the default gate needs before it says anything. */
+    private static final int CYCLES_TO_WARN = MarketCoverageReporter.DEFAULT_WARN_AFTER_CYCLES;
+
     /** An excluded assessment whose bond names {@code marketUnit} as its principal. */
     private static LiquidationAssessment excluded(String marketUnit, LiquidationExclusion reason,
                                                   String detail) {
         return LiquidationAssessment.excluded(bond(marketUnit), null, reason, detail);
+    }
+
+    /**
+     * A loan whose principal is {@code principalUnit} and whose COLLATERAL token
+     * {@code collateralUnit} has no usable feed — the shape that must be named after the collateral.
+     */
+    private static LiquidationAssessment collateralGap(String principalUnit, String collateralUnit) {
+        return LiquidationAssessment.excluded(bond(principalUnit), loan(collateralUnit),
+                LiquidationExclusion.COLLATERAL_ORACLE_UNUSABLE,
+                "collateral leg: no oracle entry for the oracle nft of " + collateralUnit);
     }
 
     /** A buildable assessment in {@code marketUnit}: the servable majority a real scan is made of. */
@@ -326,14 +630,32 @@ class MarketCoverageReporterTest {
     }
 
     /**
-     * Only {@code principalAsset} is read by anything under test — the market is the token for the
-     * principal — so the rest of the bond is the cheapest thing that constructs.
+     * Only {@code principalAsset} is read by anything under test — the principal leg's market — so
+     * the rest of the bond is the cheapest thing that constructs.
      */
     private static LenderBond bond(String marketUnit) {
-        AssetType principal = "lovelace".equals(marketUnit) ? AssetType.ada()
-                : AssetType.fromUnit(marketUnit);
         return new LenderBond("00".repeat(32), 0, "addr_test1", "bond01", "d87980",
-                new LenderManagerDatum(null, null, false, BigInteger.ZERO, "", principal));
+                new LenderManagerDatum(null, null, false, BigInteger.ZERO, "", asset(marketUnit)));
+    }
+
+    /**
+     * Only {@code collateral} is read by anything under test — the collateral leg's market — so the
+     * rest of the datum is the cheapest thing that constructs.
+     */
+    private static Loan loan(String collateralUnit) {
+        AssetType collateral = asset(collateralUnit);
+        LoanDatum datum = new LoanDatum(BigInteger.ZERO, BigInteger.ZERO, BigInteger.ZERO,
+                BigInteger.ZERO, BigInteger.ZERO, BigInteger.ZERO, AssetType.ada(), AssetType.ada(),
+                BigInteger.ZERO, BigInteger.ZERO, null, null, BigInteger.ZERO, BigInteger.ZERO,
+                false, "origin",
+                new CollateralAsset(collateral.policyId(), Optional.of(collateral.assetName()),
+                        AssetType.ada()));
+        return new Loan("11".repeat(32), 0, "addr_test1", "bond01", BigInteger.TEN, BigInteger.TEN,
+                datum);
+    }
+
+    private static AssetType asset(String unit) {
+        return "lovelace".equals(unit) ? AssetType.ada() : AssetType.fromUnit(unit);
     }
 
     private static int seriesCount(MeterRegistry registry) {

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/MarketCoverageReporterTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/MarketCoverageReporterTest.java
@@ -1,0 +1,376 @@
+package com.fluidtokens.aquarium.offchain.service.loans;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.fluidtokens.aquarium.offchain.model.AssetType;
+import com.fluidtokens.aquarium.offchain.model.loans.LenderBond;
+import com.fluidtokens.aquarium.offchain.model.loans.LenderManagerDatum;
+import com.fluidtokens.aquarium.offchain.model.loans.LiquidationAssessment;
+import com.fluidtokens.aquarium.offchain.model.loans.LiquidationExclusion;
+import com.fluidtokens.aquarium.offchain.model.loans.UnservableMarket;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.prometheus.PrometheusMetricsExportAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.StreamSupport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * <h2>Reviewer's orientation — what this class proves, and what it does not</h2>
+ * <b>Proves:</b> that a market the bot cannot serve is NAMED — in a WARN and in a Prometheus gauge
+ * label — that the label set is bounded, and that a healthy or settled market produces neither.
+ * <b>Does NOT prove:</b> anything about liquidation. Nothing here builds, prices or submits a
+ * transaction; the assessments are hand-built. That no decision changed is
+ * {@link LiquidationExecutorTest}'s to carry, and it does
+ * ({@code aThrowingReporterChangesNothingAboutTheTransactionThatIsRecorded}).
+ * <b>Evaluator:</b> none needed — no transaction exists in this file.
+ *
+ * <h2>The failure being bought protection against</h2>
+ * Giovanni, naming it: <i>"assume a new stable coin loan appears and I wouldn't be able to process
+ * that loan if it went sour, well I would need to know."</i> Before this, the executor collapsed
+ * every exclusion into a histogram keyed by reason, so the scan could say
+ * {@code PRINCIPAL_ORACLE_UNUSABLE=1} and could not say which token. The tests below are written
+ * against the token.
+ */
+class MarketCoverageReporterTest {
+
+    private static final String USDM_POLICY = "c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad";
+
+    /** {@code 0014df105553444d} — the CIP-68 (222) prefix plus {@code USDM}, as it appears on chain. */
+    private static final String USDM_NAME = "0014df105553444d";
+
+    private static final String USDM_UNIT = USDM_POLICY + USDM_NAME;
+
+    // =====================================================================================
+    // 1. the classification — which refusals mean "there is something here we cannot do"
+    // =====================================================================================
+
+    /**
+     * ⛔ <b>The partition, pinned constant by constant.</b>
+     *
+     * <p>{@link UnservableMarket#isUnservable} is an exhaustive {@code switch} with no
+     * {@code default}, so a new {@link LiquidationExclusion} constant cannot compile until someone
+     * classifies it. That protects against forgetting; it does not protect against classifying a
+     * new one wrongly, and it does not protect against the far worse direction — quietly widening
+     * the true-set until {@code NOT_LIQUIDATABLE} (a HEALTHY loan, the commonest exclusion on a
+     * working node) starts paging someone. This test is what stops both.
+     */
+    @Test
+    void onlyTheFourRefusalsThatMeanWeCannotActAreReported() {
+        assertEquals(11, LiquidationExclusion.values().length,
+                "a LiquidationExclusion constant was added or removed: classify it in "
+                        + "UnservableMarket.isUnservable and state it here, because a new reason "
+                        + "defaulting to 'servable' is exactly the silence this metric exists to end");
+
+        Set<LiquidationExclusion> unservable = EnumSet.noneOf(LiquidationExclusion.class);
+        for (LiquidationExclusion reason : LiquidationExclusion.values()) {
+            if (UnservableMarket.isUnservable(reason)) {
+                unservable.add(reason);
+            }
+        }
+
+        assertEquals(EnumSet.of(LiquidationExclusion.PRINCIPAL_ORACLE_UNUSABLE,
+                        LiquidationExclusion.COLLATERAL_ORACLE_UNUSABLE,
+                        LiquidationExclusion.HEALTH_NOT_COMPUTABLE,
+                        LiquidationExclusion.CONVERSION_TO_PRINCIPAL_REQUIRED),
+                unservable,
+                "the reported set is 'we cannot act, or cannot even tell' — never 'there is nothing "
+                        + "to do here'");
+    }
+
+    /**
+     * The single most consequential half of that partition, stated as behaviour rather than as a
+     * set: a healthy market and a settled one must produce <b>no series at all</b>, not a series
+     * holding 0. A node whose loans are all fine publishes nothing here.
+     */
+    @Test
+    void aHealthyOrSettledMarketProducesNoSeriesAndNoWarning() {
+        PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        MarketCoverageReporter reporter = new MarketCoverageReporter(registry);
+        List<ILoggingEvent> logged = capture();
+
+        reporter.report(List.of(
+                excluded(USDM_UNIT, LiquidationExclusion.NOT_LIQUIDATABLE,
+                        "not late and currentLtv <= liquidationLtv"),
+                excluded(USDM_UNIT, LiquidationExclusion.LOAN_NOT_FOUND,
+                        "no loan under the loan policy shares bond asset name aa"),
+                excluded("lovelace", LiquidationExclusion.MODE_NOT_LIQUIDATION,
+                        "liquidationMode is NoLiquidationFullCollateralClaim"),
+                buildable("lovelace")));
+
+        assertFalse(registry.scrape().contains(UNSERVABLE_METRIC),
+                "no market was unservable, so the metric must not exist at all: an always-present "
+                        + "series reading 0 invites an alert rule that can never distinguish "
+                        + "'nothing wrong' from 'nothing looked'");
+        assertTrue(warnings(logged).isEmpty(), () -> "unexpected WARN: " + warnings(logged));
+    }
+
+    // =====================================================================================
+    // 2. the two outputs Giovanni asked for
+    // =====================================================================================
+
+    /**
+     * ⛔ <b>The deliverable.</b> A loan whose principal is USDM cannot be priced, so the bot cannot
+     * process it — and it says so, naming USDM, in both places.
+     *
+     * <p>The gauge exposition is asserted as a whole line rather than by
+     * {@code contains("USDM-ish")}: the label NAME, the label VALUE and the gauge VALUE are all
+     * load-bearing for an alert rule, and a test that checked only the token would stay green if the
+     * label were renamed or the sense of the gauge inverted.
+     */
+    @Test
+    void anUnservableMarketIsNamedInAWarnAndInTheGaugeLabel() {
+        PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        MarketCoverageReporter reporter = new MarketCoverageReporter(registry);
+        List<ILoggingEvent> logged = capture();
+
+        reporter.report(List.of(
+                excluded(USDM_UNIT, LiquidationExclusion.PRINCIPAL_ORACLE_UNUSABLE,
+                        "principal leg: no oracle entry for " + USDM_UNIT),
+                buildable("lovelace")));
+
+        assertEquals(1, warnings(logged).size(), () -> "one WARN, once: " + warnings(logged));
+        assertEquals("⛔ UNSERVABLE MARKET " + USDM_UNIT + " — PRINCIPAL_ORACLE_UNUSABLE "
+                        + "(principal leg: no oracle entry for " + USDM_UNIT + "). A market is the "
+                        + "token for the principal, and the bot met a loan in this one it cannot "
+                        + "process as it stands. Gauge loans.market.unservable is now 1 for market="
+                        + USDM_UNIT + " reason=PRINCIPAL_ORACLE_UNUSABLE",
+                warnings(logged).get(0),
+                "the WARN must name the asset and carry the scanner's own reason for it");
+
+        assertTrue(registry.scrape().contains(
+                        "loans_market_unservable{market=\"" + USDM_UNIT
+                                + "\",reason=\"PRINCIPAL_ORACLE_UNUSABLE\"} 1.0"),
+                () -> "the gauge must be labelled by market and read 1; scrape was:\n" + registry.scrape());
+    }
+
+    /**
+     * ⚠ <b>A recovered market keeps its series, holding 0.</b> Deleting it would make "servable
+     * again" and "this bot stopped looking" the same observation, and no alert rule can tell those
+     * apart. The INFO is what a human reading the log afterwards needs; the 0 is what the alert
+     * needs.
+     */
+    @Test
+    void aRecoveredMarketFallsBackToZeroRatherThanDisappearing() {
+        PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        MarketCoverageReporter reporter = new MarketCoverageReporter(registry);
+
+        reporter.report(List.of(excluded(USDM_UNIT, LiquidationExclusion.PRINCIPAL_ORACLE_UNUSABLE,
+                "principal leg: oracle feed for " + USDM_UNIT + " is outside its validity window at 1")));
+        List<ILoggingEvent> logged = capture();
+        reporter.report(List.of(buildable(USDM_UNIT)));
+
+        assertTrue(registry.scrape().contains(
+                        "loans_market_unservable{market=\"" + USDM_UNIT
+                                + "\",reason=\"PRINCIPAL_ORACLE_UNUSABLE\"} 0.0"),
+                () -> "the series must survive at 0; scrape was:\n" + registry.scrape());
+        assertTrue(warnings(logged).isEmpty(), () -> "recovery is not a WARN: " + warnings(logged));
+        assertEquals(1, infos(logged).size(), () -> "recovery says so once: " + infos(logged));
+        assertTrue(infos(logged).get(0).startsWith("market " + USDM_UNIT + " is servable again"),
+                () -> infos(logged).get(0));
+    }
+
+    /**
+     * ⛔ The cycle runs every minute forever. A WARN per cycle would bury the line that matters
+     * under thousands of identical ones, so the log carries TRANSITIONS and the gauge carries the
+     * state — which is the division of labour Giovanni described ("a WARN in the logs would be a
+     * good starting point" for the human; "a prometheus metric … trigger paging" for the alert).
+     */
+    @Test
+    void theWarnFiresOnTheTransitionAndNotOnEveryCycle() {
+        MarketCoverageReporter reporter = new MarketCoverageReporter(new SimpleMeterRegistry());
+        List<ILoggingEvent> logged = capture();
+
+        LiquidationAssessment blind = excluded(USDM_UNIT,
+                LiquidationExclusion.PRINCIPAL_ORACLE_UNUSABLE, "principal leg: oracle client disabled");
+        reporter.report(List.of(blind));
+        reporter.report(List.of(blind));
+        reporter.report(List.of(blind));
+
+        assertEquals(1, warnings(logged).size(),
+                () -> "three cycles, one transition, one WARN: " + warnings(logged));
+    }
+
+    // =====================================================================================
+    // 3. cardinality — the invariant that makes this metric safe to ship
+    // =====================================================================================
+
+    /**
+     * ⛔ <b>THE DETAIL IS NOT PART OF THE KEY, AND THIS IS WHY.</b>
+     *
+     * <p>The scanner's detail for a stale feed embeds the instant it was asked about — "outside its
+     * validity window at 1757500000000". Keying the metric on it would mint a fresh series every
+     * single cycle, forever, for one market: the unbounded-label failure that takes a metrics
+     * backend down. One market, one reason, two different details ⇒ exactly one series and one WARN.
+     */
+    @Test
+    void aChangingDetailDoesNotMintANewSeries() {
+        PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        MarketCoverageReporter reporter = new MarketCoverageReporter(registry);
+        List<ILoggingEvent> logged = capture();
+
+        reporter.report(List.of(excluded(USDM_UNIT, LiquidationExclusion.PRINCIPAL_ORACLE_UNUSABLE,
+                "principal leg: oracle feed for x is outside its validity window at 1757500000000")));
+        reporter.report(List.of(excluded(USDM_UNIT, LiquidationExclusion.PRINCIPAL_ORACLE_UNUSABLE,
+                "principal leg: oracle feed for x is outside its validity window at 1757500060000")));
+
+        assertEquals(1, seriesCount(registry),
+                "the (market, reason) pair is the key; the detail only ever reaches a log line");
+        assertEquals(1, warnings(logged).size(), () -> warnings(logged).toString());
+    }
+
+    /**
+     * ⛔ <b>The label set is bounded BY CONSTRUCTION, not by optimism.</b>
+     *
+     * <p>Anyone can lock a lender bond naming an arbitrary asset as its principal, so "markets the
+     * bot has seen" is attacker-influenced rather than a closed set of tens. Past
+     * {@link MarketCoverageReporter#MAX_TRACKED_SERIES} no further series is created — and the
+     * overflow is COUNTED, because a bot that quietly reports less than it knows is the failure this
+     * whole slice exists to end.
+     */
+    @Test
+    void pastTheBoundNoNewSeriesIsCreatedAndTheOverflowIsCounted() {
+        PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        MarketCoverageReporter reporter = new MarketCoverageReporter(registry);
+        List<ILoggingEvent> logged = capture();
+
+        int flood = MarketCoverageReporter.MAX_TRACKED_SERIES + 50;
+        List<LiquidationAssessment> spam = new ArrayList<>();
+        for (int i = 0; i < flood; i++) {
+            spam.add(excluded(String.format("%056x", i) + "6675",
+                    LiquidationExclusion.PRINCIPAL_ORACLE_UNUSABLE, "principal leg: oracle client disabled"));
+        }
+        reporter.report(spam);
+
+        assertEquals(MarketCoverageReporter.MAX_TRACKED_SERIES, seriesCount(registry),
+                "the bound is the bound: an unbounded label brings a metrics backend down, which is "
+                        + "worse than no metric");
+        assertTrue(registry.scrape().contains("loans_market_unservable_untracked 50.0"),
+                () -> "the refused pairs must be counted; scrape tail was:\n" + untrackedLine(registry));
+        assertTrue(warnings(logged).stream().anyMatch(w -> w.contains("have no metric series")),
+                () -> "reaching the bound must be said out loud: " + warnings(logged));
+    }
+
+    // =====================================================================================
+    // 4. the wiring the metric depends on, which no unit test would otherwise touch
+    // =====================================================================================
+
+    /**
+     * ⚠ <b>Is a {@code MeterRegistry} actually injectable here?</b> The slice was allowed to add no
+     * dependency, so the whole design rests on the actuator starter already transitively providing
+     * one. Nothing in this repo had ever asked for a {@code MeterRegistry} before, so that was an
+     * assumption rather than a fact — and an assumption that, if wrong, fails at CONTAINER START
+     * with every unit test green ({@code ContainerWiringTest}'s whole reason for existing).
+     *
+     * <p>This stands the relevant auto-configurations up and asks the container for the bean, the
+     * same way production gets it.
+     */
+    @Test
+    void theContainerCanBuildTheReporterFromTheAutoConfiguredRegistry() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class,
+                        CompositeMeterRegistryAutoConfiguration.class,
+                        PrometheusMetricsExportAutoConfiguration.class))
+                .withUserConfiguration(MarketCoverageReporter.class)
+                .run(context -> {
+                    assertFalse(context.getStartupFailure() != null,
+                            () -> "context failed to start: " + context.getStartupFailure());
+                    assertTrue(context.getBean(MeterRegistry.class) instanceof PrometheusMeterRegistry,
+                            "the registry behind /actuator/prometheus is what the gauge must land in");
+                    context.getBean(MarketCoverageReporter.class)
+                            .report(List.of(excluded(USDM_UNIT,
+                                    LiquidationExclusion.COLLATERAL_ORACLE_UNUSABLE,
+                                    "collateral leg: oracle client disabled")));
+                    assertTrue(context.getBean(PrometheusMeterRegistry.class).scrape().contains(
+                                    "loans_market_unservable{market=\"" + USDM_UNIT
+                                            + "\",reason=\"COLLATERAL_ORACLE_UNUSABLE\"} 1.0"),
+                            "the container-built reporter must publish onto the scraped registry");
+                });
+    }
+
+    // =====================================================================================
+    // helpers
+    // =====================================================================================
+
+    private static final String UNSERVABLE_METRIC = "loans_market_unservable{";
+
+    /** An excluded assessment whose bond names {@code marketUnit} as its principal. */
+    private static LiquidationAssessment excluded(String marketUnit, LiquidationExclusion reason,
+                                                  String detail) {
+        return LiquidationAssessment.excluded(bond(marketUnit), null, reason, detail);
+    }
+
+    /** A buildable assessment in {@code marketUnit}: the servable majority a real scan is made of. */
+    private static LiquidationAssessment buildable(String marketUnit) {
+        return LiquidationAssessment.buildable(bond(marketUnit), null, "buildable liquidation",
+                BigInteger.TEN, BigInteger.ZERO, true, BigInteger.ONE);
+    }
+
+    /**
+     * Only {@code principalAsset} is read by anything under test — the market is the token for the
+     * principal — so the rest of the bond is the cheapest thing that constructs.
+     */
+    private static LenderBond bond(String marketUnit) {
+        AssetType principal = "lovelace".equals(marketUnit) ? AssetType.ada()
+                : AssetType.fromUnit(marketUnit);
+        return new LenderBond("00".repeat(32), 0, "addr_test1", "bond01", "d87980",
+                new LenderManagerDatum(null, null, false, BigInteger.ZERO, "", principal));
+    }
+
+    private static int seriesCount(MeterRegistry registry) {
+        return (int) StreamSupport.stream(registry.getMeters().spliterator(), false)
+                .map(Meter::getId)
+                .filter(id -> MarketCoverageReporter.UNSERVABLE.equals(id.getName()))
+                .count();
+    }
+
+    private static String untrackedLine(PrometheusMeterRegistry registry) {
+        return registry.scrape().lines()
+                .filter(line -> line.startsWith("loans_market_unservable_untracked"))
+                .reduce("", (a, b) -> a + b + "\n");
+    }
+
+    /** Attaches to the reporter's logger and returns the live event list, as the executor tests do. */
+    private static List<ILoggingEvent> capture() {
+        Logger logger = (Logger) LoggerFactory.getLogger(MarketCoverageReporter.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.detachAndStopAllAppenders();
+        logger.addAppender(appender);
+        logger.setLevel(Level.INFO);
+        return appender.list;
+    }
+
+    private static List<String> warnings(List<ILoggingEvent> events) {
+        return events.stream()
+                .filter(event -> event.getLevel() == Level.WARN)
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+    }
+
+    private static List<String> infos(List<ILoggingEvent> events) {
+        return events.stream()
+                .filter(event -> event.getLevel() == Level.INFO)
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+    }
+}

--- a/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/MarketCoverageReporterTest.java
+++ b/src/test/java/com/fluidtokens/aquarium/offchain/service/loans/MarketCoverageReporterTest.java
@@ -4,6 +4,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import com.fluidtokens.aquarium.offchain.config.AppConfig;
 import com.fluidtokens.aquarium.offchain.model.AssetType;
 import com.fluidtokens.aquarium.offchain.model.loans.CollateralAsset;
 import com.fluidtokens.aquarium.offchain.model.loans.LenderBond;
@@ -28,6 +29,7 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.Parameter;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -390,6 +392,45 @@ class MarketCoverageReporterTest {
                 () -> "and a recovery from something never warned about is not news: " + infos(logged));
     }
 
+    /**
+     * At a 30 s cadence, an 80 s blackout can be observed on three consecutive cycles. The WARN
+     * gate must therefore be derived from that cadence instead of retaining the default-cadence
+     * value of three.
+     */
+    @Test
+    void anEightySecondBlackoutAtThirtySecondCadenceDoesNotWarn() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class,
+                        CompositeMeterRegistryAutoConfiguration.class,
+                        PrometheusMetricsExportAutoConfiguration.class))
+                .withUserConfiguration(MarketCoverageReporter.class)
+                .withPropertyValues("loans.liquidation.delay-seconds=30")
+                .run(context -> {
+                    List<ILoggingEvent> logged = capture();
+                    MarketCoverageReporter reporter = context.getBean(MarketCoverageReporter.class);
+                    LiquidationAssessment blacked = excluded(USDM_UNIT,
+                            LiquidationExclusion.PRINCIPAL_ORACLE_UNUSABLE,
+                            "principal leg: oracle feed for " + USDM_UNIT
+                                    + " is outside its validity window at 1757500000000");
+
+                    // Observations at t=0, 30 and 60 all fit inside the 80-second blackout.
+                    reporter.report(List.of(blacked));
+                    reporter.report(List.of(blacked));
+                    reporter.report(List.of(blacked));
+
+                    assertTrue(warnings(logged).isEmpty(),
+                            () -> "an 80 s blackout at a 30 s cadence must not WARN; emitted: "
+                                    + warnings(logged));
+                });
+    }
+
+    @Test
+    void theDefaultCadenceDerivationPreservesTheExistingWarnGate() {
+        assertEquals(MarketCoverageReporter.DEFAULT_WARN_AFTER_CYCLES,
+                MarketCoverageReporter.warnAfterCyclesFor(60),
+                "the 60 s production default must continue to require exactly three cycles");
+    }
+
     // =====================================================================================
     // 3. cardinality — the invariant that makes this metric safe to ship
     // =====================================================================================
@@ -574,28 +615,35 @@ class MarketCoverageReporterTest {
                 });
     }
 
-    /**
-     * ⚠ The {@code @Value} default and {@link MarketCoverageReporter#DEFAULT_WARN_AFTER_CYCLES} are
-     * two copies of one number — the annotation cannot reference the constant — and every test in
-     * this class exercises the constant while <b>production only ever reads the annotation</b>. If
-     * they drift, the blackout suppression is measured here and absent on the node.
-     */
+    /** The reporter must derive from the exact cadence property that schedules its caller. */
     @Test
-    void theWarnGateDefaultInTheAnnotationMatchesTheConstantTheTestsUse() {
+    void theWarnGateDerivesFromTheLiquidationCadenceProperty() throws NoSuchFieldException {
         Constructor<?> injected = null;
         for (Constructor<?> candidate : MarketCoverageReporter.class.getDeclaredConstructors()) {
-            if (candidate.getParameterCount() == 2) {
+            if (candidate.getParameterCount() == 3) {
                 injected = candidate;
             }
         }
-        assertTrue(injected != null, "the two-argument constructor is the one Spring uses");
+        assertTrue(injected != null, "the three-argument constructor is the one Spring uses");
 
         Parameter gate = injected.getParameters()[1];
-        Value value = gate.getAnnotation(Value.class);
-        assertTrue(value != null, "the WARN gate must be configurable, per the blackout finding");
-        assertEquals("${" + MarketCoverageReporter.WARN_AFTER_CYCLES_PROPERTY + ":"
-                        + MarketCoverageReporter.DEFAULT_WARN_AFTER_CYCLES + "}", value.value(),
-                "the property name and its default must be the ones the tests and the javadoc claim");
+        Value gateValue = gate.getAnnotation(Value.class);
+        assertTrue(gateValue != null, "the WARN gate must be configurable, per the blackout finding");
+        assertEquals("${" + MarketCoverageReporter.WARN_AFTER_CYCLES_PROPERTY + ":0}",
+                gateValue.value(), "zero is the sentinel that enables cadence-derived debounce");
+
+        Parameter reporterCadence = injected.getParameters()[2];
+        Value reporterCadenceValue = reporterCadence.getAnnotation(Value.class);
+        assertTrue(reporterCadenceValue != null,
+                "the reporter must receive the cadence at which it is called");
+
+        Field configuredCadence = AppConfig.LiquidationConfiguration.class
+                .getDeclaredField("delaySeconds");
+        Value configuredCadenceValue = configuredCadence.getAnnotation(Value.class);
+        assertTrue(configuredCadenceValue != null,
+                "the liquidation configuration must declare its cadence property");
+        assertEquals(configuredCadenceValue.value(), reporterCadenceValue.value(),
+                "the reporter cadence property must be byte-identical to the scheduler's source");
     }
 
     // =====================================================================================


### PR DESCRIPTION
The node now names lending assets it cannot serve in WARN logs and a Prometheus gauge, `loans_market_unservable{market,leg,reason}`. Reporting observes the scanner’s assessments without changing liquidation decisions, and distinguishes principal-side from collateral-side gaps. Tracked warnings use the configured scan cadence to suppress a single oracle blackout; the gauge changes on the first observation.

Consolidates the existing market-coverage commits and cadence correction onto current main. Recovered metric slots can be reused, and CI’s result-file floor is updated to the measured 140 classes. The latest lending-v4 blueprint and mainnet parameters remain unchanged.

Validation: 140 XML files, 1,117 tests, zero failures/errors, 46 skips, zero orphan results; targeted reporter/executor/submit-veto tests; negative controls for the cadence debounce and the executor/reporting seam; packaged blueprint and clean-build commit identity. No live-chain checks were run.

Known limits: the 256-series bound applies inside the JVM, not across Prometheus retention. At saturation, overflow WARNs remain immediate and are not rate-limited; that policy is tracked separately in FAB-89. Proactive coverage before a loan is observed remains deferred.

Related to FAB-81 (reactive slice only).
